### PR TITLE
Indent "Integration" sub-points on mkdocs index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,11 +47,11 @@ Blocky is a DNS proxy and ad-blocker for the local network written in Go with fo
 
 - **Integration** - :notebook_with_decorative_cover: various integration
 
-  * [Prometheus](https://prometheus.io/) metrics
-  * Prepared [Grafana](https://grafana.com/) dashboards (Prometheus and database)
-  * Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL database - easy to analyze
-  * Various REST API endpoints
-  * CLI tool
+    * [Prometheus](https://prometheus.io/) metrics
+    * Prepared [Grafana](https://grafana.com/) dashboards (Prometheus and database)
+    * Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL database - easy to analyze
+    * Various REST API endpoints
+    * CLI tool
 
 - **Simple configuration** - :baby: single configuration file in YAML format
 


### PR DESCRIPTION
This rectifies the improperly aligned points on the mkdocs index page and normalises the formatting.