### PR TITLE
use package logger instance instead of global logrus instance

### DIFF
--- a/api/api_suite_test.go
+++ b/api/api_suite_test.go
@@ -1,15 +1,15 @@
 package api_test
 
 import (
+	"blocky/log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 )
 
 func TestResolver(t *testing.T) {
-	logrus.SetLevel(logrus.WarnLevel)
+	log.NewLogger("Warn", "text")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "API Suite")
 }

--- a/cmd/blocking.go
+++ b/cmd/blocking.go
@@ -7,7 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	"blocky/log"
+
 	"github.com/spf13/cobra"
 )
 
@@ -48,15 +49,15 @@ func newBlockingCommand() *cobra.Command {
 func enableBlocking(_ *cobra.Command, _ []string) {
 	resp, err := http.Get(apiURL(api.PathBlockingEnablePath))
 	if err != nil {
-		log.Fatal("can't execute", err)
+		log.Logger.Fatal("can't execute", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
-		log.Info("OK")
+		log.Logger.Info("OK")
 	} else {
-		log.Fatal("NOK: ", resp.Status)
+		log.Logger.Fatal("NOK: ", resp.Status)
 	}
 }
 
@@ -65,28 +66,28 @@ func disableBlocking(cmd *cobra.Command, _ []string) {
 
 	resp, err := http.Get(fmt.Sprintf("%s?duration=%s", apiURL(api.PathBlockingDisablePath), duration))
 	if err != nil {
-		log.Fatal("can't execute", err)
+		log.Logger.Fatal("can't execute", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
-		log.Info("OK")
+		log.Logger.Info("OK")
 	} else {
-		log.Fatal("NOK: ", resp.Status)
+		log.Logger.Fatal("NOK: ", resp.Status)
 	}
 }
 
 func statusBlocking(_ *cobra.Command, _ []string) {
 	resp, err := http.Get(apiURL(api.PathBlockingStatusPath))
 	if err != nil {
-		log.Fatal("can't execute", err)
+		log.Logger.Fatal("can't execute", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Fatal("NOK: ", resp.Status)
+		log.Logger.Fatal("NOK: ", resp.Status)
 		return
 	}
 
@@ -96,12 +97,12 @@ func statusBlocking(_ *cobra.Command, _ []string) {
 	util.FatalOnError("can't read response: ", err)
 
 	if result.Enabled {
-		log.Info("blocking enabled")
+		log.Logger.Info("blocking enabled")
 	} else {
 		if result.AutoEnableInSec == 0 {
-			log.Info("blocking disabled")
+			log.Logger.Info("blocking disabled")
 		} else {
-			log.Infof("blocking disabled for %d seconds", result.AutoEnableInSec)
+			log.Logger.Infof("blocking disabled for %d seconds", result.AutoEnableInSec)
 		}
 	}
 }

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
+	"blocky/log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 )
 
@@ -17,12 +17,13 @@ var (
 
 func TestCmd(t *testing.T) {
 	BeforeSuite(func() {
-		logrus.StandardLogger().ExitFunc = func(int) { fatal = true }
+		log.Logger.ExitFunc = func(int) { fatal = true }
 
 		loggerHook = test.NewGlobal()
+		log.Logger.AddHook(loggerHook)
 	})
 	AfterSuite(func() {
-		logrus.StandardLogger().ExitFunc = nil
+		log.Logger.ExitFunc = nil
 		loggerHook.Reset()
 	})
 	RegisterFailHandler(Fail)

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -8,10 +8,10 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"blocky/log"
+
 	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func NewQueryCommand() *cobra.Command {
@@ -32,7 +32,7 @@ func query(cmd *cobra.Command, args []string) {
 	qType := dns.StringToType[typeFlag]
 
 	if qType == dns.TypeNone {
-		log.Fatalf("unknown query type '%s'", typeFlag)
+		log.Logger.Fatalf("unknown query type '%s'", typeFlag)
 		return
 	}
 
@@ -45,7 +45,7 @@ func query(cmd *cobra.Command, args []string) {
 	resp, err := http.Post(apiURL(api.PathQueryPath), "application/json", bytes.NewBuffer(jsonValue))
 
 	if err != nil {
-		log.Fatal("can't execute", err)
+		log.Logger.Fatal("can't execute", err)
 
 		return
 	}
@@ -53,7 +53,7 @@ func query(cmd *cobra.Command, args []string) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
-		log.Fatalf("NOK: %s %s", resp.Status, string(body))
+		log.Logger.Fatalf("NOK: %s %s", resp.Status, string(body))
 
 		return
 	}
@@ -63,9 +63,9 @@ func query(cmd *cobra.Command, args []string) {
 
 	util.FatalOnError("can't read response: ", err)
 
-	log.Infof("Query result for '%s' (%s):", apiRequest.Query, apiRequest.Type)
-	log.Infof("\treason:        %20s", result.Reason)
-	log.Infof("\tresponse type: %20s", result.ResponseType)
-	log.Infof("\tresponse:      %20s", result.Response)
-	log.Infof("\treturn code:   %20s", result.ReturnCode)
+	log.Logger.Infof("Query result for '%s' (%s):", apiRequest.Query, apiRequest.Type)
+	log.Logger.Infof("\treason:        %20s", result.Reason)
+	log.Logger.Infof("\tresponse type: %20s", result.ResponseType)
+	log.Logger.Infof("\tresponse:      %20s", result.Response)
+	log.Logger.Infof("\treturn code:   %20s", result.ReturnCode)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"blocky/config"
+	"blocky/log"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
-	prefixed "github.com/x-cray/logrus-prefixed-formatter"
-
-	log "github.com/sirupsen/logrus"
 )
 
 //nolint:gochecknoglobals
@@ -57,39 +55,9 @@ func init() {
 	cobra.OnInitialize(initConfig)
 }
 
-func configureLog(cfg *config.Config) {
-	if level, err := log.ParseLevel(cfg.LogLevel); err != nil {
-		log.Fatalf("invalid log level %s %v", cfg.LogLevel, err)
-	} else {
-		log.SetLevel(level)
-	}
-
-	if cfg.LogFormat == config.CfgLogFormatText {
-		logFormatter := &prefixed.TextFormatter{
-			TimestampFormat:  "2006-01-02 15:04:05",
-			FullTimestamp:    true,
-			ForceFormatting:  true,
-			ForceColors:      true,
-			QuoteEmptyFields: true}
-
-		logFormatter.SetColorScheme(&prefixed.ColorScheme{
-			PrefixStyle:    "blue+b",
-			TimestampStyle: "white+h",
-		})
-
-		log.SetFormatter(logFormatter)
-	}
-
-	if cfg.LogFormat == config.CfgLogFormatJSON {
-		log.SetFormatter(&log.JSONFormatter{})
-	}
-
-	log.SetOutput(os.Stdout)
-}
-
 func initConfig() {
 	cfg = config.NewConfig(configPath)
-	configureLog(&cfg)
+	log.NewLogger(cfg.LogLevel, cfg.LogFormat)
 
 	if apiPort == 0 {
 		apiPort = cfg.HTTPPort

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -14,7 +14,8 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"blocky/log"
+
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +50,7 @@ func startServer(_ *cobra.Command, _ []string) {
 
 	go func() {
 		<-signals
-		log.Infof("Terminating...")
+		log.Logger.Infof("Terminating...")
 		srv.Stop()
 		done <- true
 	}()
@@ -62,7 +63,7 @@ func configureHTTPClient(cfg *config.Config) {
 	if cfg.BootstrapDNS != (config.Upstream{}) {
 		if cfg.BootstrapDNS.Net == config.NetTCPUDP {
 			dns := net.JoinHostPort(cfg.BootstrapDNS.Host, fmt.Sprint(cfg.BootstrapDNS.Port))
-			log.Debugf("using %s as bootstrap dns server", dns)
+			log.Logger.Debugf("using %s as bootstrap dns server", dns)
 
 			r := &net.Resolver{
 				PreferGo: true,
@@ -81,25 +82,25 @@ func configureHTTPClient(cfg *config.Config) {
 				TLSHandshakeTimeout: 5 * time.Second,
 			}
 		} else {
-			log.Fatal("bootstrap dns net should be tcp+udp")
+			log.Logger.Fatal("bootstrap dns net should be tcp+udp")
 		}
 	}
 }
 
 func printBanner() {
-	log.Info("_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/")
-	log.Info("_/                                                              _/")
-	log.Info("_/                                                              _/")
-	log.Info("_/       _/        _/                      _/                   _/")
-	log.Info("_/      _/_/_/    _/    _/_/      _/_/_/  _/  _/    _/    _/    _/")
-	log.Info("_/     _/    _/  _/  _/    _/  _/        _/_/      _/    _/     _/")
-	log.Info("_/    _/    _/  _/  _/    _/  _/        _/  _/    _/    _/      _/")
-	log.Info("_/   _/_/_/    _/    _/_/      _/_/_/  _/    _/    _/_/_/       _/")
-	log.Info("_/                                                    _/        _/")
-	log.Info("_/                                               _/_/           _/")
-	log.Info("_/                                                              _/")
-	log.Info("_/                                                              _/")
-	log.Infof("_/  Version: %-18s Build time: %-18s  _/", version, buildTime)
-	log.Info("_/                                                              _/")
-	log.Info("_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/")
+	log.Logger.Info("_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/")
+	log.Logger.Info("_/                                                              _/")
+	log.Logger.Info("_/                                                              _/")
+	log.Logger.Info("_/       _/        _/                      _/                   _/")
+	log.Logger.Info("_/      _/_/_/    _/    _/_/      _/_/_/  _/  _/    _/    _/    _/")
+	log.Logger.Info("_/     _/    _/  _/  _/    _/  _/        _/_/      _/    _/     _/")
+	log.Logger.Info("_/    _/    _/  _/  _/    _/  _/        _/  _/    _/    _/      _/")
+	log.Logger.Info("_/   _/_/_/    _/    _/_/      _/_/_/  _/    _/    _/_/_/       _/")
+	log.Logger.Info("_/                                                    _/        _/")
+	log.Logger.Info("_/                                               _/_/           _/")
+	log.Logger.Info("_/                                                              _/")
+	log.Logger.Info("_/                                                              _/")
+	log.Logger.Infof("_/  Version: %-18s Build time: %-18s  _/", version, buildTime)
+	log.Logger.Info("_/                                                              _/")
+	log.Logger.Info("_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"blocky/log"
 
 	"gopkg.in/yaml.v2"
 )
@@ -126,13 +126,13 @@ func ParseUpstream(upstream string) (result Upstream, err error) {
 
 func extractNet(upstream string) (string, string) {
 	if strings.HasPrefix(upstream, NetTCP+":") {
-		log.Warnf("net prefix tcp is deprecated, using tcp+udp as default fallback")
+		log.Logger.Warnf("net prefix tcp is deprecated, using tcp+udp as default fallback")
 
 		return NetTCPUDP, strings.Replace(upstream, NetTCP+":", "", 1)
 	}
 
 	if strings.HasPrefix(upstream, NetUDP+":") {
-		log.Warnf("net prefix udp is deprecated, using tcp+udp as default fallback")
+		log.Logger.Warnf("net prefix udp is deprecated, using tcp+udp as default fallback")
 		return NetTCPUDP, strings.Replace(upstream, NetUDP+":", "", 1)
 	}
 
@@ -154,11 +154,6 @@ func extractNet(upstream string) (string, string) {
 const (
 	cfgDefaultPort           = "53"
 	cfgDefaultPrometheusPath = "/metrics"
-)
-
-const (
-	CfgLogFormatText = "text"
-	CfgLogFormatJSON = "json"
 )
 
 // main configuration
@@ -236,16 +231,16 @@ func NewConfig(path string) Config {
 	data, err := ioutil.ReadFile(path)
 
 	if err != nil {
-		log.Fatal("Can't read config file: ", err)
+		log.Logger.Fatal("Can't read config file: ", err)
 	}
 
 	err = yaml.UnmarshalStrict(data, &cfg)
 	if err != nil {
-		log.Fatal("wrong file structure: ", err)
+		log.Logger.Fatal("wrong file structure: ", err)
 	}
 
-	if cfg.LogFormat != CfgLogFormatText && cfg.LogFormat != CfgLogFormatJSON {
-		log.Fatal("LogFormat should be 'text' or 'json'")
+	if cfg.LogFormat != log.CfgLogFormatText && cfg.LogFormat != log.CfgLogFormatJSON {
+		log.Logger.Fatal("LogFormat should be 'text' or 'json'")
 	}
 
 	return cfg
@@ -254,6 +249,6 @@ func NewConfig(path string) Config {
 func setDefaultValues(cfg *Config) {
 	cfg.Port = cfgDefaultPort
 	cfg.LogLevel = "info"
-	cfg.LogFormat = CfgLogFormatText
+	cfg.LogFormat = log.CfgLogFormatText
 	cfg.Prometheus.Path = cfgDefaultPrometheusPath
 }

--- a/config/config_suite_test.go
+++ b/config/config_suite_test.go
@@ -1,16 +1,15 @@
 package config
 
 import (
+	"blocky/log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
 )
 
 func TestConfig(t *testing.T) {
-	logrus.SetLevel(logrus.WarnLevel)
+	log.NewLogger("Warn", "Text")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
 }

--- a/helpertest/helper.go
+++ b/helpertest/helper.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
+
+	"blocky/log"
 
 	"github.com/miekg/dns"
 	"github.com/onsi/gomega/types"
@@ -17,12 +18,12 @@ import (
 func TempFile(data string) *os.File {
 	f, err := ioutil.TempFile("", "prefix")
 	if err != nil {
-		log.Fatal(err)
+		log.Logger.Fatal(err)
 	}
 
 	_, err = f.WriteString(data)
 	if err != nil {
-		log.Fatal(err)
+		log.Logger.Fatal(err)
 	}
 
 	return f
@@ -33,7 +34,7 @@ func TestServer(data string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		_, err := rw.Write([]byte(data))
 		if err != nil {
-			log.Fatal("can't write to buffer:", err)
+			log.Logger.Fatal("can't write to buffer:", err)
 		}
 	}))
 }

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"blocky/log"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -146,7 +148,7 @@ func periodicUpdate(cache *ListCache) {
 }
 
 func logger() *logrus.Entry {
-	return logrus.WithField("prefix", "list_cache")
+	return log.Logger.WithField("prefix", "list_cache")
 }
 
 // downloads and reads files with domain names and creates cache for them

--- a/lists/list_suite_test.go
+++ b/lists/list_suite_test.go
@@ -1,16 +1,15 @@
 package lists
 
 import (
+	"blocky/log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
 )
 
 func TestLists(t *testing.T) {
-	logrus.SetLevel(logrus.WarnLevel)
+	log.NewLogger("Warn", "text")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Lists Suite")
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,52 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
+)
+
+var Logger *logrus.Logger
+
+const (
+	CfgLogFormatText = "text"
+	CfgLogFormatJSON = "json"
+)
+
+func init() {
+	NewLogger("info", "text")
+}
+
+func NewLogger(logLevel, logFormat string) {
+	if len(logLevel) == 0 {
+		logLevel = "info"
+	}
+
+	logger := logrus.New()
+	if level, err := logrus.ParseLevel(logLevel); err != nil {
+		logger.Fatalf("invalid log level %s %v", logLevel, err)
+	} else {
+		logger.SetLevel(level)
+	}
+
+	if logFormat == CfgLogFormatText {
+		logFormatter := &prefixed.TextFormatter{
+			TimestampFormat:  "2006-01-02 15:04:05",
+			FullTimestamp:    true,
+			ForceFormatting:  true,
+			ForceColors:      true,
+			QuoteEmptyFields: true}
+
+		logFormatter.SetColorScheme(&prefixed.ColorScheme{
+			PrefixStyle:    "blue+b",
+			TimestampStyle: "white+h",
+		})
+
+		logger.SetFormatter(logFormatter)
+	}
+
+	if logFormat == CfgLogFormatJSON {
+		logger.SetFormatter(&logrus.JSONFormatter{})
+	}
+
+	Logger = logger
+}

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -14,8 +14,10 @@ import (
 	"strings"
 	"time"
 
+	"blocky/log"
+
 	"github.com/miekg/dns"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func createBlockHandler(cfg config.BlockingConfig) blockHandler {
@@ -43,7 +45,7 @@ func createBlockHandler(cfg config.BlockingConfig) blockHandler {
 		}
 	}
 
-	log.Fatalf("unknown blockType, please use one of: ZeroIP, NxDomain or specify destination IP address(es)")
+	log.Logger.Fatalf("unknown blockType, please use one of: ZeroIP, NxDomain or specify destination IP address(es)")
 
 	return zeroIPBlockHandler{}
 }
@@ -108,12 +110,12 @@ func (r *BlockingResolver) DisableBlocking(duration time.Duration) {
 	s.disableEnd = time.Now().Add(duration)
 
 	if duration == 0 {
-		log.Info("disable blocking")
+		log.Logger.Info("disable blocking")
 	} else {
-		log.Infof("disable blocking for %s", duration)
+		log.Logger.Infof("disable blocking for %s", duration)
 		s.enableTimer = time.AfterFunc(duration, func() {
 			r.EnableBlocking()
-			log.Info("blocking enabled again")
+			log.Logger.Info("blocking enabled again")
 		})
 	}
 }
@@ -146,7 +148,7 @@ func determineWhitelistOnlyGroups(cfg *config.BlockingConfig) (result []string) 
 }
 
 // sets answer and/or return code for DNS response, if request should be blocked
-func (r *BlockingResolver) handleBlocked(logger *log.Entry,
+func (r *BlockingResolver) handleBlocked(logger *logrus.Entry,
 	request *Request, question dns.Question, reason string) (*Response, error) {
 	response := new(dns.Msg)
 	response.SetReply(request.Req)
@@ -188,7 +190,7 @@ func shouldHandle(question dns.Question) bool {
 }
 
 func (r *BlockingResolver) handleBlacklist(groupsToCheck []string,
-	request *Request, logger *log.Entry) (*Response, error) {
+	request *Request, logger *logrus.Entry) (*Response, error) {
 	logger.WithField("groupsToCheck", strings.Join(groupsToCheck, "; ")).Debug("checking groups for request")
 	whitelistOnlyAllowed := reflect.DeepEqual(groupsToCheck, r.whitelistOnlyGroups)
 

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"blocky/config"
+	"blocky/log"
 	"blocky/util"
 	"bufio"
 	"encoding/csv"
@@ -16,8 +17,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var _ = Describe("QueryLoggingResolver", func() {
@@ -179,11 +178,11 @@ var _ = Describe("QueryLoggingResolver", func() {
 		When("Log directory does not exist", func() {
 
 			It("should exit with error", func() {
-				defer func() { log.StandardLogger().ExitFunc = nil }()
+				defer func() { log.Logger.ExitFunc = nil }()
 
 				var fatal bool
 
-				log.StandardLogger().ExitFunc = func(int) { fatal = true }
+				log.Logger.ExitFunc = func(int) { fatal = true }
 				_ = NewQueryLoggingResolver(config.QueryLogConfig{Dir: "notExists"})
 
 				Expect(fatal).Should(BeTrue())
@@ -191,11 +190,11 @@ var _ = Describe("QueryLoggingResolver", func() {
 		})
 		When("not existing log directory is configured, log retention is enabled", func() {
 			It("should exit with error", func() {
-				defer func() { log.StandardLogger().ExitFunc = nil }()
+				defer func() { log.Logger.ExitFunc = nil }()
 
 				var fatal bool
 
-				log.StandardLogger().ExitFunc = func(int) { fatal = true }
+				log.Logger.ExitFunc = func(int) { fatal = true }
 
 				sut := NewQueryLoggingResolver(config.QueryLogConfig{
 					Dir:              "wrongDir",
@@ -254,7 +253,7 @@ func readCsv(file string) [][]string {
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			log.Fatal("can't read line", err)
+			log.Logger.Fatal("can't read line", err)
 		}
 
 		result = append(result, line)

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"blocky/log"
 	"blocky/util"
 	"fmt"
 	"net"
@@ -111,7 +112,7 @@ func (r *NextResolver) GetNext() Resolver {
 }
 
 func logger(prefix string) *logrus.Entry {
-	return logrus.WithField("prefix", prefix)
+	return log.Logger.WithField("prefix", prefix)
 }
 
 func withPrefix(logger *logrus.Entry, prefix string) *logrus.Entry {

--- a/resolver/resolver_suite_test.go
+++ b/resolver/resolver_suite_test.go
@@ -1,15 +1,15 @@
 package resolver_test
 
 import (
+	"blocky/log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 )
 
 func TestResolver(t *testing.T) {
-	logrus.SetLevel(logrus.WarnLevel)
+	log.NewLogger("Warn", "text")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Resolver Suite")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"blocky/api"
 	"blocky/config"
+	"blocky/log"
 	"blocky/metrics"
 	"blocky/resolver"
 	"net/http"
@@ -31,7 +32,7 @@ type Server struct {
 }
 
 func logger() *logrus.Entry {
-	return logrus.WithField("prefix", "server")
+	return log.Logger.WithField("prefix", "server")
 }
 
 func getServerAddress(cfg *config.Config) string {
@@ -43,23 +44,14 @@ func getServerAddress(cfg *config.Config) string {
 	return address
 }
 
-func initLogging(cfg *config.Config) {
-	if level, err := logrus.ParseLevel(cfg.LogLevel); err != nil {
-		logrus.Fatalf("invalid log level %s %v", cfg.LogLevel, err)
-	} else {
-		logrus.SetLevel(level)
-	}
-}
-
 func NewServer(cfg *config.Config) (server *Server, err error) {
 	address := getServerAddress(cfg)
+	log.NewLogger(cfg.LogLevel, cfg.LogFormat)
 
 	udpServer := createUDPServer(address)
 	tcpServer := createTCPServer(address)
 
 	var httpListener, httpsListener net.Listener
-
-	initLogging(cfg)
 
 	router := createRouter(cfg)
 
@@ -265,7 +257,7 @@ func newRequest(clientIP net.IP, protocol resolver.RequestProtocol, request *dns
 		Protocol:  protocol,
 		Req:       request,
 		RequestTS: time.Now(),
-		Log: logrus.WithFields(logrus.Fields{
+		Log: log.Logger.WithFields(logrus.Fields{
 			"question":  util.QuestionToString(request.Question),
 			"client_ip": clientIP,
 		}),

--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -1,16 +1,15 @@
 package server
 
 import (
+	"blocky/log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
 )
 
 func TestDNSServer(t *testing.T) {
-	logrus.SetLevel(logrus.WarnLevel)
+	log.NewLogger("Warn", "text")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Server Suite")
 }

--- a/stats/stats_suite_test.go
+++ b/stats/stats_suite_test.go
@@ -1,16 +1,15 @@
 package stats
 
 import (
+	"blocky/log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
 )
 
 func TestStats(t *testing.T) {
-	logrus.SetLevel(logrus.WarnLevel)
+	log.NewLogger("Warn", "text")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Stats Suite")
 }

--- a/util/common.go
+++ b/util/common.go
@@ -6,8 +6,10 @@ import (
 	"sort"
 	"strings"
 
+	"blocky/log"
+
 	"github.com/miekg/dns"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func AnswerToString(answer []dns.RR) string {
@@ -58,7 +60,7 @@ func CreateAnswerFromQuestion(question dns.Question, ip net.IP, remainingTTL uin
 		return a, nil
 	}
 
-	log.Errorf("Using fallback for unsupported query type %s", dns.TypeToString[question.Qtype])
+	log.Logger.Errorf("Using fallback for unsupported query type %s", dns.TypeToString[question.Qtype])
 
 	return dns.NewRR(fmt.Sprintf("%s %d %s %s %s",
 		question.Name, remainingTTL, "IN", dns.TypeToString[question.Qtype], ip))
@@ -113,11 +115,11 @@ func IterateValueSorted(in map[string]int, fn func(string, int)) {
 
 func LogOnError(message string, err error) {
 	if err != nil {
-		log.Error(message, err)
+		log.Logger.Error(message, err)
 	}
 }
 
-func LogOnErrorWithEntry(logEntry *log.Entry, message string, err error) {
+func LogOnErrorWithEntry(logEntry *logrus.Entry, message string, err error) {
 	if err != nil {
 		logEntry.Error(message, err)
 	}
@@ -125,7 +127,7 @@ func LogOnErrorWithEntry(logEntry *log.Entry, message string, err error) {
 
 func FatalOnError(message string, err error) {
 	if err != nil {
-		log.Fatal(message, err)
+		log.Logger.Fatal(message, err)
 	}
 }
 

--- a/util/common_test.go
+++ b/util/common_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"blocky/log"
 	"errors"
 	"fmt"
 	"net"
@@ -175,6 +176,7 @@ var _ = Describe("Common function tests", func() {
 			err := errors.New("test")
 			It("should log", func() {
 				hook := test.NewGlobal()
+				log.Logger.AddHook(hook)
 				defer hook.Reset()
 				LogOnError("message ", err)
 				Expect(hook.LastEntry().Message).Should(Equal("message test"))
@@ -185,6 +187,7 @@ var _ = Describe("Common function tests", func() {
 			err := errors.New("test")
 			It("should log", func() {
 				hook := test.NewGlobal()
+				log.Logger.AddHook(hook)
 				defer hook.Reset()
 				logger, hook := test.NewNullLogger()
 				entry := logrus.NewEntry(logger)
@@ -197,6 +200,7 @@ var _ = Describe("Common function tests", func() {
 			err := errors.New("test")
 			It("should log and exit", func() {
 				hook := test.NewGlobal()
+				log.Logger.AddHook(hook)
 				fatal := false
 				logrus.StandardLogger().ExitFunc = func(int) { fatal = true }
 				defer func() {

--- a/util/util_suite_test.go
+++ b/util/util_suite_test.go
@@ -1,16 +1,15 @@
 package util
 
 import (
+	"blocky/log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
 )
 
 func TestLists(t *testing.T) {
-	logrus.SetLevel(logrus.WarnLevel)
+	log.NewLogger("Warn", "text")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Util Suite")
 }


### PR DESCRIPTION
Created internal logger instance so that it doesn't interfere with the users global instance when used as a package. This was very annoying for us since we wanted our code to have debug level but that would also set blocky's log level which is too verbose and not relevant for us.

Seems like there are some test are failing. Not too sure how to fix them.