### PR TITLE
Blocking with conditional upstream

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -145,8 +145,8 @@ func createQueryResolver(cfg *config.Config) resolver.Resolver {
 		resolver.NewMetricsResolver(cfg.Prometheus),
 		resolver.NewCustomDNSResolver(cfg.CustomDNS),
 		resolver.NewBlockingResolver(cfg.Blocking),
-		resolver.NewConditionalUpstreamResolver(cfg.Conditional),
 		resolver.NewCachingResolver(cfg.Caching),
+		resolver.NewConditionalUpstreamResolver(cfg.Conditional),
 		resolver.NewParallelBestResolver(cfg.Upstream.ExternalResolvers),
 	)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -144,8 +144,8 @@ func createQueryResolver(cfg *config.Config) resolver.Resolver {
 		resolver.NewStatsResolver(),
 		resolver.NewMetricsResolver(cfg.Prometheus),
 		resolver.NewCustomDNSResolver(cfg.CustomDNS),
-		resolver.NewConditionalUpstreamResolver(cfg.Conditional),
 		resolver.NewBlockingResolver(cfg.Blocking),
+		resolver.NewConditionalUpstreamResolver(cfg.Conditional),
 		resolver.NewCachingResolver(cfg.Caching),
 		resolver.NewParallelBestResolver(cfg.Upstream.ExternalResolvers),
 	)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -68,6 +68,7 @@ var _ = Describe("Running DNS server", func() {
 			Conditional: config.ConditionalUpstreamConfig{
 				Mapping: config.ConditionalUpstreamMapping{
 					Upstreams: map[string][]config.Upstream{
+						"net.cn":    {upstreamClient},
 						"fritz.box": {upstreamFritzbox},
 					},
 				},
@@ -167,6 +168,13 @@ var _ = Describe("Running DNS server", func() {
 				resp = requestServer(util.NewMsgWithQuestion("host.fritz.box.", dns.TypeA))
 
 				Expect(resp.Answer).Should(BeDNSRecord("host.fritz.box.", dns.TypeA, 3600, "192.168.178.2"))
+			})
+		})
+		Context("Conditional upstream blocking", func() {
+			It("Query should be blocked, domain is in default group", func() {
+				resp = requestServer(util.NewMsgWithQuestion("doubleclick.net.cn.", dns.TypeA))
+
+				Expect(resp.Answer).Should(BeDNSRecord("doubleclick.net.cn.", dns.TypeA, 21600, "0.0.0.0"))
 			})
 		})
 		Context("Blocking default group", func() {

--- a/testdata/doubleclick.net.txt
+++ b/testdata/doubleclick.net.txt
@@ -1,1 +1,2 @@
 doubleclick.net
+doubleclick.net.cn


### PR DESCRIPTION
We should check ads before query conditional upstream.

e.g. I mapped "cn" ccTLD to ISP provided DNS, defaults use Google DNS, but also expect ads can be blocked.