### PR TITLE
Allow configuration of block time

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -258,6 +258,7 @@ type BlockingConfig struct {
 	WhiteLists        map[string][]string `yaml:"whiteLists"`
 	ClientGroupsBlock map[string][]string `yaml:"clientGroupsBlock"`
 	BlockType         string              `yaml:"blockType"`
+	BlockTimeSec      int                 `yaml:"blockTTL"`
 	RefreshPeriod     int                 `yaml:"refreshPeriod"`
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -268,6 +268,19 @@ default** block type. Server returns 0.0.0.0 (or :: for IPv6) as result for A an
       blockType: nxDomain
     ```
 
+### Block TTL
+
+TTL for answers to blocked domains can be set to customize the time clients ask for those domains again.
+This setting only makes sense when `blockType` is set to `nxDomain` or `zeroIP`, and will affect how much time it could take for a client to be able to see the real IP address for a domain after receiving the custom value.
+
+!!! example
+
+    ```yaml
+    blocking:
+      blockType: 192.100.100.15, 2001:0db8:85a3:08d3:1319:8a2e:0370:7344
+      blockTTL: 10
+    ```
+
 ### List refresh period
 
 To keep the list cache up-to-date, blocky will periodically download and reload all external lists. Default period is **

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -245,6 +245,40 @@ badcnamedomain.com`)
 			})
 		})
 
+		When("BlockTimeSec is set", func() {
+			BeforeEach(func() {
+				sutConfig = config.BlockingConfig{
+					BlackLists: map[string][]string{
+						"defaultGroup": {defaultGroupFile.Name()},
+					},
+					ClientGroupsBlock: map[string][]string{
+						"default": {"defaultGroup"},
+					},
+					BlockTimeSec: 1234,
+				}
+			})
+
+			It("should return answer with specified TTL", func() {
+				resp, err = sut.Resolve(newRequestWithClient("blocked3.com.", dns.TypeA, "1.2.1.2", "unknown"))
+
+				Expect(resp.Reason).Should(Equal("BLOCKED (defaultGroup)"))
+				Expect(resp.Res.Answer).Should(BeDNSRecord("blocked3.com.", dns.TypeA, 1234, "0.0.0.0"))
+			})
+
+			When("BlockType is custom IP", func() {
+				BeforeEach(func() {
+					sutConfig.BlockType = "12.12.12.12"
+				})
+
+				It("should return custom IP with specified TTL", func() {
+					resp, err = sut.Resolve(newRequestWithClient("blocked3.com.", dns.TypeA, "1.2.1.2", "unknown"))
+
+					Expect(resp.Reason).Should(Equal("BLOCKED (defaultGroup)"))
+					Expect(resp.Res.Answer).Should(BeDNSRecord("blocked3.com.", dns.TypeA, 1234, "12.12.12.12"))
+				})
+			})
+		})
+
 		When("BlockType is custom IP", func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{


### PR DESCRIPTION
When an address is blocked, it can be cached by the client. If we
then wish to allow that address, or just disable the blocking
feature, that client is not gonna be able to see that domain until
the previous domain expires.

The units of time for this setting is in seconds, since we might
want to set it to values around 5 or 10 seconds, depending on the
scenario. The default value for it is the value used before, so
ignoring this setting wont result on any change.

Wasn't sure about the names to use, so make sure you comment
if you have some better examples or comment regarding that or
anything else!