### PR TITLE
docs/config.yml: default for tlsPort is 853

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -175,7 +175,7 @@ redis:
 # optional: DNS listener port(s) and bind ip address(es), default 53 (UDP and TCP). Example: 53, :53, "127.0.0.1:5353,[::1]:5353"
 port: 53
 # optional: Port(s) and bind ip address(es) for DoT (DNS-over-TLS) listener. Example: 853, 127.0.0.1:853
-#tlsPort: 53
+#tlsPort: 853
 # optional: HTTPS listener port(s) and bind ip address(es), default empty = no http listener. If > 0, will be used for prometheus metrics, pprof, REST API, DoH... Example: 443, :443, 127.0.0.1:443
 httpPort: 4000
 #httpsPort: 443


### PR DESCRIPTION
default for `tlsPort` is 853, hence adjusting the (commented out) example