### PR TITLE
Cache refresh memory consumption optimization (#470)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -474,16 +474,17 @@ type ConditionalUpstreamMapping struct {
 
 // BlockingConfig configuration for query blocking
 type BlockingConfig struct {
-	BlackLists           map[string][]string `yaml:"blackLists"`
-	WhiteLists           map[string][]string `yaml:"whiteLists"`
-	ClientGroupsBlock    map[string][]string `yaml:"clientGroupsBlock"`
-	BlockType            string              `yaml:"blockType" default:"ZEROIP"`
-	BlockTTL             Duration            `yaml:"blockTTL" default:"6h"`
-	DownloadTimeout      Duration            `yaml:"downloadTimeout" default:"60s"`
-	DownloadAttempts     uint                `yaml:"downloadAttempts" default:"3"`
-	DownloadCooldown     Duration            `yaml:"downloadCooldown" default:"1s"`
-	RefreshPeriod        Duration            `yaml:"refreshPeriod" default:"4h"`
-	FailStartOnListError bool                `yaml:"failStartOnListError" default:"false"`
+	BlackLists            map[string][]string `yaml:"blackLists"`
+	WhiteLists            map[string][]string `yaml:"whiteLists"`
+	ClientGroupsBlock     map[string][]string `yaml:"clientGroupsBlock"`
+	BlockType             string              `yaml:"blockType" default:"ZEROIP"`
+	BlockTTL              Duration            `yaml:"blockTTL" default:"6h"`
+	DownloadTimeout       Duration            `yaml:"downloadTimeout" default:"60s"`
+	DownloadAttempts      uint                `yaml:"downloadAttempts" default:"3"`
+	DownloadCooldown      Duration            `yaml:"downloadCooldown" default:"1s"`
+	RefreshPeriod         Duration            `yaml:"refreshPeriod" default:"4h"`
+	FailStartOnListError  bool                `yaml:"failStartOnListError" default:"false"`
+	ProcessingConcurrency uint                `yaml:"processingConcurrency" default:"4"`
 }
 
 // ClientLookupConfig configuration for the client lookup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -446,6 +446,19 @@ downloaded or opened. Default value is `false`.
       failStartOnListError: false
     ```
 
+### Concurrency
+
+Blocky downloads and processes links in a single group concurrently. With parameter `processingConcurrency` you can adjust
+how many links can be processed in the same time. Higher value can reduce the overall list refresh time, but more parallel
+ download and processing jobs need more RAM. Please consider to reduce this value on systems with limited memory. Default value is 4.
+
+    !!! example
+
+    ```yaml
+    blocking:
+      processingConcurrency: 10
+    ```
+
 ## Caching
 
 Each DNS response has a TTL (Time-to-live) value. This value defines, how long is the record valid in seconds. The

--- a/lists/list_cache_benchmark_test.go
+++ b/lists/list_cache_benchmark_test.go
@@ -1,0 +1,22 @@
+package lists
+
+import (
+	"testing"
+)
+
+func BenchmarkRefresh(b *testing.B) {
+	file1 := createTestListFile(b.TempDir(), 100000)
+	file2 := createTestListFile(b.TempDir(), 150000)
+	file3 := createTestListFile(b.TempDir(), 130000)
+	lists := map[string][]string{
+		"gr1": {file1, file2, file3},
+	}
+
+	cache, _ := NewListCache(ListCacheTypeBlacklist, lists, -1, NewDownloader(), 5)
+
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		cache.Refresh()
+	}
+}


### PR DESCRIPTION
- introduced new config parameter 'processingConcurrency' to limit working goroutines for cache refresh (Default value 4)
- rewrite cache refresh logic: collect lines from list files immediately and don't collect all lines in memory in a slice

closes #470