### PR TITLE
Add cd bit to cache key to fix DNS poisoning

### DIFF
--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -95,7 +95,7 @@ func (r *CachingResolver) isPrefetchingDomain(cacheKey string) bool {
 }
 
 func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.Duration) {
-	qType, domainName := util.ExtractCacheKey(cacheKey)
+	_, qType, domainName := util.ExtractCacheKey(cacheKey)
 
 	logger := logger("caching_resolver")
 
@@ -160,7 +160,7 @@ func (r *CachingResolver) Resolve(request *model.Request) (response *model.Respo
 
 	for _, question := range request.Req.Question {
 		domain := util.ExtractDomain(question)
-		cacheKey := util.GenerateCacheKey(question.Qtype, domain)
+		cacheKey := util.GenerateCacheKey(&request.Req.MsgHdr, question.Qtype, domain)
 		logger := logger.WithField("domain", util.Obfuscate(domain))
 
 		r.trackQueryDomainNameCount(domain, cacheKey, logger)

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -526,7 +526,7 @@ var _ = Describe("CachingResolver", func() {
 			It("load", func() {
 				request := newRequest("example2.com.", dns.TypeA)
 				domain := util.ExtractDomain(request.Req.Question[0])
-				cacheKey := util.GenerateCacheKey(dns.TypeA, domain)
+				cacheKey := util.GenerateCacheKey(&dns.MsgHdr{}, dns.TypeA, domain)
 				redisMockMsg := &redis.CacheMessage{
 					Key: cacheKey,
 					Response: &Response{

--- a/util/common_test.go
+++ b/util/common_test.go
@@ -215,8 +215,9 @@ var _ = Describe("Common function tests", func() {
 
 	Describe("Domain cache key generate/extract", func() {
 		It("should works", func() {
-			cacheKey := GenerateCacheKey(dns.TypeA, "example.com")
-			qType, qName := ExtractCacheKey(cacheKey)
+			cacheKey := GenerateCacheKey(&dns.MsgHdr{CheckingDisabled: true}, dns.TypeA, "example.com")
+			cd, qType, qName := ExtractCacheKey(cacheKey)
+			Expect(cd).Should(BeTrue())
 			Expect(qType).Should(Equal(dns.TypeA))
 			Expect(qName).Should(Equal("example.com"))
 		})


### PR DESCRIPTION
The CheckingDisabled flag tells the resolver to skip DNSSEC signature
verification.

Fixes #455