### PR TITLE
Update installation doc with change of depreacted externalResolvers

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ Simple configuration file, which enables only basic features:
 
 ```yaml
 upstream:
-  externalResolvers:
+  default:
     - 46.182.19.48
     - 80.241.218.68
     - tcp-tls:fdns1.dismail.de:853


### PR DESCRIPTION
Before blocky complained about:

```
[2021-06-25 10:10:20]  WARN parallel_best_resolver: using deprecated 'externalResolvers' as default upstream resolver configuration name, please consider to change it to 'default'
```