### PR TITLE
Allow configuring custom DNS TTL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -289,7 +289,8 @@ type UpstreamConfig struct {
 
 // CustomDNSConfig custom DNS configuration
 type CustomDNSConfig struct {
-	Mapping CustomDNSMapping `yaml:"mapping"`
+	CustomTTL Duration         `yaml:"customTTL" default:"1h"`
+	Mapping   CustomDNSMapping `yaml:"mapping"`
 }
 
 // CustomDNSMapping mapping for the custom DNS configuration

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -18,6 +18,7 @@ upstreamTimeout: 2s
 # optional: custom IP address(es) for domain name (with all sub-domains). Multiple addresses must be separated by a comma
 # example: query "printer.lan" or "my.printer.lan" will return 192.168.178.3
 customDNS:
+  customTTL: 1h
   mapping:
     printer.lan: 192.168.178.3,2001:0db8:85a3:08d3:1319:8a2e:0370:7344
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,10 +115,16 @@ You can define your own domain name to IP mappings. For example, you can use a u
 or define a domain name for your local device on order to use the HTTPS certificate. Multiple IP addresses for one
 domain must be separated by a comma.
 
+| Parameter | Type                                    | Mandatory | Default value | 
+| --------- | --------------------------------------- | --------- | ------------- |
+| customTTL | duration (no unit is minutes)           | no        | 1h            | 
+| mapping   | string: string (hostname: address list) | no        |               | 
+
 !!! example
 
     ```yaml
     customDNS:
+      customTTL: 1h
       mapping:
         printer.lan: 192.168.178.3 
         otherdevice.lan: 192.168.178.15,2001:0db8:85a3:08d3:1319:8a2e:0370:7344

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -60,6 +60,7 @@ var _ = Describe("Running DNS server", func() {
 		// create server
 		sut, err = NewServer(&config.Config{
 			CustomDNS: config.CustomDNSConfig{
+				CustomTTL: config.Duration(time.Duration(3600) * time.Second),
 				Mapping: config.CustomDNSMapping{
 					HostIPs: map[string][]net.IP{
 						"custom.lan": {net.ParseIP("192.168.178.55")},


### PR DESCRIPTION
I changed the tests to use a random but common TTL on each run. Maybe you'd prefer a separate test for the TTL explicitly.
Also, I haven't updated the docs.