### PR TITLE
Update config.yml: "net:" not optional since 0.9

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -1,6 +1,6 @@
 upstream:
   # these external DNS resolvers will be used. Blocky picks 2 random resolvers from the list for each query
-  # format for resolver: [net:]host:[port][/path]. net could be empty (default, shortcut for tcp+udp), tcp+udp, tcp, udp, tcp-tls or https (DoH). If port is empty, default port will be used (53 for udp and tcp, 853 for tcp-tls, 443 for https (Doh))
+  # format for resolver: net:host:[port][/path]. net could be empty (default, shortcut for tcp+udp), tcp+udp, tcp, udp, tcp-tls or https (DoH). If port is empty, default port will be used (53 for udp and tcp, 853 for tcp-tls, 443 for https (Doh))
   externalResolvers:
     - tcp:46.182.19.48
     - tcp:80.241.218.68

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -2,8 +2,8 @@ upstream:
   # these external DNS resolvers will be used. Blocky picks 2 random resolvers from the list for each query
   # format for resolver: [net:]host:[port][/path]. net could be empty (default, shortcut for tcp+udp), tcp+udp, tcp, udp, tcp-tls or https (DoH). If port is empty, default port will be used (53 for udp and tcp, 853 for tcp-tls, 443 for https (Doh))
   externalResolvers:
-    - 46.182.19.48
-    - 80.241.218.68
+    - tcp:46.182.19.48
+    - tcp:80.241.218.68
     - tcp-tls:fdns1.dismail.de:853
     - https://dns.digitale-gesellschaft.ch/dns-query
 


### PR DESCRIPTION
Reflect in config.yml, that "net:" for the upstream server is not optional since 0.9