### PR TITLE
Disable colors when not in interactive terminal

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -69,7 +69,7 @@ func ConfigureLogger(logLevel Level, formatType FormatType, logTimestamp bool) {
 			TimestampFormat:  "2006-01-02 15:04:05",
 			FullTimestamp:    true,
 			ForceFormatting:  true,
-			ForceColors:      true,
+			ForceColors:      false,
 			QuoteEmptyFields: true,
 			DisableTimestamp: !logTimestamp}
 


### PR DESCRIPTION
Forcing colors in logrus causes color escapes sequences when logging to file or pipe.

Fixes #602.