### PR TITLE
Remove net.Error.Temporary

### DIFF
--- a/lists/downloader.go
+++ b/lists/downloader.go
@@ -115,7 +115,7 @@ func (d *HTTPDownloader) DownloadFile(link string) (io.ReadCloser, error) {
 				return fmt.Errorf("got status code %d", resp.StatusCode)
 			}
 			var netErr net.Error
-			if errors.As(httpErr, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
+			if errors.As(httpErr, &netErr) && netErr.Timeout() {
 				return &TransientError{inner: netErr}
 			}
 

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -266,7 +266,7 @@ func (r *UpstreamResolver) Resolve(request *model.Request) (response *model.Resp
 		retry.RetryIf(func(err error) bool {
 			var netErr net.Error
 
-			return errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary())
+			return errors.As(err, &netErr) && netErr.Timeout()
 		}),
 		retry.OnRetry(func(n uint, err error) {
 			logger.WithFields(logrus.Fields{


### PR DESCRIPTION
This fixes #533 to remove functionality, deprecated in Go 1.18.