### PR TITLE
Update to Go 1.18

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,5 +16,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.46.2
           args: --timeout 5m0s

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
 
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.17-alpine AS build-env
+FROM golang:1.18-alpine AS build-env
 RUN apk add --no-cache \
     git \
     make \
@@ -23,7 +23,7 @@ ARG opts
 RUN env ${opts} make build
 
 # final stage
-FROM alpine:3.15
+FROM alpine:3.16
 
 LABEL org.opencontainers.image.source="https://github.com/0xERR0R/blocky" \
       org.opencontainers.image.url="https://github.com/0xERR0R/blocky" \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ race: ## run tests with race detector
 	go test -race -short ./...
 
 lint: build ## run golangcli-lint checks
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 	$(shell go env GOPATH)/bin/golangci-lint run
 
 run: build ## Build and run binary

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xERR0R/blocky
 
-go 1.17
+go 1.18
 
 require (
 	github.com/alicebob/miniredis/v2 v2.21.0

--- a/lists/list_cache_test.go
+++ b/lists/list_cache_test.go
@@ -79,13 +79,13 @@ var _ = Describe("ListCache", func() {
 				// should produce a transient error on second and third attempt
 				data := make(chan func() (io.ReadCloser, error), 3)
 				mockDownloader := &MockDownloader{data: data}
-				data <- func() (io.ReadCloser, error) { //nolint:unparam
+				data <- func() (io.ReadCloser, error) {
 					return io.NopCloser(strings.NewReader("blocked1.com")), nil
 				}
-				data <- func() (io.ReadCloser, error) { //nolint:unparam
+				data <- func() (io.ReadCloser, error) {
 					return nil, &TransientError{inner: errors.New("boom")}
 				}
-				data <- func() (io.ReadCloser, error) { //nolint:unparam
+				data <- func() (io.ReadCloser, error) {
 					return nil, &TransientError{inner: errors.New("boom")}
 				}
 				lists := map[string][]string{
@@ -131,7 +131,7 @@ var _ = Describe("ListCache", func() {
 				// should produce a 404 err on second attempt
 				data := make(chan func() (io.ReadCloser, error), 2)
 				mockDownloader := &MockDownloader{data: data}
-				data <- func() (io.ReadCloser, error) { //nolint:unparam
+				data <- func() (io.ReadCloser, error) {
 					return io.NopCloser(strings.NewReader("blocked1.com")), nil
 				}
 				data <- func() (io.ReadCloser, error) {


### PR DESCRIPTION
Updated things to Go 1.18. Also upgraded the Alpine Linux version in Dockerfile, as 3.16 [has been released recently](https://alpinelinux.org/posts/Alpine-3.16.0-released.html).

Lint action fails, but this has been addressed in #536, so should be fine once it's merged.