### PR TITLE
Implements minimum TLSv1.2 for DoH

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -355,7 +355,21 @@ func (s *Server) Start(errCh chan<- error) {
 		go func() {
 			logger().Infof("https server is up and running on addr/port %s", address)
 
-			if err := http.ServeTLS(listener, s.httpMux, s.cfg.CertFile, s.cfg.KeyFile); err != nil {
+			httpServer := &http.Server{
+				TLSConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+					CipherSuites: []uint16{
+						tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+						tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+						tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+						tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+					},
+				},
+			}
+
+			if err := httpServer.ServeTLS(listener, s.cfg.CertFile, s.cfg.KeyFile); err != nil {
 				errCh <- fmt.Errorf("start https listener failed: %w", err)
 			}
 		}()

--- a/server/server.go
+++ b/server/server.go
@@ -356,6 +356,7 @@ func (s *Server) Start(errCh chan<- error) {
 			logger().Infof("https server is up and running on addr/port %s", address)
 
 			httpServer := &http.Server{
+				Handler: s.httpMux,
 				TLSConfig: &tls.Config{
 					MinVersion: tls.VersionTLS12,
 					CipherSuites: []uint16{


### PR DESCRIPTION
This fixes #517 and sets minimum TLS version for DoH to 1.2.

Test with [testssl.sh](https://github.com/drwetter/testssl.sh):

```
 Testing protocols via sockets except NPN+ALPN

 SSLv2      not offered (OK)
 SSLv3      not offered (OK)
 TLS 1      not offered
 TLS 1.1    not offered
 TLS 1.2    offered (OK)
 TLS 1.3    offered (OK): final
 NPN/SPDY   not offered
 ALPN/HTTP2 h2, http/1.1 (offered)
 ```