### PR TITLE
Add fallbackUpstream to RewriterResolver

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -449,7 +449,8 @@ type UpstreamConfig struct {
 
 // RewriteConfig custom DNS configuration
 type RewriteConfig struct {
-	Rewrite map[string]string `yaml:"rewrite"`
+	Rewrite        map[string]string `yaml:"rewrite"`
+	FallbackOnFail bool              `yaml:"fallbackOnFail" default:"false"`
 }
 
 // CustomDNSConfig custom DNS configuration

--- a/config/config.go
+++ b/config/config.go
@@ -449,8 +449,8 @@ type UpstreamConfig struct {
 
 // RewriteConfig custom DNS configuration
 type RewriteConfig struct {
-	Rewrite        map[string]string `yaml:"rewrite"`
-	FallbackOnFail bool              `yaml:"fallbackOnFail" default:"false"`
+	Rewrite          map[string]string `yaml:"rewrite"`
+	FallbackUpstream bool              `yaml:"fallbackUpstream" default:"false"`
 }
 
 // CustomDNSConfig custom DNS configuration

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -35,6 +35,10 @@ customDNS:
 # optional: definition, which DNS resolver(s) should be used for queries to the domain (with all sub-domains). Multiple resolvers must be separated by a comma
 # Example: Query client.fritz.box will ask DNS server 192.168.178.1. This is necessary for local network, to resolve clients by host name
 conditional:
+  # optional: if false (default), return empty result if after rewrite, the mapped resolver returned an empty answer. If true, the original query will be sent to the upstream resolver
+  # Example: The query "blog.example.com" will be rewritten to "blog.fritz.box" and also redirected to the resolver at 192.168.178.1. If not found and if `fallbackOnFailure` was set to `true`, the original query "blog.example.com" will be sent upstream.
+  # Usage: One usecase when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain.
+  fallbackOnFailure: false
   # optional: replace domain in the query with other domain before resolver lookup in the mapping
   rewrite:
     example.com: fritz.box

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -36,9 +36,9 @@ customDNS:
 # Example: Query client.fritz.box will ask DNS server 192.168.178.1. This is necessary for local network, to resolve clients by host name
 conditional:
   # optional: if false (default), return empty result if after rewrite, the mapped resolver returned an empty answer. If true, the original query will be sent to the upstream resolver
-  # Example: The query "blog.example.com" will be rewritten to "blog.fritz.box" and also redirected to the resolver at 192.168.178.1. If not found and if `fallbackOnFailure` was set to `true`, the original query "blog.example.com" will be sent upstream.
+  # Example: The query "blog.example.com" will be rewritten to "blog.fritz.box" and also redirected to the resolver at 192.168.178.1. If not found and if `fallbackUpstream` was set to `true`, the original query "blog.example.com" will be sent upstream.
   # Usage: One usecase when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain.
-  fallbackOnFailure: false
+  fallbackUpstream: false
   # optional: replace domain in the query with other domain before resolver lookup in the mapping
   rewrite:
     example.com: fritz.box

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,8 +232,12 @@ The optional parameter fallbackOnFailure, if false (default), return empty resul
     You can use `.` as wildcard for all non full qualified domains (domains without dot)
 
 In this example, a DNS query "client.fritz.box" will be redirected to the router's DNS server at 192.168.178.1 and client.lan.net to 192.170.1.2 and 192.170.1.3.
-The query "client.example.com" will be rewritten to "client.fritz.box" and also redirected to the resolver at 192.168.178.1. If not found and if `fallbackOnFailure` was set to `true`, the original query "blog.example.com" will be sent upstream.
-All unqualified hostnames (e.g. "test") will be redirected to the DNS server at 168.168.0.1
+The query "client.example.com" will be rewritten to "client.fritz.box" and also redirected to the resolver at 192.168.178.1.
+
+If not found and if `fallbackOnFailure` was set to `true`, the original query "blog.example.com" will be sent upstream.
+
+All unqualified hostnames (e.g. "test") will be redirected to the DNS server at 168.168.0.1.
+
 One usecase for `fallbackOnFailure` is when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain.
 
 ## Client name lookup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,10 +207,14 @@ hostname belongs to which IP address, all DNS queries for the local network shou
 
 The optional parameter `rewrite` behaves the same as with custom DNS.
 
+The optional parameter fallbackOnFailure, if false (default), return empty result if after rewrite, the mapped resolver returned an empty answer. If true, the original query will be sent to the upstream resolver.
+# Usage: One usecase when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain.
+
 !!! example
 
     ```yaml
     conditional:
+      fallbackOnFailure: false
       rewrite:
         example.com: fritz.box
         replace-me.com: with-this.com
@@ -228,9 +232,9 @@ The optional parameter `rewrite` behaves the same as with custom DNS.
     You can use `.` as wildcard for all non full qualified domains (domains without dot)
 
 In this example, a DNS query "client.fritz.box" will be redirected to the router's DNS server at 192.168.178.1 and client.lan.net to 192.170.1.2 and 192.170.1.3.
-The query "client.example.com" will be rewritten to "client.fritz.box" and also redirected to the resolver at 192.168.178.1. All unqualified hostnames (e.g. "test")
-will be redirected to the DNS server at 168.168.0.1
-
+The query "client.example.com" will be rewritten to "client.fritz.box" and also redirected to the resolver at 192.168.178.1. If not found and if `fallbackOnFailure` was set to `true`, the original query "blog.example.com" will be sent upstream.
+All unqualified hostnames (e.g. "test") will be redirected to the DNS server at 168.168.0.1
+One usecase for `fallbackOnFailure` is when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain.
 
 ## Client name lookup
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,14 +207,14 @@ hostname belongs to which IP address, all DNS queries for the local network shou
 
 The optional parameter `rewrite` behaves the same as with custom DNS.
 
-The optional parameter fallbackOnFailure, if false (default), return empty result if after rewrite, the mapped resolver returned an empty answer. If true, the original query will be sent to the upstream resolver.
+The optional parameter fallbackUpstream, if false (default), return empty result if after rewrite, the mapped resolver returned an empty answer. If true, the original query will be sent to the upstream resolver.
 # Usage: One usecase when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain.
 
 !!! example
 
     ```yaml
     conditional:
-      fallbackOnFailure: false
+      fallbackUpstream: false
       rewrite:
         example.com: fritz.box
         replace-me.com: with-this.com
@@ -234,11 +234,11 @@ The optional parameter fallbackOnFailure, if false (default), return empty resul
 In this example, a DNS query "client.fritz.box" will be redirected to the router's DNS server at 192.168.178.1 and client.lan.net to 192.170.1.2 and 192.170.1.3.
 The query "client.example.com" will be rewritten to "client.fritz.box" and also redirected to the resolver at 192.168.178.1.
 
-If not found and if `fallbackOnFailure` was set to `true`, the original query "blog.example.com" will be sent upstream.
+If not found and if `fallbackUpstream` was set to `true`, the original query "blog.example.com" will be sent upstream.
 
 All unqualified hostnames (e.g. "test") will be redirected to the DNS server at 168.168.0.1.
 
-One usecase for `fallbackOnFailure` is when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain.
+One usecase for `fallbackUpstream` is when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain.
 
 ## Client name lookup
 

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -161,9 +161,9 @@ var _ = Describe("RewriterResolver", func() {
 			mNext.AssertNotCalled(GinkgoT(), "Resolve", mock.Anything)
 		})
 
-		When("has fallback on failure", func() {
+		When("has fallbackUpstream", func() {
 			BeforeEach(func() {
-				sutConfig.FallbackOnFail = true
+				sutConfig.FallbackUpstream = true
 			})
 
 			It("should call next resolver", func() {

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+const (
+	sampleOriginal  = "test.original."
+	sampleRewritten = "test.rewritten."
+)
+
 var _ = Describe("RewriterResolver", func() {
 	var (
 		sut       ChainedResolver
@@ -90,8 +95,8 @@ var _ = Describe("RewriterResolver", func() {
 		})
 
 		It("should modify names", func() {
-			fqdnOriginal = "test.original."
-			fqdnRewritten = "test.rewritten."
+			fqdnOriginal = sampleOriginal
+			fqdnRewritten = sampleRewritten
 		})
 
 		It("should modify subdomains", func() {
@@ -110,8 +115,8 @@ var _ = Describe("RewriterResolver", func() {
 		})
 
 		It("should call next resolver", func() {
-			fqdnOriginal = "test.original."
-			fqdnRewritten = "test.rewritten."
+			fqdnOriginal = sampleOriginal
+			fqdnRewritten = sampleRewritten
 			fqdnEmptyResponse = true
 
 			// Make inner call the NoOpResolver
@@ -134,8 +139,8 @@ var _ = Describe("RewriterResolver", func() {
 		})
 
 		It("should not call next resolver", func() {
-			fqdnOriginal = "test.original."
-			fqdnRewritten = "test.rewritten."
+			fqdnOriginal = sampleOriginal
+			fqdnRewritten = sampleRewritten
 
 			// Make inner return a nil Answer but not an empty Response
 			mInner.ResolveFn = func(req *model.Request) (*model.Response, error) {
@@ -195,8 +200,8 @@ var _ = Describe("RewriterResolver", func() {
 		})
 
 		It("should modify names", func() {
-			fqdnOriginal = "test.original."
-			fqdnRewritten = "test.rewritten."
+			fqdnOriginal = sampleOriginal
+			fqdnRewritten = sampleRewritten
 		})
 
 		It("should modify subdomains", func() {
@@ -215,8 +220,8 @@ var _ = Describe("RewriterResolver", func() {
 		})
 
 		It("should call next resolver", func() {
-			fqdnOriginal = "test.original."
-			fqdnRewritten = "test.rewritten."
+			fqdnOriginal = sampleOriginal
+			fqdnRewritten = sampleRewritten
 
 			// Make inner return a nil Answer but not an empty Response
 			mInner.ResolveFn = func(req *model.Request) (*model.Response, error) {


### PR DESCRIPTION
Introducing a `fallbackOnFail` flag which passes the query to the next resolver if the answer from the RewriterResolver is nil.

Fixes #587 