### PR TITLE
Suppress health check output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=build-env /usr/share/zoneinfo /usr/share/zoneinfo
 # the tls certificates:
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-HEALTHCHECK --interval=1m --timeout=3s CMD dig @127.0.0.1 -p 53 healthcheck.blocky +tcp || exit 1
+HEALTHCHECK --interval=1m --timeout=3s CMD dig @127.0.0.1 -p 53 healthcheck.blocky +tcp +short || exit 1
 
 WORKDIR /app
 


### PR DESCRIPTION
To avoid something like this:

<img width="959" alt="image" src="https://user-images.githubusercontent.com/19761269/132238149-f9462be1-96fe-4d34-a902-e6f59bcda0ee.png">
