### PR TITLE
Enable "ForceAttemptHTTP2" for DoH upstreamClient

### DIFF
--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -68,6 +68,7 @@ func createUpstreamClient(cfg config.Upstream) upstreamClient {
 				Transport: &http.Transport{
 					TLSClientConfig:     &tlsConfig,
 					TLSHandshakeTimeout: defaultTLSHandshakeTimeout,
+					ForceAttemptHTTP2:   true,
 				},
 				Timeout: timeout,
 			},


### PR DESCRIPTION
According to https://pkg.go.dev/net/http#Transport, when `TLSClientConfig` is provided, HTTP/2 will be disabled. Setting this option to `true`, when using custom TLS config, will still attempt HTTP/2 upgrades.

The DoH request access log fetched from nginx to verify the change:

Before the patch:
```
192.168.10.1 - - [13/May/2022:23:34:44 +0800] "POST /dns-query HTTP/1.1" 200 76 "-" "Go-http-client/1.1"
```

After the patch:
```
192.168.10.1 - - [13/May/2022:23:59:47 +0800] "POST /dns-query HTTP/2.0" 200 76 "-" "Go-http-client/2.0"
```