### PR TITLE
Defining env var for configurable config file location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
     ca-certificates
 
 ENV GO111MODULE=on \
-    CGO_ENABLED=0
+    CGO_ENABLED=0 \
+    CONFIG_FILE=/app/config.yml
     
 WORKDIR /src
 
@@ -40,4 +41,4 @@ USER blocky
 WORKDIR /app
 
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["/app/blocky","--config","/app/config.yml"]
+CMD ["/app/blocky","--config","$CONFIG_FILE"]


### PR DESCRIPTION
When deploying blocky in my environment, I had wanted to use a NFS volume to externalize the config file. However this is not possible when the executable is in the same directory the config file is in. Making the config file location a variable allows this.

The edge case arises as NFS can only mount filesystems instead of individual files. If you mount the volume into the _/app_ directory of the container, this overrides the existing content (the _blocky_ executable) causing the container to fail to start.