### PR TITLE
Support multiple instances of blocky

### DIFF
--- a/docs/blocky-grafana.json
+++ b/docs/blocky-grafana.json
@@ -82,7 +82,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "up{job=\"blocky\"}",
+          "expr": "sum(up{job=\"blocky\"})",
           "instant": true,
           "refId": "A"
         }
@@ -345,7 +345,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "go_memstats_sys_bytes{job=\"blocky\"}",
+          "expr": "sum(go_memstats_sys_bytes{job=\"blocky\"})/sum(up{job=\"blocky\"})",
           "instant": false,
           "refId": "A"
         }
@@ -517,7 +517,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(blocky_blacklist_cache)",
+          "expr": "sum(blocky_blacklist_cache) / sum(up{job=\"blocky\"})",
           "instant": false,
           "refId": "A"
         }
@@ -603,7 +603,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "increase(blocky_error_total[24h])",
+          "expr": "sum(increase(blocky_error_total[24h]))",
           "instant": false,
           "refId": "A"
         }
@@ -958,7 +958,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sort_desc(blocky_blacklist_cache)",
+          "expr": "topk(1, blocky_blacklist_cache) by (group)",
           "instant": true,
           "legendFormat": "{{ group }}",
           "refId": "A"


### PR DESCRIPTION
When running multiple instances of blocky and emitting metrics to prometheus, the grafana dashboard will have trouble when prometheus has multiple instances of blocky collected.

This pull request will remedy some of the problematic queries to properly handle multiple instances.

For example, with 3 instances of blocky running and emitting metrics the proposed changes shows this:
![image](https://user-images.githubusercontent.com/6393612/76318301-e7739080-62b3-11ea-8b27-b2229d9812bf.png)

Running just one instance with the proposed changes shows this:
![image](https://user-images.githubusercontent.com/6393612/76318785-9adc8500-62b4-11ea-9fbc-8b7fbbc34b02.png)

