### PR TITLE
Log output to stdout instead of stderr

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,8 @@ func configureLog(cfg *config.Config) {
 	if cfg.LogFormat == config.CfgLogFormatJSON {
 		log.SetFormatter(&log.JSONFormatter{})
 	}
+
+	log.SetOutput(os.Stdout)
 }
 
 func initConfig() {


### PR DESCRIPTION
By default, logrus outputs to `stderr`. Other than being semantically incorrect for the output generated, it also makes it hard to grep through the output as `stderr` messages aren't filtered by grep.