### PR TITLE
wip: socket activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ todo.txt
 !docs/config.yml
 node_modules
 package-lock.json
+
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@ todo.txt
 !docs/config.yml
 node_modules
 package-lock.json
-
 vendor

--- a/config/config.go
+++ b/config/config.go
@@ -331,7 +331,6 @@ func ParseUpstream(upstream string) (Upstream, error) {
 	// string contains host:port
 	if err == nil {
 		p, err := ConvertPort(portString)
-
 		if err != nil {
 			err = fmt.Errorf("can't convert port to number (1 - 65535) %w", err)
 
@@ -430,11 +429,13 @@ type Config struct {
 	Filtering    FilteringConfig `yaml:"filtering"`
 }
 
-type BootstrapConfig bootstrapConfig // to avoid infinite recursion. See BootstrapConfig.UnmarshalYAML.
-type bootstrapConfig struct {
-	Upstream Upstream `yaml:"upstream"`
-	IPs      []net.IP `yaml:"ips"`
-}
+type (
+	BootstrapConfig bootstrapConfig // to avoid infinite recursion. See BootstrapConfig.UnmarshalYAML.
+	bootstrapConfig struct {
+		Upstream Upstream `yaml:"upstream"`
+		IPs      []net.IP `yaml:"ips"`
+	}
+)
 
 // PrometheusConfig contains the config values for prometheus
 type PrometheusConfig struct {
@@ -653,7 +654,6 @@ func ConvertPort(in string) (uint16, error) {
 
 	var p uint64
 	p, err := strconv.ParseUint(strings.TrimSpace(in), base, bitSize)
-
 	if err != nil {
 		return 0, err
 	}

--- a/socket/launchd_disabled.go
+++ b/socket/launchd_disabled.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package socket
+
+import (
+	"errors"
+	"net"
+)
+
+func LaunchdSockets(address string) ([]int, error) {
+	return nil, errors.New("launchd socket activation is only supported on darwin")
+}

--- a/socket/launchd_enabled.go
+++ b/socket/launchd_enabled.go
@@ -1,0 +1,53 @@
+//go:build darwin
+package socket
+
+/*
+#include <stdlib.h>
+#include <launch.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"unsafe"
+)
+
+func LaunchdSockets(address string) ([]int, error) {
+	c_name := C.CString(address)
+	var c_fds *C.int
+	c_cnt := C.size_t(0)
+
+	err := C.launch_activate_socket(c_name, &c_fds, &c_cnt)
+	if err != 0 {
+		return nil, fmt.Errorf("couldn't activate launchd socket: %v", err)
+	}
+
+	length := int(c_cnt)
+	if length < 2 {
+		return nil, fmt.Errorf("expected at least two sockets to be configured in launchd for '%s', found %d", address, length)
+	}
+	ptr := unsafe.Pointer(c_fds)
+	defer C.free(ptr)
+
+	fds := (*[1 << 30]C.int)(ptr)[:length:length]
+	res := make([]int, length)
+	for i := 0; i < length; i++ {
+		res[i] = int(fds[i])
+	}
+
+	return res, nil
+}
+
+func BuildPacketConn(fd int) (net.PacketConn, error) {
+	file := os.NewFile(uintptr(fd), "")
+
+	return net.FilePacketConn(file)
+}
+
+func BuildListener(fd int) (net.Listener, error) {
+	file := os.NewFile(uintptr(fd), "")
+
+	return net.FileListener(file)
+}

--- a/socket/net.go
+++ b/socket/net.go
@@ -1,0 +1,16 @@
+package socket
+
+import "strings"
+
+func ParseAddress(input string) (address, network string) {
+	if strings.HasPrefix(input, "launchd:") {
+		address = input[8:]
+		network = "launchd"
+		return
+	}
+
+	address = input
+	network = ""
+
+	return
+}


### PR DESCRIPTION
My motivation is to run blocky as a local resolver on my macOS machines, for which I prefer to run as a user-level process but still with the ability to bind to :53

This is totally a WIP—I'm not too familiar with the codebase, socket activation, or golang. I'll continue to clean it up, but pointers and guidance would be appreciated! I can take a look at tackling systemd socket activation too, but I doubt I'll have the availability to test that it works.


example with only launchd
```yaml
# config.yaml
port: launchd:Listeners
```

or with other bindings

```yaml
# config.yaml
port: launchd:Listeners,:54,192.168.1.10:853
```

<details>
<summary>Example blocky.plist</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>Label</key>
	<string>blocky</string>

	<key>ProgramArguments</key>
	<array>
		<string>${BLOCKY_BIN}</string>
		<string>--config</string>
		<string>${BLOCKY_CONFIG}</string>
		<string>serve</string>
	</array>

	<key>RunAtLoad</key>
	<true/>

	<key>KeepAlive</key>
	<dict>
		<key>Crashed</key>
		<true/>
	</dict>

	<key>StandardOutPath</key>
	<string>/tmp/log/blocky/stdout.log</string>

	<key>StandardErrorPath</key>
	<string>/tmp/log/blocky/stderr.log</string>

	<key>Sockets</key>
	<dict>
	    <key>Listeners</key>
	    <array>
		    <dict>
			<key>SockType</key>
			<string>dgram</string>
			<key>SockServiceName</key>
			<string>domain</string>
			<key>SockNodeName</key>
			<string>127.0.0.1</string>
		    </dict>
		    <dict>
			<key>SockType</key>
			<string>stream</string>
			<key>SockServiceName</key>
			<string>domain</string>
			<key>SockNodeName</key>
			<string>127.0.0.1</string>
		    </dict>
		</array>
	</dict>
</dict>
</plist>
```
</details>

Heavily based on https://github.com/ghostunnel/ghostunnel/blob/cd0886b72a0ba9b32f3d05bd401f3d9f118018f3/socket/net.go, and https://github.com/x13a/go-launch/blob/master/launch.go, and will likely require attribution if kept as-is

