### PR TITLE
set loglevel on new

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -64,6 +64,12 @@ func NewServer(cfg *config.Config) (server *Server, err error) {
 
 	var httpListener, httpsListener net.Listener
 
+	if level, err := logrus.ParseLevel(cfg.LogLevel); err != nil {
+		logrus.Fatalf("invalid log level %s %v", cfg.LogLevel, err)
+	} else {
+		logrus.SetLevel(level)
+	}
+
 	router := createRouter(cfg)
 
 	if cfg.HTTPPort > 0 {


### PR DESCRIPTION
When starting blocky via `NewServer` the loglevel isn't parsed and set unlike when starting it via `root.go`