### PR TITLE
Change golang build constraint syntax

### DIFF
--- a/resolver/stats_resolver_trigger.go
+++ b/resolver/stats_resolver_trigger.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package resolver
 

--- a/server/server_config_trigger.go
+++ b/server/server_config_trigger.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package server
 


### PR DESCRIPTION
It took me a bit to make the `golangci-lint` tool work on my end, but it seems like using the new format fixes the issues.