### PR TITLE
Update README for correct refreshPeriod

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ blocking:
     # optional: automatically list refresh period in minutes. Default: 4h.
     # Negative value -> deactivate automatically refresh.
     # 0 value -> use default
-    refreshPeriod: 1
+    refreshPeriod: 0
 
 # optional: configuration for caching of DNS responses
 caching:


### PR DESCRIPTION
Current refreshPeriod example sets refresh to 1 minute. This results in DNS queries failing during Blocky reload 4 seconds of every minute.