### PR TITLE
Make go:build compatible with go 1.16

### DIFF
--- a/server/server_config_trigger.go
+++ b/server/server_config_trigger.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 package server
 


### PR DESCRIPTION
#267 broke building on older go versions. This fixes it.
I also made sure it still builds with 1.17.