### PR TITLE
Add failed_download_count metric

### DIFF
--- a/docs/prometheus_grafana.md
+++ b/docs/prometheus_grafana.md
@@ -20,6 +20,7 @@ Following metrics will be exported:
 | blocky_cache_hit_count / blocky_cache_miss_count | Cache hit/miss counters |
 | blocky_prefetch_count | Amount of prefetched DNS responses |
 | blocky_prefetch_domain_name_cache_count | Amount of domain names being prefetched |
+| blocky_failed_download_count      | Number of failed list downloads |
 
 ### Grafana dashboard
 

--- a/evt/events.go
+++ b/evt/events.go
@@ -29,6 +29,9 @@ const (
 	// CachingDomainsToPrefetchCountChanged fires, if a number of domains being prefetched changed, Parameter: new count
 	CachingDomainsToPrefetchCountChanged = "caching:domainsToPrefetchCountChanged"
 
+	// CachingFailedDownloadChanged fires, if a download of a blocking list fails
+	CachingFailedDownloadChanged = "caching:failedDownload"
+
 	// ApplicationStarted fires on start of the application. Parameter: version number, build time
 	ApplicationStarted = "application:started"
 )

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -272,6 +272,8 @@ func (b *ListCache) downloadFile(link string) (io.ReadCloser, error) {
 			default:
 				logger.Warnf("Can't download file: %s", err)
 			}
+
+			evt.Bus().Publish(evt.CachingFailedDownloadChanged, link)
 		}))
 
 	return body, err

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -120,6 +120,7 @@ func registerCachingEventListeners() {
 	missCount := cacheMissCount()
 	prefetchCount := domainPrefetchCount()
 	prefetchHitCount := domainPrefetchHitCount()
+	failedDownloadCount := failedDownloadCount()
 
 	RegisterMetric(entryCount)
 	RegisterMetric(prefetchDomainCount)
@@ -127,6 +128,7 @@ func registerCachingEventListeners() {
 	RegisterMetric(missCount)
 	RegisterMetric(prefetchCount)
 	RegisterMetric(prefetchHitCount)
+	RegisterMetric(failedDownloadCount)
 
 	subscribe(evt.CachingDomainsToPrefetchCountChanged, func(cnt int) {
 		prefetchDomainCount.Set(float64(cnt))
@@ -150,6 +152,17 @@ func registerCachingEventListeners() {
 
 	subscribe(evt.CachingResultCacheChanged, func(cnt int) {
 		entryCount.Set(float64(cnt))
+	})
+
+	subscribe(evt.CachingFailedDownloadChanged, func(_ string) {
+		failedDownloadCount.Inc()
+	})
+}
+
+func failedDownloadCount() prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "blocky_failed_download_count",
+		Help: "Failed download counter",
 	})
 }
 


### PR DESCRIPTION
This implements #309 . Adds `blocky_failed_download_count` Prometheus metric, which increments the counter for every failed attempt to download a blocking list.