### PR TITLE
Adds user customizable DoH upstream user agent

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -417,6 +417,7 @@ type Config struct {
 	HTTPPorts       ListenConfig              `yaml:"httpPort"`
 	HTTPSPorts      ListenConfig              `yaml:"httpsPort"`
 	TLSPorts        ListenConfig              `yaml:"tlsPort"`
+	DoHUserAgent    string                    `yaml:"dohUserAgent" default:"blocky"`
 	// Deprecated
 	DisableIPv6  bool            `yaml:"disableIPv6" default:"false"`
 	CertFile     string          `yaml:"certFile"`

--- a/config/config.go
+++ b/config/config.go
@@ -417,7 +417,7 @@ type Config struct {
 	HTTPPorts       ListenConfig              `yaml:"httpPort"`
 	HTTPSPorts      ListenConfig              `yaml:"httpsPort"`
 	TLSPorts        ListenConfig              `yaml:"tlsPort"`
-	DoHUserAgent    string                    `yaml:"dohUserAgent" default:"blocky"`
+	DoHUserAgent    string                    `yaml:"dohUserAgent"`
 	// Deprecated
 	DisableIPv6  bool            `yaml:"disableIPv6" default:"false"`
 	CertFile     string          `yaml:"certFile"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -50,6 +50,8 @@ var _ = Describe("Config", func() {
 				Expect(config.Caching.MaxCachingTime).Should(Equal(Duration(0)))
 				Expect(config.Caching.MinCachingTime).Should(Equal(Duration(0)))
 
+				Expect(config.DoHUserAgent).Should(Equal("testBlocky"))
+
 				Expect(GetConfig()).Should(Not(BeNil()))
 
 			})

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ configuration properties as [JSON](config.yml).
 | logFormat    | enum (text, json)               | no                    | text          | Log format (text or json).                                                                                                                                                                                                                        |
 | logTimestamp | bool                            | no                    | true          | Log time stamps (true or false).                                                                                                                                                                                                                  |
 | logPrivacy   | bool                            | no                    | false         | Obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy.                                                                                                 |
-| dohUserAgent | string                          | no                    | blocky        | HTTP User Agent for DoH upstreams                                                                                                  |
+| dohUserAgent | string                          | no                    |               | HTTP User Agent for DoH upstreams                                                                                                  |
 
 !!! example
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,8 @@ configuration properties as [JSON](config.yml).
 | logLevel     | enum (debug, info, warn, error) | no                    | info          | Log level                                                                                                                                                                                                                                         |
 | logFormat    | enum (text, json)               | no                    | text          | Log format (text or json).                                                                                                                                                                                                                        |
 | logTimestamp | bool                            | no                    | true          | Log time stamps (true or false).                                                                                                                                                                                                                  |
-| logPrivacy   | bool                            | no                    | false         | Obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy.                                                                                                  |
+| logPrivacy   | bool                            | no                    | false         | Obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy.                                                                                                 |
+| dohUserAgent | string                          | no                    | blocky        | HTTP User Agent for DoH upstreams                                                                                                  |
 
 !!! example
 

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -125,7 +125,7 @@ func (r *httpUpstreamClient) callExternal(msg *dns.Msg,
 		return nil, 0, fmt.Errorf("can't create the new request %w", err)
 	}
 
-	req.Header.Set("User-Agent", "")
+	req.Header.Set("User-Agent", config.GetConfig().DoHUserAgent)
 	req.Header.Set("Content-Type", dnsContentType)
 	httpResponse, err := r.client.Do(req)
 

--- a/testdata/config.yml
+++ b/testdata/config.yml
@@ -50,3 +50,4 @@ queryLog:
 
 port: 55553,:55554,[::1]:55555
 logLevel: debug
+dohUserAgent: testBlocky


### PR DESCRIPTION
Adds a new top-level configuration option `dohUserAgent`, as discussed in #518 and #446.