### PR TITLE
feat(docker): add tini to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.source="https://github.com/0xERR0R/blocky" \
       org.opencontainers.image.url="https://github.com/0xERR0R/blocky" \
       org.opencontainers.image.title="DNS proxy as ad-blocker for local network"
 
-RUN apk add --no-cache bind-tools
+RUN apk add --no-cache bind-tools tini
 COPY --from=build-env /src/bin/blocky /app/blocky
 
 # the timezone data:
@@ -42,4 +42,5 @@ HEALTHCHECK --interval=1m --timeout=3s CMD dig @127.0.0.1 -p 53 healthcheck.bloc
 
 WORKDIR /app
 
-ENTRYPOINT ["/app/blocky","--config","/app/config.yml"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/app/blocky","--config","/app/config.yml"]


### PR DESCRIPTION
Hi :wave: Small change here. I created an `ENTRYPOINT` with [tini](https://github.com/krallin/tini) and updated the `CMD` in the `Dockerfile`. tini is already included in the `Docker` CRI, however some people (like me) use a different CRI like `containerd` or `cri-o` where we don't have access to an `--init` flag. 

`tini` also has other benefits as described in this [Github issue](https://github.com/krallin/tini/issues/8#issuecomment-146135930).