### PR TITLE
Exclude resolvers without config from the chain

### DIFF
--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -90,6 +90,10 @@ type BlockingResolver struct {
 
 // NewBlockingResolver returns a new configured instance of the resolver
 func NewBlockingResolver(cfg config.BlockingConfig, redis *redis.Client) (ChainedResolver, error) {
+	if len(cfg.ClientGroupsBlock) == 0 {
+		return nil, nil
+	}
+
 	blockHandler := createBlockHandler(cfg)
 	refreshPeriod := time.Duration(cfg.RefreshPeriod)
 	timeout := time.Duration(cfg.DownloadTimeout)
@@ -310,34 +314,30 @@ func (r *BlockingResolver) handleBlocked(logger *logrus.Entry,
 
 // Configuration returns the current resolver configuration
 func (r *BlockingResolver) Configuration() (result []string) {
-	if len(r.cfg.ClientGroupsBlock) > 0 {
-		result = append(result, "clientGroupsBlock")
-		for key, val := range r.cfg.ClientGroupsBlock {
-			result = append(result, fmt.Sprintf("  %s = \"%s\"", key, strings.Join(val, ";")))
-		}
+	result = append(result, "clientGroupsBlock")
+	for key, val := range r.cfg.ClientGroupsBlock {
+		result = append(result, fmt.Sprintf("  %s = \"%s\"", key, strings.Join(val, ";")))
+	}
 
-		blockType := r.cfg.BlockType
-		result = append(result, fmt.Sprintf("blockType = \"%s\"", blockType))
+	blockType := r.cfg.BlockType
+	result = append(result, fmt.Sprintf("blockType = \"%s\"", blockType))
 
-		if blockType != "NXDOMAIN" {
-			result = append(result, fmt.Sprintf("blockTTL = %s", r.cfg.BlockTTL.String()))
-		}
+	if blockType != "NXDOMAIN" {
+		result = append(result, fmt.Sprintf("blockTTL = %s", r.cfg.BlockTTL.String()))
+	}
 
-		result = append(result, fmt.Sprintf("downloadTimeout = %s", r.cfg.DownloadTimeout.String()))
+	result = append(result, fmt.Sprintf("downloadTimeout = %s", r.cfg.DownloadTimeout.String()))
 
-		result = append(result, fmt.Sprintf("FailStartOnListError = %t", r.cfg.FailStartOnListError))
+	result = append(result, fmt.Sprintf("FailStartOnListError = %t", r.cfg.FailStartOnListError))
 
-		result = append(result, "blacklist:")
-		for _, c := range r.blacklistMatcher.Configuration() {
-			result = append(result, fmt.Sprintf("  %s", c))
-		}
+	result = append(result, "blacklist:")
+	for _, c := range r.blacklistMatcher.Configuration() {
+		result = append(result, fmt.Sprintf("  %s", c))
+	}
 
-		result = append(result, "whitelist:")
-		for _, c := range r.whitelistMatcher.Configuration() {
-			result = append(result, fmt.Sprintf("  %s", c))
-		}
-	} else {
-		result = []string{"deactivated"}
+	result = append(result, "whitelist:")
+	for _, c := range r.whitelistMatcher.Configuration() {
+		result = append(result, fmt.Sprintf("  %s", c))
 	}
 
 	return result

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -20,6 +20,10 @@ type ConditionalUpstreamResolver struct {
 
 // NewConditionalUpstreamResolver returns new resolver instance
 func NewConditionalUpstreamResolver(cfg config.ConditionalUpstreamConfig) ChainedResolver {
+	if len(cfg.Mapping.Upstreams) == 0 {
+		return nil
+	}
+
 	m := make(map[string]Resolver, len(cfg.Mapping.Upstreams))
 
 	for domain, upstream := range cfg.Mapping.Upstreams {
@@ -33,12 +37,8 @@ func NewConditionalUpstreamResolver(cfg config.ConditionalUpstreamConfig) Chaine
 
 // Configuration returns current configuration
 func (r *ConditionalUpstreamResolver) Configuration() (result []string) {
-	if len(r.mapping) > 0 {
-		for key, val := range r.mapping {
-			result = append(result, fmt.Sprintf("%s = \"%s\"", key, val))
-		}
-	} else {
-		result = []string{"deactivated"}
+	for key, val := range r.mapping {
+		result = append(result, fmt.Sprintf("%s = \"%s\"", key, val))
 	}
 
 	return

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -25,6 +25,10 @@ type CustomDNSResolver struct {
 
 // NewCustomDNSResolver creates new resolver instance
 func NewCustomDNSResolver(cfg config.CustomDNSConfig) ChainedResolver {
+	if len(cfg.Mapping.HostIPs) == 0 {
+		return nil
+	}
+
 	m := make(map[string][]net.IP, len(cfg.Mapping.HostIPs))
 	reverse := make(map[string][]string, len(cfg.Mapping.HostIPs))
 
@@ -49,12 +53,8 @@ func NewCustomDNSResolver(cfg config.CustomDNSConfig) ChainedResolver {
 
 // Configuration returns current resolver configuration
 func (r *CustomDNSResolver) Configuration() (result []string) {
-	if len(r.mapping) > 0 {
-		for key, val := range r.mapping {
-			result = append(result, fmt.Sprintf("%s = \"%s\"", key, val))
-		}
-	} else {
-		result = []string{"deactivated"}
+	for key, val := range r.mapping {
+		result = append(result, fmt.Sprintf("%s = \"%s\"", key, val))
 	}
 
 	return

--- a/resolver/ipv6_disabling_resolver.go
+++ b/resolver/ipv6_disabling_resolver.go
@@ -8,11 +8,10 @@ import (
 // IPv6DisablingResolver can drop all AAAA query (empty ANSWER with NOERROR)
 type IPv6DisablingResolver struct {
 	NextResolver
-	disableAAAA bool
 }
 
 func (r *IPv6DisablingResolver) Resolve(request *model.Request) (*model.Response, error) {
-	if r.disableAAAA && request.Req.Question[0].Qtype == dns.TypeAAAA {
+	if request.Req.Question[0].Qtype == dns.TypeAAAA {
 		response := new(dns.Msg)
 		response.SetRcode(request.Req, dns.RcodeSuccess)
 
@@ -23,15 +22,14 @@ func (r *IPv6DisablingResolver) Resolve(request *model.Request) (*model.Response
 }
 
 func (r *IPv6DisablingResolver) Configuration() (result []string) {
-	if r.disableAAAA {
-		result = append(result, "drop AAAA")
-	} else {
-		result = append(result, "accept AAAA")
-	}
-
+	result = append(result, "drop AAAA")
 	return
 }
 
-func NewIPv6Checker(disable bool) ChainedResolver {
-	return &IPv6DisablingResolver{disableAAAA: disable}
+func NewIPv6Checker(disableAAAA bool) ChainedResolver {
+	if !disableAAAA {
+		return nil
+	}
+
+	return &IPv6DisablingResolver{}
 }

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,31 +1,75 @@
 package resolver
 
 import (
-	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/model"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Resolver", func() {
-	Describe("Creating resolver chain", func() {
-		When("A chain of resolvers will be created", func() {
-			It("should be iterable by calling 'GetNext'", func() {
-				br, _ := NewBlockingResolver(config.BlockingConfig{BlockType: "zeroIP"}, nil)
-				ch := Chain(br, NewClientNamesResolver(config.ClientLookupConfig{}))
-				c, ok := ch.(ChainedResolver)
-				Expect(ok).Should(BeTrue())
+type NoOpChainedResolver struct {
+	NextResolver
+}
 
-				next := c.GetNext()
-				Expect(next).ShouldNot(BeNil())
+func (r NoOpChainedResolver) Resolve(req *model.Request) (*model.Response, error) {
+	return r.next.Resolve(req)
+}
+
+func (r NoOpChainedResolver) Configuration() []string {
+	return nil
+}
+
+var _ = Describe("Resolver", func() {
+	Describe("ChainBuilder", func() {
+		var (
+			beg ChainedResolver
+			mid ChainedResolver
+			end Resolver
+			cb  *ChainBuilder
+			ch  Resolver
+			err error
+		)
+
+		BeforeEach(func() {
+			beg = &NoOpChainedResolver{}
+			mid = &NoOpChainedResolver{}
+			end = NewNoOpResolver()
+		})
+
+		Describe("successful build", func() {
+			AfterEach(func() {
+				Expect(ch).Should(Equal(beg))
+				Expect(beg.GetNext()).Should(Equal(mid))
+				Expect(mid.GetNext()).Should(Equal(end))
+			})
+
+			When("complete", func() {
+				BeforeEach(func() {
+					cb = NewChainBuilder(beg, mid)
+					Expect(cb).ShouldNot(BeNil())
+
+					ch, err = cb.End(end)
+					Expect(err).Should(Succeed())
+					Expect(ch).ShouldNot(BeNil())
+				})
+
+				It("should be iterable by calling 'GetNext'", func() {})
+
+				It("should not be reusable", func() {
+					defer func() {
+						Expect(recover()).ShouldNot(BeNil())
+					}()
+
+					cb.Next(&NoOpChainedResolver{})
+				})
 			})
 		})
-		When("'Name' is called", func() {
-			It("should return resolver name", func() {
-				br, _ := NewBlockingResolver(config.BlockingConfig{BlockType: "zeroIP"}, nil)
-				name := Name(br)
-				Expect(name).Should(Equal("BlockingResolver"))
-			})
+	})
+
+	When("'Name' is called", func() {
+		It("should return resolver name", func() {
+			name := Name(NewNoOpResolver())
+			Expect(name).Should(Equal("NoOpResolver"))
 		})
 		When("'Name' is called on a NamedResolver", func() {
 			It("should return it's custom name", func() {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -63,6 +63,66 @@ var _ = Describe("Resolver", func() {
 					cb.Next(&NoOpChainedResolver{})
 				})
 			})
+
+			When("first is nil", func() {
+				It("should complete", func() {
+					ch, err = NewChainBuilder(nil, beg, mid).End(end)
+					Expect(err).Should(Succeed())
+					Expect(ch).ShouldNot(BeNil())
+				})
+			})
+
+			When("first two are nil", func() {
+				It("should complete", func() {
+					ch, err = NewChainBuilder(nil, nil, beg, mid).End(end)
+					Expect(err).Should(Succeed())
+					Expect(ch).ShouldNot(BeNil())
+				})
+			})
+
+			When("some are nil", func() {
+				It("should complete", func() {
+					ch, err = NewChainBuilder(nil, beg, nil, mid, nil).End(end)
+					Expect(err).Should(Succeed())
+					Expect(ch).ShouldNot(BeNil())
+				})
+			})
+		})
+
+		When("given no resolvers", func() {
+			It("should be nil", func() {
+				cb := NewChainBuilder(nil)
+				Expect(cb).Should(BeNil())
+			})
+
+			It("should complete", func() {
+				cb := NewChainBuilder(nil)
+				Expect(cb).Should(BeNil())
+
+				ch, err := cb.End(NewNoOpResolver())
+				Expect(err).Should(Succeed())
+				Expect(ch).ShouldNot(BeNil())
+			})
+		})
+
+		When("ended with nil", func() {
+			It("should fail", func() {
+				cb := NewChainBuilder(nil, nil)
+				Expect(cb).Should(BeNil())
+
+				_, err := cb.End(nil)
+				Expect(err).ShouldNot(BeNil())
+			})
+		})
+
+		When("ended with a ChainedResolver", func() {
+			It("should fail", func() {
+				cb := NewChainBuilder(nil, nil)
+				Expect(cb).Should(BeNil())
+
+				_, err := cb.End(&NoOpChainedResolver{})
+				Expect(err).ShouldNot(BeNil())
+			})
 		})
 	})
 

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -32,23 +32,7 @@ var _ = Describe("RewriterResolver", func() {
 	})
 
 	JustBeforeEach(func() {
-		sut = NewRewriterResolver(sutConfig, mInner)
-		sut.Next(mNext)
-	})
-
-	AfterEach(func() {
-		mInner.AssertExpectations(GinkgoT())
-		mNext.AssertExpectations(GinkgoT())
-	})
-
-	When("has no configuration", func() {
-		BeforeEach(func() {
-			sutConfig = config.RewriteConfig{}
-		})
-
-		It("should return the inner resolver", func() {
-			Expect(sut).Should(BeIdenticalTo(mInner))
-		})
+		sut = NewRewriterResolver(cfg, NewChainBuilder(m))
 	})
 
 	When("has rewrite", func() {

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -88,6 +89,10 @@ func NewServer(cfg *config.Config) (server *Server, err error) {
 	queryResolver, queryError := createQueryResolver(cfg, redisClient)
 	if queryError != nil {
 		return nil, queryError
+	}
+
+	if queryResolver == nil {
+		return nil, errors.New("no resolvers are configured")
 	}
 
 	server = &Server{


### PR DESCRIPTION
The code in this branch makes it so only actually configured resolvers are created and added to the chain.
This should simplify reading trace logs, and add a small speedup to queries (didn't attempt to benchmark).

The PR is not ready: tests do not pass yet, and that's a fair bit of work.
Is it worth it I spend time fixing the tests, is this something you'd be interested in merging?
