### PR TITLE
Dockerfile for adding Prom. access.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -150,6 +150,7 @@ services:
     ports:
       - "53:53/tcp"
       - "53:53/udp"
+      - "4000:4000/tcp" # Prometheus stats (if enabled).
     environment:
       - TZ=Europe/Berlin
     volumes:


### PR DESCRIPTION
Awesome little DNS proxy!  This just adds a line in the Dockerfile to allow Prometheus to pull stats.