### PR TITLE
 Make DoH/DoT server mininum TLS version configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -418,6 +418,7 @@ type Config struct {
 	HTTPSPorts      ListenConfig              `yaml:"httpsPort"`
 	TLSPorts        ListenConfig              `yaml:"tlsPort"`
 	DoHUserAgent    string                    `yaml:"dohUserAgent"`
+	MinTLSServeVer  string                    `yaml:"minTlsServeVersion" default:"1.2"`
 	// Deprecated
 	DisableIPv6  bool            `yaml:"disableIPv6" default:"false"`
 	CertFile     string          `yaml:"certFile"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -577,6 +577,7 @@ func defaultTestFileConfig() {
 	Expect(config.Caching.MinCachingTime).Should(Equal(Duration(0)))
 
 	Expect(config.DoHUserAgent).Should(Equal("testBlocky"))
+	Expect(config.MinTLSServeVer).Should(Equal("1.3"))
 
 	Expect(GetConfig()).Should(Not(BeNil()))
 }

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -185,6 +185,8 @@ port: 53
 # optional: HTTPS listener port(s) and bind ip address(es), default empty = no http listener. If > 0, will be used for prometheus metrics, pprof, REST API, DoH... Example: 443, :443, 127.0.0.1:443
 httpPort: 4000
 #httpsPort: 443
+# optional: Mininal TLS version that the DoH and DoT server will use
+minTlsServeVersion: 1.3
 # if https port > 0: path to cert and key file for SSL encryption. if not set, self-signed certificate will be generated
 #certFile: server.crt
 #keyFile: server.key

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ configuration properties as [JSON](config.yml).
 | logTimestamp | bool                            | no                    | true          | Log time stamps (true or false).                                                                                                                                                                                                                  |
 | logPrivacy   | bool                            | no                    | false         | Obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy.                                                                                                 |
 | dohUserAgent | string                          | no                    |               | HTTP User Agent for DoH upstreams                                                                                                  |
+| minTlsServeVersion | string                    | no                    | 1.2           | Minimum TLS version that the DoT and DoH server use to serve those encrypted DNS requests                       |
 
 !!! example
 

--- a/server/server.go
+++ b/server/server.go
@@ -55,6 +55,20 @@ func logger() *logrus.Entry {
 	return log.PrefixedLog("server")
 }
 
+func minTLSVersion() uint16 {
+	minTLSVer := config.GetConfig().MinTLSServeVer
+	switch minTLSVer {
+	case "1.2":
+		return tls.VersionTLS12
+	case "1.3":
+		return tls.VersionTLS13
+	default:
+		logger().Warn("Not allowed or supported mininum TLS version ", minTLSVer, ", fallback to TLS 1.3")
+
+		return tls.VersionTLS13
+	}
+}
+
 func tlsCipherSuites() []uint16 {
 	tlsCipherSuites := []uint16{
 		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -232,7 +246,7 @@ func createTLSServer(address string, cert tls.Certificate) (*dns.Server, error) 
 		Net:  "tcp-tls",
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS12,
+			MinVersion:   minTLSVersion(),
 			CipherSuites: tlsCipherSuites(),
 		},
 		Handler: dns.NewServeMux(),
@@ -478,7 +492,7 @@ func (s *Server) Start(errCh chan<- error) {
 			server := http.Server{
 				Handler: s.httpsMux,
 				TLSConfig: &tls.Config{
-					MinVersion:   tls.VersionTLS12,
+					MinVersion:   minTLSVersion(),
 					CipherSuites: tlsCipherSuites(),
 					Certificates: []tls.Certificate{s.cert},
 				},

--- a/server/server.go
+++ b/server/server.go
@@ -244,6 +244,7 @@ func createTLSServer(address string, cert tls.Certificate) (*dns.Server, error) 
 	return &dns.Server{
 		Addr: address,
 		Net:  "tcp-tls",
+		//nolint:gosec
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   minTLSVersion(),
@@ -491,6 +492,7 @@ func (s *Server) Start(errCh chan<- error) {
 
 			server := http.Server{
 				Handler: s.httpsMux,
+				//nolint:gosec
 				TLSConfig: &tls.Config{
 					MinVersion:   minTLSVersion(),
 					CipherSuites: tlsCipherSuites(),

--- a/testdata/config.yml
+++ b/testdata/config.yml
@@ -51,3 +51,4 @@ queryLog:
 port: 55553,:55554,[::1]:55555
 logLevel: debug
 dohUserAgent: testBlocky
+minTlsServeVersion: 1.3

--- a/testdata/config/config2.yaml
+++ b/testdata/config/config2.yaml
@@ -34,3 +34,4 @@ queryLog:
 port: 55553,:55554,[::1]:55555
 logLevel: debug
 dohUserAgent: testBlocky
+minTlsServeVersion: 1.3


### PR DESCRIPTION
This allows us to set the minimum TLS version for the DoH & DoT server, without modify the source code and recompile it.