### PR TITLE
update golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,5 +16,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.43.0
+          version: v1.45.2
           args: --timeout 5m0s

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - nakedret
     - nestif
     - nilerr
+    - nilnil
     - prealloc
     - revive
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
     - nestif
     - nilerr
     - nilnil
+    - nlreturn
     - prealloc
     - revive
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - nilerr
     - nilnil
     - nlreturn
+    - nolintlint
     - prealloc
     - revive
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - asciicheck
     - bodyclose
     - deadcode
     - depguard
@@ -51,7 +52,7 @@ linters-settings:
   gomnd:
     ignored-numbers:
       - '0666'
-      
+
 issues:
   exclude-rules:
     # Exclude some linters from running on tests files.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,7 @@ linters:
     - makezero
     - misspell
     - nakedret
+    - nestif 
     - prealloc
     - revive
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
     - prealloc
     - predeclared
     - revive
+    - sqlclosecheck
     - staticcheck
     - structcheck
     - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - dupl
     - durationcheck
     - errcheck
+    - errchkjson
     - exportloopref
     - funlen
     - gochecknoglobals

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - durationcheck
     - errcheck
     - errchkjson
+    - errorlint
     - exportloopref
     - funlen
     - gochecknoglobals

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - gofmt
     - goimports
     - gomnd
+    - gomoddirectives
     - gosec
     - gosimple
     - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,8 @@ linters:
     - makezero
     - misspell
     - nakedret
-    - nestif 
+    - nestif
+    - nilerr
     - prealloc
     - revive
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - errcheck
     - errchkjson
     - errorlint
+    - exhaustive
     - exportloopref
     - funlen
     - gochecknoglobals

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters:
     - nlreturn
     - nolintlint
     - prealloc
+    - predeclared
     - revive
     - staticcheck
     - structcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - durationcheck
     - errcheck
     - exportloopref
     - funlen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - gomoddirectives
     - gomodguard
     - gosec
+    - grouper
     - gosimple
     - govet
     - ineffassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - importas
     - ineffassign
     - lll
+    - makezero
     - misspell
     - nakedret
     - prealloc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,9 +27,10 @@ linters:
     - gomoddirectives
     - gomodguard
     - gosec
-    - grouper
     - gosimple
     - govet
+    - grouper
+    - ifshort
     - ineffassign
     - lll
     - misspell

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,41 +1,42 @@
 linters:
   enable:
-    - govet
-    - errcheck
-    - staticcheck
-    - unused
-    - gosimple
-    - structcheck
-    - varcheck
-    - ineffassign
-    - deadcode
-    - typecheck
     - bodyclose
-    - revive
-    - stylecheck
-    - gosec
-    - unconvert
-    - dupl
-    - goconst
-    - gocyclo
-    - gocognit
-    - gofmt
-    - goimports
+    - deadcode
     - depguard
-    - misspell
-    - lll
-    - unparam
     - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
     - funlen
     - gochecknoglobals
     - gochecknoinits
+    - gocognit
+    - goconst
     - gocritic
+    - gocyclo
     - godox
+    - gofmt
+    - goimports
+    - gomnd
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
     - nakedret
     - prealloc
+    - revive
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
     - whitespace
     - wsl
-    - exportloopref
   disable:
     - noctx
     - scopelint
@@ -46,6 +47,11 @@ linters:
     - unused
   fast: false
 
+linters-settings:
+  gomnd:
+    ignored-numbers:
+      - '0666'
+      
 issues:
   exclude-rules:
     # Exclude some linters from running on tests files.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,6 +49,7 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
+    - tenv
     - typecheck
     - unconvert
     - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,7 @@ linters:
     - unparam
     - unused
     - varcheck
+    - wastedassign
     - whitespace
     - wsl
   disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
     - asciicheck
+    - bidichk
     - bodyclose
     - deadcode
     - depguard

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - goimports
     - gomnd
     - gomoddirectives
+    - gomodguard
     - gosec
     - gosimple
     - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - govet
     - grouper
     - ifshort
+    - importas
     - ineffassign
     - lll
     - misspell

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ race: ## run tests with race detector
 	go test -race -short ./...
 
 lint: build ## run golangcli-lint checks
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 	$(shell go env GOPATH)/bin/golangci-lint run
 
 run: build ## Build and run binary

--- a/api/api_endpoints_test.go
+++ b/api/api_endpoints_test.go
@@ -30,6 +30,7 @@ func (b *BlockingControlMock) EnableBlocking() {
 }
 func (b *BlockingControlMock) DisableBlocking(_ time.Duration, disableGroups []string) error {
 	b.enabled = false
+
 	return nil
 }
 

--- a/cache/expirationcache/expiration_cache.go
+++ b/cache/expirationcache/expiration_cache.go
@@ -139,8 +139,7 @@ func isExpired(el *element) bool {
 }
 
 func calculateRemainTTL(expiresEpoch int64) time.Duration {
-	now := time.Now().UnixMilli()
-	if now < expiresEpoch {
+	if now := time.Now().UnixMilli(); now < expiresEpoch {
 		return time.Duration(expiresEpoch-now) * time.Millisecond
 	}
 

--- a/cache/stringcache/string_caches.go
+++ b/cache/stringcache/string_caches.go
@@ -99,6 +99,7 @@ func (cache regexCache) Contains(searchString string) bool {
 	for _, regex := range cache {
 		if regex.MatchString(searchString) {
 			log.PrefixedLog("regexCache").Debugf("regex '%s' matched with '%s'", regex, searchString)
+
 			return true
 		}
 	}

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -40,6 +40,7 @@ func refreshList(_ *cobra.Command, _ []string) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
+
 		return fmt.Errorf("response NOK, %s %s", resp.Status, string(body))
 	}
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -54,6 +54,7 @@ func query(cmd *cobra.Command, args []string) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
+
 		return fmt.Errorf("response NOK, %s %s", resp.Status, string(body))
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,7 @@ func initConfig() {
 		port, err := config.ConvertPort(split[lastIdx])
 		if err != nil {
 			util.FatalOnError("can't convert port to number (1 - 65535)", err)
+
 			return
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
@@ -18,6 +17,12 @@ var (
 	configPath string
 	apiHost    string
 	apiPort    uint16
+)
+
+const (
+	defaultPort       = 4000
+	defaultHost       = "localhost"
+	defaultConfigPath = "./config.yml"
 )
 
 // NewRootCommand creates a new root cli command instance
@@ -35,9 +40,9 @@ Complete documentation is available at https://github.com/0xERR0R/blocky`,
 		SilenceUsage: true,
 	}
 
-	c.PersistentFlags().StringVarP(&configPath, "config", "c", "./config.yml", "path to config file")
-	c.PersistentFlags().StringVar(&apiHost, "apiHost", "localhost", "host of blocky (API). Default overridden by config and CLI.") // nolint:lll
-	c.PersistentFlags().Uint16Var(&apiPort, "apiPort", 4000, "port of blocky (API). Default overridden by config and CLI.")
+	c.PersistentFlags().StringVarP(&configPath, "config", "c", defaultConfigPath, "path to config file")
+	c.PersistentFlags().StringVar(&apiHost, "apiHost", defaultHost, "host of blocky (API). Default overridden by config and CLI.") // nolint:lll
+	c.PersistentFlags().Uint16Var(&apiPort, "apiPort", defaultPort, "port of blocky (API). Default overridden by config and CLI.") // nolint:lll
 
 	c.AddCommand(newRefreshCommand(),
 		NewQueryCommand(),
@@ -73,15 +78,13 @@ func initConfig() {
 
 		apiHost = strings.Join(split[:lastIdx], ":")
 
-		var p uint64
-		p, err := strconv.ParseUint(strings.TrimSpace(split[lastIdx]), 10, 16)
-
+		port, err := config.ConvertPort(split[lastIdx])
 		if err != nil {
 			util.FatalOnError("can't convert port to number (1 - 65535)", err)
 			return
 		}
 
-		apiPort = uint16(p)
+		apiPort = port
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -49,7 +49,8 @@ func startServer(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("can't start server: %w", err)
 	}
 
-	errChan := make(chan error, 10)
+	const errChanSize = 10
+	errChan := make(chan error, errChanSize)
 
 	srv.Start(errChan)
 

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ func NewQTypeSet(qTypes ...dns.Type) QTypeSet {
 
 func (s QTypeSet) Contains(qType dns.Type) bool {
 	_, found := s[QType(qType)]
+
 	return found
 }
 
@@ -258,12 +259,14 @@ func (c *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		// duration is defined as number without unit
 		// use minutes to ensure back compatibility
 		*c = Duration(time.Duration(minutes) * time.Minute)
+
 		return nil
 	}
 
 	duration, err := time.ParseDuration(input)
 	if err == nil {
 		*c = Duration(duration)
+
 		return nil
 	}
 
@@ -330,6 +333,7 @@ func ParseUpstream(upstream string) (Upstream, error) {
 
 		if err != nil {
 			err = fmt.Errorf("can't convert port to number (1 - 65535) %w", err)
+
 			return Upstream{}, err
 		}
 
@@ -547,6 +551,7 @@ func LoadConfig(path string, mandatory bool) (*Config, error) {
 			// config file does not exist
 			// return config with default values
 			config = &cfg
+
 			return config, nil
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -345,9 +345,7 @@ func ParseUpstream(upstream string) (Upstream, error) {
 	}
 
 	// validate hostname or ip
-	ip := net.ParseIP(host)
-
-	if ip == nil {
+	if ip := net.ParseIP(host); ip == nil {
 		// is not IP
 		if !validDomain.MatchString(host) {
 			return Upstream{}, fmt.Errorf("wrong host name '%s'", host)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -269,6 +269,7 @@ bootstrapDns:
 				u := &Upstream{}
 				err := u.UnmarshalYAML(func(i interface{}) error {
 					*i.(*string) = "tcp+udp:1.2.3.4"
+
 					return nil
 
 				})
@@ -292,6 +293,7 @@ bootstrapDns:
 				l := &ListenConfig{}
 				err := l.UnmarshalYAML(func(i interface{}) error {
 					*i.(*string) = "55,:56"
+
 					return nil
 				})
 				Expect(err).Should(Succeed())
@@ -311,6 +313,7 @@ bootstrapDns:
 				d := Duration(0)
 				err := d.UnmarshalYAML(func(i interface{}) error {
 					*i.(*string) = "1m20s"
+
 					return nil
 				})
 				Expect(err).Should(Succeed())
@@ -321,6 +324,7 @@ bootstrapDns:
 				d := Duration(0)
 				err := d.UnmarshalYAML(func(i interface{}) error {
 					*i.(*string) = "wrong"
+
 					return nil
 				})
 				Expect(err).Should(HaveOccurred())
@@ -342,6 +346,7 @@ bootstrapDns:
 				c := &ConditionalUpstreamMapping{}
 				err := c.UnmarshalYAML(func(i interface{}) error {
 					*i.(*map[string]string) = map[string]string{"key": "1.2.3.4"}
+
 					return nil
 				})
 				Expect(err).Should(Succeed())
@@ -364,6 +369,7 @@ bootstrapDns:
 				c := &CustomDNSMapping{}
 				err := c.UnmarshalYAML(func(i interface{}) error {
 					*i.(*map[string]string) = map[string]string{"key": "1.2.3.4"}
+
 					return nil
 				})
 				Expect(err).Should(Succeed())
@@ -385,6 +391,7 @@ bootstrapDns:
 				t := QType(0)
 				err := t.UnmarshalYAML(func(i interface{}) error {
 					*i.(*string) = "AAAA"
+
 					return nil
 				})
 				Expect(err).Should(Succeed())
@@ -395,6 +402,7 @@ bootstrapDns:
 				t := QType(0)
 				err := t.UnmarshalYAML(func(i interface{}) error {
 					*i.(*string) = "WRONGTYPE"
+
 					return nil
 				})
 				Expect(err).Should(HaveOccurred())

--- a/lists/downloader.go
+++ b/lists/downloader.go
@@ -103,7 +103,6 @@ func (d *HTTPDownloader) DownloadFile(link string) (io.ReadCloser, error) {
 		func() error {
 			var resp *http.Response
 			var httpErr error
-			//nolint:bodyclose
 			if resp, httpErr = client.Get(link); httpErr == nil {
 				if resp.StatusCode == http.StatusOK {
 					body = resp.Body

--- a/lists/downloader.go
+++ b/lists/downloader.go
@@ -107,6 +107,7 @@ func (d *HTTPDownloader) DownloadFile(link string) (io.ReadCloser, error) {
 			if resp, httpErr = client.Get(link); httpErr == nil {
 				if resp.StatusCode == http.StatusOK {
 					body = resp.Body
+
 					return nil
 				}
 
@@ -118,6 +119,7 @@ func (d *HTTPDownloader) DownloadFile(link string) (io.ReadCloser, error) {
 			if errors.As(httpErr, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
 				return &TransientError{inner: netErr}
 			}
+
 			return httpErr
 		},
 		retry.Attempts(d.downloadAttempts),

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -307,9 +307,7 @@ func processLine(line string) string {
 		return ""
 	}
 
-	parts := strings.Fields(line)
-
-	if len(parts) > 0 {
+	if parts := strings.Fields(line); len(parts) > 0 {
 		host := parts[len(parts)-1]
 
 		ip := net.ParseIP(host)

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -163,6 +163,7 @@ Loop:
 			}
 		default:
 			close(c)
+
 			break Loop
 		}
 	}

--- a/lists/list_cache_test.go
+++ b/lists/list_cache_test.go
@@ -152,6 +152,7 @@ var _ = Describe("ListCache", func() {
 				By("List couldn't be loaded due to 404 err", func() {
 					Eventually(func() bool {
 						found, _ := sut.Match("blocked1.com", []string{"gr1"})
+
 						return found
 					}, "1s").Should(BeFalse())
 				})
@@ -313,5 +314,6 @@ type MockDownloader struct {
 
 func (m *MockDownloader) DownloadFile(link string) (io.ReadCloser, error) {
 	fn := <-m.data
+
 	return fn()
 }

--- a/querylog/database_writer_test.go
+++ b/querylog/database_writer_test.go
@@ -45,6 +45,7 @@ var _ = Describe("DatabaseWriter", func() {
 					result := writer.db.Find(&logEntry{})
 
 					result.Count(&res)
+
 					return res
 				}, "1s").Should(BeNumerically("==", 1))
 			})
@@ -91,6 +92,7 @@ var _ = Describe("DatabaseWriter", func() {
 					result := writer.db.Find(&logEntry{})
 
 					result.Count(&res)
+
 					return res
 				}, "1s").Should(BeNumerically("==", 2))
 
@@ -102,6 +104,7 @@ var _ = Describe("DatabaseWriter", func() {
 					result := writer.db.Find(&logEntry{})
 
 					result.Count(&res)
+
 					return res
 				}, "1s").Should(BeNumerically("==", 1))
 			})

--- a/querylog/file_writer.go
+++ b/querylog/file_writer.go
@@ -72,6 +72,8 @@ func (d *FileWriter) Write(entry *LogEntry) {
 
 // CleanUp deletes old log files
 func (d *FileWriter) CleanUp() {
+	const hoursPerDay = 24
+
 	logger := log.PrefixedLog(loggerPrefixFileWriter)
 
 	logger.Trace("starting clean up")
@@ -85,7 +87,7 @@ func (d *FileWriter) CleanUp() {
 		if strings.HasSuffix(f.Name(), ".log") && len(f.Name()) > 10 {
 			t, err := time.Parse("2006-01-02", f.Name()[:10])
 			if err == nil {
-				differenceDays := uint64(time.Since(t).Hours() / 24)
+				differenceDays := uint64(time.Since(t).Hours() / hoursPerDay)
 				if d.logRetentionDays > 0 && differenceDays > d.logRetentionDays {
 					logger.WithFields(logrus.Fields{
 						"file":             f.Name(),

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -164,7 +164,12 @@ func (c *Client) startup() error {
 				select {
 				// received message from subscription
 				case msg := <-ps.Channel():
-					err = c.processReceivedMessage(msg)
+					c.l.Debug("Received message: ", msg)
+
+					if msg != nil && len(msg.Payload) > 0 {
+						// message is not empty
+						err = c.processReceivedMessage(msg)
+					}
 					// publish message from buffer
 				case s := <-c.sendBuffer:
 					c.publishMessageFromBuffer(s)
@@ -201,34 +206,30 @@ func (c *Client) publishMessageFromBuffer(s *bufferMessage) {
 }
 
 func (c *Client) processReceivedMessage(msg *redis.Message) (err error) {
-	c.l.Debug("Received message: ", msg)
-	// message is not empty
-	if msg != nil && len(msg.Payload) > 0 {
-		var rm redisMessage
+	var rm redisMessage
 
-		err = json.Unmarshal([]byte(msg.Payload), &rm)
-		if err == nil {
-			// message was sent from a different blocky instance
-			if !bytes.Equal(rm.Client, c.id) {
-				switch rm.Type {
-				case messageTypeCache:
-					var cm *CacheMessage
+	err = json.Unmarshal([]byte(msg.Payload), &rm)
+	if err == nil {
+		// message was sent from a different blocky instance
+		if !bytes.Equal(rm.Client, c.id) {
+			switch rm.Type {
+			case messageTypeCache:
+				var cm *CacheMessage
 
-					cm, err = convertMessage(&rm, 0)
-					if err == nil {
-						c.CacheChannel <- cm
-					}
-				case messageTypeEnable:
-					err = c.processEnabledMessage(&rm)
-				default:
-					c.l.Warn("Unknown message type: ", rm.Type)
+				cm, err = convertMessage(&rm, 0)
+				if err == nil {
+					c.CacheChannel <- cm
 				}
+			case messageTypeEnable:
+				err = c.processEnabledMessage(&rm)
+			default:
+				c.l.Warn("Unknown message type: ", rm.Type)
 			}
 		}
+	}
 
-		if err != nil {
-			c.l.Error("Processing error: ", err)
-		}
+	if err != nil {
+		c.l.Error("Processing error: ", err)
 	}
 
 	return err

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -69,7 +69,7 @@ type Client struct {
 func New(cfg *config.RedisConfig) (*Client, error) {
 	// disable redis if no address is provided
 	if cfg == nil || len(cfg.Address) == 0 {
-		return nil, nil
+		return nil, nil // nolint:nilnil
 	}
 
 	rdb := redis.NewClient(&redis.Options{

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -364,7 +364,7 @@ func (r *BlockingResolver) hasWhiteListOnlyAllowed(groupsToCheck []string) bool 
 }
 
 func (r *BlockingResolver) handleBlacklist(groupsToCheck []string,
-	request *model.Request, logger *logrus.Entry) (*model.Response, error) {
+	request *model.Request, logger *logrus.Entry) (bool, *model.Response, error) {
 	logger.WithField("groupsToCheck", strings.Join(groupsToCheck, "; ")).Debug("checking groups for request")
 	whitelistOnlyAllowed := r.hasWhiteListOnlyAllowed(groupsToCheck)
 
@@ -374,19 +374,26 @@ func (r *BlockingResolver) handleBlacklist(groupsToCheck []string,
 
 		if whitelisted, group := r.matches(groupsToCheck, r.whitelistMatcher, domain); whitelisted {
 			logger.WithField("group", group).Debugf("domain is whitelisted")
-			return r.next.Resolve(request)
+
+			resp, err := r.next.Resolve(request)
+
+			return true, resp, err
 		}
 
 		if whitelistOnlyAllowed {
-			return r.handleBlocked(logger, request, question, "BLOCKED (WHITELIST ONLY)")
+			resp, err := r.handleBlocked(logger, request, question, "BLOCKED (WHITELIST ONLY)")
+
+			return true, resp, err
 		}
 
 		if blocked, group := r.matches(groupsToCheck, r.blacklistMatcher, domain); blocked {
-			return r.handleBlocked(logger, request, question, fmt.Sprintf("BLOCKED (%s)", group))
+			resp, err := r.handleBlocked(logger, request, question, fmt.Sprintf("BLOCKED (%s)", group))
+
+			return true, resp, err
 		}
 	}
 
-	return nil, nil
+	return false, nil, nil
 }
 
 // Resolve checks the query against the blacklist and delegates to next resolver if domain is not blocked
@@ -395,8 +402,8 @@ func (r *BlockingResolver) Resolve(request *model.Request) (*model.Response, err
 	groupsToCheck := r.groupsToCheckForClient(request)
 
 	if len(groupsToCheck) > 0 {
-		resp, err := r.handleBlacklist(groupsToCheck, request, logger)
-		if resp != nil || err != nil {
+		handled, resp, err := r.handleBlacklist(groupsToCheck, request, logger)
+		if handled {
 			return resp, err
 		}
 	}

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -550,6 +550,7 @@ func (b zeroIPBlockHandler) handleBlock(question dns.Question, response *dns.Msg
 		zeroIP = net.IPv4zero
 	default:
 		response.Rcode = dns.RcodeNameError
+
 		return
 	}
 
@@ -627,5 +628,6 @@ func (r *BlockingResolver) initFQDNIPCache() {
 
 func isFQDN(in string) bool {
 	s := strings.Trim(in, ".")
+
 	return strings.Contains(s, ".")
 }

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -25,6 +25,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const defaultBlockingCleanUpInterval = 5 * time.Second
+
 func createBlockHandler(cfg config.BlockingConfig) (blockHandler, error) {
 	cfgBlockType := cfg.BlockType
 
@@ -603,7 +605,7 @@ func (r *BlockingResolver) initFQDNIPCache() {
 		identifiers = append(identifiers, identifier)
 	}
 
-	r.fqdnIPCache = expirationcache.NewCache(expirationcache.WithCleanUpInterval(5*time.Second),
+	r.fqdnIPCache = expirationcache.NewCache(expirationcache.WithCleanUpInterval(defaultBlockingCleanUpInterval),
 		expirationcache.WithOnExpiredFn(func(key string) (val interface{}, ttl time.Duration) {
 			return r.queryForFQIdentifierIPs(key)
 		}))

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -130,8 +130,10 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				m.AnswerFn = func(t uint16, qName string) *dns.Msg {
 					if t == dns.TypeA && qName == "full.qualified.com." {
 						a, _ := util.NewMsgWithAnswer(qName, 60*60, dns.Type(dns.TypeA), "192.168.178.39")
+
 						return a
 					}
+
 					return nil
 				}
 				Bus().Publish(ApplicationStarted, "")

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -176,7 +176,7 @@ func (b *Bootstrap) NewHTTPTransport() *http.Transport {
 }
 
 func (b *Bootstrap) resolve(hostname string, qTypes []dns.Type) (ips []net.IP, err error) {
-	ips = make([]net.IP, 0, 2)
+	ips = make([]net.IP, 0, len(qTypes))
 
 	for _, qType := range qTypes {
 		qIPs, qErr := b.resolveType(hostname, qType)

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -141,6 +141,7 @@ func (b *Bootstrap) NewHTTPTransport() *http.Transport {
 			host, port, err := net.SplitHostPort(addr)
 			if err != nil {
 				log.Errorf("dial error: %s", err)
+
 				return nil, err
 			}
 
@@ -161,6 +162,7 @@ func (b *Bootstrap) NewHTTPTransport() *http.Transport {
 			ips, err := b.resolve(host, qTypes)
 			if err != nil {
 				log.Errorf("resolve error: %s", err)
+
 				return nil, err
 			}
 
@@ -170,6 +172,7 @@ func (b *Bootstrap) NewHTTPTransport() *http.Transport {
 
 			// Use the standard dialer to actually connect
 			addrWithIP := net.JoinHostPort(ip.String(), port)
+
 			return dialer.DialContext(ctx, network, addrWithIP)
 		},
 	}
@@ -182,6 +185,7 @@ func (b *Bootstrap) resolve(hostname string, qTypes []dns.Type) (ips []net.IP, e
 		qIPs, qErr := b.resolveType(hostname, qType)
 		if qErr != nil {
 			err = multierror.Append(err, qErr)
+
 			continue
 		}
 
@@ -235,6 +239,7 @@ type IPSet struct {
 
 func (ips *IPSet) Current() net.IP {
 	idx := atomic.LoadUint32(&ips.index)
+
 	return ips.values[idx]
 }
 

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -196,8 +196,7 @@ func (b *Bootstrap) resolve(hostname string, qTypes []dns.Type) (ips []net.IP, e
 }
 
 func (b *Bootstrap) resolveType(hostname string, qType dns.Type) (ips []net.IP, err error) {
-	ip := net.ParseIP(hostname)
-	if ip != nil {
+	if ip := net.ParseIP(hostname); ip != nil {
 		return []net.IP{ip}, nil
 	}
 

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -244,10 +244,10 @@ func (ips *IPSet) Current() net.IP {
 }
 
 func (ips *IPSet) Next() {
-	old := ips.index
-	new := uint32(int(ips.index+1) % len(ips.values))
+	oldIP := ips.index
+	newIP := uint32(int(ips.index+1) % len(ips.values))
 
 	// We don't care about the result: if the call fails,
 	// it means the value was incremented by another goroutine
-	_ = atomic.CompareAndSwapUint32(&ips.index, old, new)
+	_ = atomic.CompareAndSwapUint32(&ips.index, oldIP, newIP)
 }

--- a/resolver/bootstrap_test.go
+++ b/resolver/bootstrap_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 					PreferGo: true,
 					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 						usedSystemResolver <- true
+
 						return nil, errors.New("don't actually do anything")
 					},
 				}

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -17,6 +17,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const defaultCachingCleanUpInterval = 5 * time.Second
+
 // CachingResolver caches answers from dns queries with their TTL time,
 // to avoid external resolver calls for recurrent queries
 type CachingResolver struct {
@@ -58,7 +60,7 @@ func NewCachingResolver(cfg config.CachingConfig, redis *redis.Client) ChainedRe
 }
 
 func configureCaches(c *CachingResolver, cfg *config.CachingConfig) {
-	cleanupOption := expirationcache.WithCleanUpInterval(5 * time.Second)
+	cleanupOption := expirationcache.WithCleanUpInterval(defaultCachingCleanUpInterval)
 	maxSizeOption := expirationcache.WithMaxSize(uint(cfg.MaxItemsCount))
 
 	if cfg.Prefetching {

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -93,6 +93,7 @@ func setupRedisCacheSubscriber(c *CachingResolver) {
 // check if domain was queried > threshold in the time window
 func (r *CachingResolver) isPrefetchingDomain(cacheKey string) bool {
 	cnt, _ := r.prefetchingNameCache.Get(cacheKey)
+
 	return cnt != nil && cnt.(int) > r.prefetchThreshold
 }
 
@@ -110,6 +111,7 @@ func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.
 		if err == nil {
 			if response.Res.Rcode == dns.RcodeSuccess {
 				evt.Bus().Publish(evt.CachingDomainPrefetched, domainName)
+
 				return cacheValue{response.Res.Answer, true}, time.Duration(r.adjustTTLs(response.Res.Answer)) * time.Second
 			}
 		} else {
@@ -124,6 +126,7 @@ func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.
 func (r *CachingResolver) Configuration() (result []string) {
 	if r.maxCacheTimeSec < 0 {
 		result = []string{"deactivated"}
+
 		return
 	}
 
@@ -154,6 +157,7 @@ func (r *CachingResolver) Resolve(request *model.Request) (response *model.Respo
 
 	if r.maxCacheTimeSec < 0 {
 		logger.Debug("skip cache")
+
 		return r.next.Resolve(request)
 	}
 

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -151,7 +151,6 @@ func (r *CachingResolver) Configuration() (result []string) {
 
 // Resolve checks if the current query result is already in the cache and returns it
 // or delegates to the next resolver
-//nolint:gocognit,funlen
 func (r *CachingResolver) Resolve(request *model.Request) (response *model.Response, err error) {
 	logger := withPrefix(request.Log, "caching_resolver")
 

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -547,6 +547,7 @@ var _ = Describe("CachingResolver", func() {
 
 				Eventually(func() error {
 					resp, err = sut.Resolve(request)
+
 					return err
 				}, "50ms").Should(Succeed())
 			})

--- a/resolver/client_names_resolver.go
+++ b/resolver/client_names_resolver.go
@@ -142,6 +142,7 @@ func (r *ClientNamesResolver) resolveClientNames(ip net.IP, logger *logrus.Entry
 
 	if err != nil {
 		logger.Error("can't resolve client name: ", err)
+
 		return []string{ip.String()}
 	}
 
@@ -152,6 +153,7 @@ func (r *ClientNamesResolver) resolveClientNames(ip net.IP, logger *logrus.Entry
 		for _, i := range r.singleNameOrder {
 			if i > 0 && int(i) <= len(clientNames) {
 				result = []string{clientNames[i-1]}
+
 				break
 			}
 		}

--- a/resolver/client_names_resolver.go
+++ b/resolver/client_names_resolver.go
@@ -105,6 +105,21 @@ func (r *ClientNamesResolver) getClientNames(request *model.Request) []string {
 	return names
 }
 
+func extractClientNamesFromAnswer(answer []dns.RR, fallbackIP net.IP) (clientNames []string) {
+	for _, answer := range answer {
+		if t, ok := answer.(*dns.PTR); ok {
+			hostName := strings.TrimSuffix(t.Ptr, ".")
+			clientNames = append(clientNames, hostName)
+		}
+	}
+
+	if len(clientNames) == 0 {
+		clientNames = []string{fallbackIP.String()}
+	}
+
+	return
+}
+
 // tries to resolve client name from mapping, performs reverse DNS lookup otherwise
 func (r *ClientNamesResolver) resolveClientNames(ip net.IP, logger *logrus.Entry) (result []string) {
 	// try client mapping first
@@ -114,48 +129,37 @@ func (r *ClientNamesResolver) resolveClientNames(ip net.IP, logger *logrus.Entry
 		return
 	}
 
-	if r.externalResolver != nil {
-		reverse, _ := dns.ReverseAddr(ip.String())
-
-		resp, err := r.externalResolver.Resolve(&model.Request{
-			Req: util.NewMsgWithQuestion(reverse, dns.Type(dns.TypePTR)),
-			Log: logger,
-		})
-
-		if err != nil {
-			logger.Error("can't resolve client name: ", err)
-			return []string{ip.String()}
-		}
-
-		var clientNames []string
-
-		for _, answer := range resp.Res.Answer {
-			if t, ok := answer.(*dns.PTR); ok {
-				hostName := strings.TrimSuffix(t.Ptr, ".")
-				clientNames = append(clientNames, hostName)
-			}
-		}
-
-		if len(clientNames) == 0 {
-			clientNames = []string{ip.String()}
-		}
-
-		// optional: if singleNameOrder is set, use only one name in the defined order
-		if len(r.singleNameOrder) > 0 {
-			for _, i := range r.singleNameOrder {
-				if i > 0 && int(i) <= len(clientNames) {
-					result = []string{clientNames[i-1]}
-					break
-				}
-			}
-		} else {
-			result = clientNames
-		}
-
-		logger.WithField("client_names", strings.Join(result, "; ")).Debug("resolved client name(s) from external resolver")
-	} else {
-		result = []string{ip.String()}
+	if r.externalResolver == nil {
+		return []string{ip.String()}
 	}
+
+	reverse, _ := dns.ReverseAddr(ip.String())
+
+	resp, err := r.externalResolver.Resolve(&model.Request{
+		Req: util.NewMsgWithQuestion(reverse, dns.Type(dns.TypePTR)),
+		Log: logger,
+	})
+
+	if err != nil {
+		logger.Error("can't resolve client name: ", err)
+		return []string{ip.String()}
+	}
+
+	clientNames := extractClientNamesFromAnswer(resp.Res.Answer, ip)
+
+	// optional: if singleNameOrder is set, use only one name in the defined order
+	if len(r.singleNameOrder) > 0 {
+		for _, i := range r.singleNameOrder {
+			if i > 0 && int(i) <= len(clientNames) {
+				result = []string{clientNames[i-1]}
+				break
+			}
+		}
+	} else {
+		result = clientNames
+	}
+
+	logger.WithField("client_names", strings.Join(result, "; ")).Debug("resolved client name(s) from external resolver")
 
 	return result
 }

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -51,31 +51,38 @@ func (r *ConditionalUpstreamResolver) Configuration() (result []string) {
 	return
 }
 
+func (r *ConditionalUpstreamResolver) processRequest(request *model.Request) (*model.Response, error) {
+	domainFromQuestion := util.ExtractDomain(request.Req.Question[0])
+	domain := domainFromQuestion
+
+	if strings.Contains(domainFromQuestion, ".") {
+		// try with domain with and without sub-domains
+		for len(domain) > 0 {
+			if resolver, found := r.mapping[domain]; found {
+				return r.internalResolve(resolver, domainFromQuestion, domain, request)
+			}
+
+			if i := strings.Index(domain, "."); i >= 0 {
+				domain = domain[i+1:]
+			} else {
+				break
+			}
+		}
+	} else if resolver, found := r.mapping["."]; found {
+		return r.internalResolve(resolver, domainFromQuestion, domain, request)
+	}
+
+	return nil, nil
+}
+
 // Resolve uses the conditional resolver to resolve the query
 func (r *ConditionalUpstreamResolver) Resolve(request *model.Request) (*model.Response, error) {
 	logger := withPrefix(request.Log, "conditional_resolver")
 
 	if len(r.mapping) > 0 {
-		domainFromQuestion := util.ExtractDomain(request.Req.Question[0])
-		domain := domainFromQuestion
-
-		if !strings.Contains(domainFromQuestion, ".") {
-			if resolver, found := r.mapping["."]; found {
-				return r.internalResolve(resolver, domainFromQuestion, domain, request)
-			}
-		} else {
-			// try with domain with and without sub-domains
-			for len(domain) > 0 {
-				if resolver, found := r.mapping[domain]; found {
-					return r.internalResolve(resolver, domainFromQuestion, domain, request)
-				}
-
-				if i := strings.Index(domain, "."); i >= 0 {
-					domain = domain[i+1:]
-				} else {
-					break
-				}
-			}
+		resp, err := r.processRequest(request)
+		if resp != nil || err != nil {
+			return resp, err
 		}
 	}
 

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -60,6 +60,7 @@ func (r *ConditionalUpstreamResolver) processRequest(request *model.Request) (bo
 		for len(domain) > 0 {
 			if resolver, found := r.mapping[domain]; found {
 				resp, err := r.internalResolve(resolver, domainFromQuestion, domain, request)
+
 				return true, resp, err
 			}
 
@@ -71,6 +72,7 @@ func (r *ConditionalUpstreamResolver) processRequest(request *model.Request) (bo
 		}
 	} else if resolver, found := r.mapping["."]; found {
 		resp, err := r.internalResolve(resolver, domainFromQuestion, domain, request)
+
 		return true, resp, err
 	}
 

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -127,9 +127,7 @@ func NewHostsFileResolver(cfg config.HostsFileConfig) ChainedResolver {
 		refreshPeriod: time.Duration(cfg.RefreshPeriod),
 	}
 
-	err := r.parseHostsFile()
-
-	if err != nil {
+	if err := r.parseHostsFile(); err != nil {
 		logger := logger(hostsFileResolverLogger)
 		logger.Warnf("cannot parse hosts file: %s, hosts file resolving is disabled", r.HostsFilePath)
 		r.HostsFilePath = ""

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -147,6 +147,8 @@ type host struct {
 }
 
 func (r *HostsFileResolver) parseHostsFile() error {
+	const minColumnCount = 2
+
 	if r.HostsFilePath == "" {
 		return nil
 	}
@@ -177,7 +179,7 @@ func (r *HostsFileResolver) parseHostsFile() error {
 			fields = strings.Fields(trimmed[:end])
 		}
 
-		if len(fields) < 2 {
+		if len(fields) < minColumnCount {
 			// Skip invalid entry
 			continue
 		}
@@ -191,7 +193,7 @@ func (r *HostsFileResolver) parseHostsFile() error {
 		h.IP = net.ParseIP(fields[0])
 		h.Hostname = fields[1]
 
-		if len(fields) > 2 {
+		if len(fields) > minColumnCount {
 			for i := 2; i < len(fields); i++ {
 				h.Aliases = append(h.Aliases, fields[i])
 			}

--- a/resolver/mocks.go
+++ b/resolver/mocks.go
@@ -28,6 +28,7 @@ type MockResolver struct {
 
 func (r *MockResolver) Configuration() []string {
 	args := r.Called()
+
 	return args.Get(0).([]string)
 }
 
@@ -181,6 +182,7 @@ func (t *MockUDPUpstreamServer) WithAnswerError(errorCode int) *MockUDPUpstreamS
 
 func (t *MockUDPUpstreamServer) WithAnswerFn(fn func(request *dns.Msg) (response *dns.Msg)) *MockUDPUpstreamServer {
 	t.answerFn = fn
+
 	return t
 }
 
@@ -239,6 +241,7 @@ func (t *MockUDPUpstreamServer) Start() config.Upstream {
 			// nil should indicate an error
 			if response == nil {
 				_, _ = ln.WriteToUDP([]byte("dummy"), addr)
+
 				continue
 			}
 

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -134,6 +134,7 @@ func (r *ParallelBestResolver) Resolve(request *model.Request) (*model.Response,
 
 	if len(resolvers) == 1 {
 		logger.WithField("resolver", resolvers[0].resolver).Debug("delegating to resolver")
+
 		return resolvers[0].resolver.Resolve(request)
 	}
 
@@ -164,6 +165,7 @@ func (r *ParallelBestResolver) Resolve(request *model.Request) (*model.Response,
 					"resolver": r1.resolver,
 					"answer":   util.AnswerToString(result.response.Res.Answer),
 				}).Debug("using response from resolver")
+
 				return result.response, nil
 			}
 		}

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -43,6 +43,7 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 						time.Sleep(50 * time.Millisecond)
 
 						Expect(err).Should(Succeed())
+
 						return response
 					})
 					DeferCleanup(slowTestUpstream.Close)
@@ -71,6 +72,7 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 						time.Sleep(50 * time.Millisecond)
 
 						Expect(err).Should(Succeed())
+
 						return response
 					})
 					DeferCleanup(slowTestUpstream.Close)

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -14,6 +14,7 @@ const (
 	cleanUpRunPeriod           = 12 * time.Hour
 	queryLoggingResolverPrefix = "query_logging_resolver"
 	logChanCap                 = 1000
+	defaultFlushPeriod         = 30 * time.Second
 )
 
 // QueryLoggingResolver writes query information (question, answer, duration, ...)
@@ -40,9 +41,9 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 			case config.QueryLogTypeCsvClient:
 				writer, err = querylog.NewCSVWriter(cfg.Target, true, cfg.LogRetentionDays)
 			case config.QueryLogTypeMysql:
-				writer, err = querylog.NewDatabaseWriter("mysql", cfg.Target, cfg.LogRetentionDays, 30*time.Second)
+				writer, err = querylog.NewDatabaseWriter("mysql", cfg.Target, cfg.LogRetentionDays, defaultFlushPeriod)
 			case config.QueryLogTypePostgresql:
-				writer, err = querylog.NewDatabaseWriter("postgresql", cfg.Target, cfg.LogRetentionDays, 30*time.Second)
+				writer, err = querylog.NewDatabaseWriter("postgresql", cfg.Target, cfg.LogRetentionDays, defaultFlushPeriod)
 			case config.QueryLogTypeConsole:
 				writer = querylog.NewLoggerWriter()
 			case config.QueryLogTypeNone:
@@ -130,7 +131,7 @@ func (r *QueryLoggingResolver) writeLog() {
 
 		r.writer.Write(logEntry)
 
-		halfCap := cap(r.logChan) / 2
+		halfCap := cap(r.logChan) / 2 // nolint:gomnd
 
 		// if log channel is > 50% full, this could be a problem with slow writer (external storage over network etc.)
 		if len(r.logChan) > halfCap {

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -49,6 +49,7 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 			case config.QueryLogTypeNone:
 				writer = querylog.NewNoneWriter()
 			}
+
 			return err
 		},
 		retry.Attempts(uint(cfg.CreationAttempts)),

--- a/resolver/rewriter_resolver.go
+++ b/resolver/rewriter_resolver.go
@@ -80,6 +80,7 @@ func (r *RewriterResolver) Resolve(request *model.Request) (*model.Response, err
 	if response == NoResponse {
 		// Inner resolver had no response, continue with the normal chain
 		logger.WithField("next_resolver", Name(r.next)).Trace("go to next resolver")
+
 		return r.next.Resolve(request)
 	}
 
@@ -128,6 +129,7 @@ func (r *RewriterResolver) rewriteDomain(domain string) (string, string) {
 	for k, v := range r.rewrite {
 		if strings.HasSuffix(domain, "."+k) {
 			newDomain := strings.TrimSuffix(domain, "."+k) + "." + v
+
 			return newDomain, k
 		}
 	}

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -122,6 +122,7 @@ var _ = Describe("RewriterResolver", func() {
 			mNext.On("Resolve", mock.Anything)
 			mNext.ResolveFn = func(req *model.Request) (*model.Response, error) {
 				Expect(req.Req.Question[0].Name).Should(Equal(fqdnOriginal))
+
 				return mNextResponse, nil
 			}
 		})

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	dnsContentType = "application/dns-message"
+	dnsContentType             = "application/dns-message"
+	defaultTLSHandshakeTimeout = 5 * time.Second
 )
 
 // nolint:gochecknoglobals
@@ -66,7 +67,7 @@ func createUpstreamClient(cfg config.Upstream) upstreamClient {
 			client: &http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig:     &tlsConfig,
-					TLSHandshakeTimeout: 5 * time.Second,
+					TLSHandshakeTimeout: defaultTLSHandshakeTimeout,
 				},
 				Timeout: timeout,
 			},

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -247,6 +247,7 @@ func (r *UpstreamResolver) Resolve(request *model.Request) (response *model.Resp
 					"response_time_ms": rtt.Milliseconds(),
 				}).Debugf("received response from upstream")
 			}
+
 			return err
 		},
 		retry.Attempts(retryAttempts),

--- a/resolver/upstream_resolver_test.go
+++ b/resolver/upstream_resolver_test.go
@@ -131,6 +131,7 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 				response, err := util.NewMsgWithAnswer("example.com", 123, dns.Type(dns.TypeA), "123.124.122.122")
 
 				Expect(err).Should(Succeed())
+
 				return response
 			}
 		})

--- a/server/server.go
+++ b/server/server.go
@@ -25,6 +25,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	maxUDPBufferSize = 65535
+)
+
 // Server controls the endpoints for DNS and HTTP
 type Server struct {
 	dnsServers     []*dns.Server
@@ -213,7 +217,7 @@ func createUDPServer(address string) (*dns.Server, error) {
 		NotifyStartedFunc: func() {
 			logger().Infof("UDP server is up and running on address %s", address)
 		},
-		UDPSize: 65535,
+		UDPSize: maxUDPBufferSize,
 	}, nil
 }
 
@@ -304,7 +308,8 @@ func (s *Server) printConfiguration() {
 }
 
 func toMB(b uint64) uint64 {
-	return b / 1024 / 1024
+	const bytesInKB = 1024
+	return b / bytesInKB / bytesInKB
 }
 
 // Start starts the server

--- a/server/server.go
+++ b/server/server.go
@@ -309,6 +309,7 @@ func (s *Server) printConfiguration() {
 
 func toMB(b uint64) uint64 {
 	const bytesInKB = 1024
+
 	return b / bytesInKB / bytesInKB
 }
 

--- a/server/server_endpoints.go
+++ b/server/server_endpoints.go
@@ -111,6 +111,7 @@ func (s *Server) processDohMessage(rawMsg []byte, rw http.ResponseWriter, req *h
 
 	if err != nil {
 		logAndResponseWithError(err, "unable to process query: ", rw)
+
 		return
 	}
 
@@ -122,6 +123,7 @@ func (s *Server) processDohMessage(rawMsg []byte, rw http.ResponseWriter, req *h
 	b, err := resResponse.Res.Pack()
 	if err != nil {
 		logAndResponseWithError(err, "can't serialize message: ", rw)
+
 		return
 	}
 
@@ -165,6 +167,7 @@ func (s *Server) apiQuery(rw http.ResponseWriter, req *http.Request) {
 
 	if err != nil {
 		logAndResponseWithError(err, "can't read request: ", rw)
+
 		return
 	}
 
@@ -191,6 +194,7 @@ func (s *Server) apiQuery(rw http.ResponseWriter, req *http.Request) {
 
 	if err != nil {
 		logAndResponseWithError(err, "unable to process query: ", rw)
+
 		return
 	}
 
@@ -203,6 +207,7 @@ func (s *Server) apiQuery(rw http.ResponseWriter, req *http.Request) {
 
 	if err != nil {
 		logAndResponseWithError(err, "unable to marshal response: ", rw)
+
 		return
 	}
 

--- a/server/server_endpoints.go
+++ b/server/server_endpoints.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/0xERR0R/blocky/api"
 	"github.com/0xERR0R/blocky/config"
@@ -26,6 +27,7 @@ import (
 const (
 	dohMessageLimit = 512
 	dnsContentType  = "application/dns-message"
+	corsMaxAge      = 5 * time.Minute
 )
 
 func (s *Server) registerAPIEndpoints(router *chi.Mux) {
@@ -289,7 +291,7 @@ func configureCorsHandler(router *chi.Mux) {
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: true,
-		MaxAge:           300,
+		MaxAge:           int(corsMaxAge.Seconds()),
 	})
 	router.Use(crs.Handler)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -561,10 +561,9 @@ var _ = Describe("Running DNS server", func() {
 				Expect(err).Should(Succeed())
 
 				errChan := make(chan error, 10)
+
 				// start server
-				go func() {
-					server.Start(errChan)
-				}()
+				go server.Start(errChan)
 
 				DeferCleanup(server.Stop)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,6 +44,7 @@ var _ = BeforeSuite(func() {
 		)
 
 		Expect(err).Should(Succeed())
+
 		return response
 	})
 	DeferCleanup(googleMockUpstream.Close)
@@ -54,6 +55,7 @@ var _ = BeforeSuite(func() {
 		)
 
 		Expect(err).Should(Succeed())
+
 		return response
 	})
 	DeferCleanup(fritzboxMockUpstream.Close)
@@ -64,6 +66,7 @@ var _ = BeforeSuite(func() {
 		)
 
 		Expect(err).Should(Succeed())
+
 		return response
 	})
 	DeferCleanup(clientMockUpstream.Close)
@@ -153,6 +156,7 @@ var _ = Describe("Running DNS server", func() {
 			for res != nil {
 				if t, ok := res.(*resolver.ClientNamesResolver); ok {
 					t.FlushCache()
+
 					break
 				}
 				if c, ok := res.(resolver.ChainedResolver); ok {

--- a/util/common.go
+++ b/util/common.go
@@ -193,7 +193,8 @@ func Chunks(s string, chunkSize int) []string {
 
 // GenerateCacheKey return cacheKey by query type/domain
 func GenerateCacheKey(qType dns.Type, qName string) string {
-	b := make([]byte, 2+len(qName))
+	const qTypeLength = 2
+	b := make([]byte, qTypeLength+len(qName))
 
 	binary.BigEndian.PutUint16(b, uint16(qType))
 	copy(b[2:], strings.ToLower(qName))

--- a/util/common.go
+++ b/util/common.go
@@ -225,5 +225,6 @@ func CidrContainsIP(cidr string, ip net.IP) bool {
 // ClientNameMatchesGroupName checks if a group with optional wildcards contains a client name
 func ClientNameMatchesGroupName(group string, clientName string) bool {
 	match, _ := filepath.Match(group, clientName)
+
 	return match
 }


### PR DESCRIPTION
Updated golangci-lint to the latest version. Enabled additional linters:

- wastedassign
- tenv
- sqlclosecheck
- predeclared
- nolintlint
- nlreturn
- nilnil
- nilerr
- nestif
- makezero
- importas
- grouper 
- ifshort
- grouper
- gomodguard
- gomoddirectives
- exhaustive
- errorlint
- errchkjson
- durationcheck
- bidichk
- asciicheck
- gomnd






























































