### PR TITLE
Improve DoT server TLS cipher suites

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -190,6 +190,14 @@ func createTLSServer(address string, certFile string, keyFile string) (*dns.Serv
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cer},
 			MinVersion:   tls.VersionTLS12,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			},
 		},
 		Handler: dns.NewServeMux(),
 		NotifyStartedFunc: func() {


### PR DESCRIPTION
This removes some VULNERABLE, or potentially VULNERABLE ciphers, like Triple DES and Obsoleted CBC ciphers, for the DoT server.

For the cipher suggestions, we can refer to Mozilla SSL Configuration Generator:
- https://ssl-config.mozilla.org/#server=go 