### PR TITLE
Implemented the option to disable query logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,8 @@ import (
 type NetProtocol uint16
 
 // QueryLogType type of the query log ENUM(
-// none // use logger as fallback
+// console // use logger as fallback
+// none // no logging
 // mysql // MySQL or MariaDB database
 // csv // CSV file per day
 // csv-client // CSV file per day and client
@@ -394,7 +395,7 @@ func validateConfig(cfg *Config) {
 			cfg.QueryLog.Target = cfg.QueryLog.Dir
 		}
 
-		if cfg.QueryLog.Type == QueryLogTypeNone {
+		if cfg.QueryLog.Type == QueryLogTypeConsole {
 			if cfg.QueryLog.PerClient {
 				cfg.QueryLog.Type = QueryLogTypeCsvClient
 			} else {

--- a/config/config_enum.go
+++ b/config/config_enum.go
@@ -95,9 +95,12 @@ func (x *NetProtocol) UnmarshalText(text []byte) error {
 }
 
 const (
-	// QueryLogTypeNone is a QueryLogType of type None.
+	// QueryLogTypeConsole is a QueryLogType of type Console.
 	// use logger as fallback
-	QueryLogTypeNone QueryLogType = iota
+	QueryLogTypeConsole QueryLogType = iota
+	// QueryLogTypeNone is a QueryLogType of type None.
+	// no logging
+	QueryLogTypeNone
 	// QueryLogTypeMysql is a QueryLogType of type Mysql.
 	// MySQL or MariaDB database
 	QueryLogTypeMysql
@@ -109,13 +112,14 @@ const (
 	QueryLogTypeCsvClient
 )
 
-const _QueryLogTypeName = "nonemysqlcsvcsv-client"
+const _QueryLogTypeName = "consolenonemysqlcsvcsv-client"
 
 var _QueryLogTypeNames = []string{
-	_QueryLogTypeName[0:4],
-	_QueryLogTypeName[4:9],
-	_QueryLogTypeName[9:12],
-	_QueryLogTypeName[12:22],
+	_QueryLogTypeName[0:7],
+	_QueryLogTypeName[7:11],
+	_QueryLogTypeName[11:16],
+	_QueryLogTypeName[16:19],
+	_QueryLogTypeName[19:29],
 }
 
 // QueryLogTypeNames returns a list of possible string values of QueryLogType.
@@ -126,10 +130,11 @@ func QueryLogTypeNames() []string {
 }
 
 var _QueryLogTypeMap = map[QueryLogType]string{
-	0: _QueryLogTypeName[0:4],
-	1: _QueryLogTypeName[4:9],
-	2: _QueryLogTypeName[9:12],
-	3: _QueryLogTypeName[12:22],
+	0: _QueryLogTypeName[0:7],
+	1: _QueryLogTypeName[7:11],
+	2: _QueryLogTypeName[11:16],
+	3: _QueryLogTypeName[16:19],
+	4: _QueryLogTypeName[19:29],
 }
 
 // String implements the Stringer interface.
@@ -141,10 +146,11 @@ func (x QueryLogType) String() string {
 }
 
 var _QueryLogTypeValue = map[string]QueryLogType{
-	_QueryLogTypeName[0:4]:   0,
-	_QueryLogTypeName[4:9]:   1,
-	_QueryLogTypeName[9:12]:  2,
-	_QueryLogTypeName[12:22]: 3,
+	_QueryLogTypeName[0:7]:   0,
+	_QueryLogTypeName[7:11]:  1,
+	_QueryLogTypeName[11:16]: 2,
+	_QueryLogTypeName[16:19]: 3,
+	_QueryLogTypeName[19:29]: 4,
 }
 
 // ParseQueryLogType attempts to convert a string to a QueryLogType

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -436,14 +436,16 @@ You can select one of following query log types:
 - `mysql` - log each query in the external MySQL/MariaDB database
 - `csv` - log into CSV file (one per day)
 - `csv-client` - log into CSV file (one per day and per client)
+- `console` - log into console output
+- `none` - do not log any queries
 
 Configuration parameters:
 
-| Parameter                | Type                                      | Mandatory | Default value      | Description                                                                 |
-| ---------------------    | ----------------------------------------- | --------- | ------------------ | --------------------------------------------------------------------------- |
-| queryLog.type            | enum (mysql, csv, csv-client (see above)) | no        |                    |  Type of logging target. Console if empty                                   |
-| queryLog.target          | string                                    | no        |                    |  directory for writing the logs (for csv) or database url (for mysql)       |
-| queryLog.logRetentionDays| int                                       | no        | 0                  |  if > 0, deletes log files/database entries which are older than ... days   |
+| Parameter                | Type                                                     | Mandatory | Default value      | Description                                                                 |
+| ---------------------    | -------------------------------------------------------- | --------- | ------------------ | --------------------------------------------------------------------------- |
+| queryLog.type            | enum (mysql, csv, csv-client, console, none (see above)) | no        |                    |  Type of logging target. Console if empty                                   |
+| queryLog.target          | string                                                   | no        |                    |  directory for writing the logs (for csv) or database url (for mysql)       |
+| queryLog.logRetentionDays| int                                                      | no        | 0                  |  if > 0, deletes log files/database entries which are older than ... days   |
 
 !!! hint
 

--- a/querylog/none_writer.go
+++ b/querylog/none_writer.go
@@ -1,0 +1,16 @@
+package querylog
+
+type NoneWriter struct {
+}
+
+func NewNoneWriter() *NoneWriter {
+	return &NoneWriter{}
+}
+
+func (d *NoneWriter) Write(entry *Entry) {
+	// Nothing to do
+}
+
+func (d *NoneWriter) CleanUp() {
+	// Nothing to do
+}

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -35,8 +35,10 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 		writer = querylog.NewCSVWriter(cfg.Target, true, cfg.LogRetentionDays)
 	case config.QueryLogTypeMysql:
 		writer = querylog.NewDatabaseWriter(cfg.Target, cfg.LogRetentionDays, 30*time.Second)
-	case config.QueryLogTypeNone:
+	case config.QueryLogTypeConsole:
 		writer = querylog.NewLoggerWriter()
+	case config.QueryLogTypeNone:
+		writer = querylog.NewNoneWriter()
 	}
 
 	logChan := make(chan *querylog.Entry, logChanCap)


### PR DESCRIPTION
This implements the option to disable query logging, as requested in #333. A new `NoneWriter` is implemented, which requires almost no change in code to implement the new feature.

The default behaviour is unchanged; if there is no `queryLog` configured, the output is to console. To disable query logging, the following configuration is required:

```
queryLog:
  type: none
```

Documentation has been modified to reflect the changes.
