### PR TITLE
Make UpstreamResolver re-use IPSet between Resolves

### DIFF
--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -111,7 +111,7 @@ func (b *Bootstrap) resolveUpstream(r Resolver, host string) ([]net.IP, error) {
 		if timeout != 0 {
 			var cancel context.CancelFunc
 
-			ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout))
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout))
 			defer cancel()
 		}
 


### PR DESCRIPTION
Tried implementing this idea again because of https://github.com/0xERR0R/blocky/discussions/557.

Do you think this is worth the extra complexity?