### PR TITLE
Add config.yml.example

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -1,0 +1,7 @@
+port: 5300
+httpPort: 4000
+logLevel: info
+
+upstream:
+  default:
+    - 8.8.8.8

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-This chapter describes all configuration options in `config.yaml`. You can download a reference file with all
+This chapter describes all configuration options in `config.yml`. You can download a reference file with all
 configuration properties as [JSON](config.yml).
 
 ??? example "reference configuration file"
@@ -189,10 +189,10 @@ domain must be separated by a comma.
     ```
 
 This configuration will also resolve any subdomain of the defined domain. For example a query "printer.lan" or "
-my.printer.lan" will return 192.168.178.3 as IP address.  
+my.printer.lan" will return 192.168.178.3 as IP address.
 
 With the optional parameter `rewrite` you can replace domain part of the query with the defined part **before** the
-resolver lookup is performed.  
+resolver lookup is performed.
 The query "printer.home" will be rewritten to "printer.lan" and return 192.168.178.3.
 
 With parameter `filterUnmappedTypes = true` (default), blocky will filter all queries with unmapped types, for example:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ You can choose one of the following installation options:
 
 ## Prepare your configuration
 
-Blocky supports single or multiple YAML files as configuration. Create new `config.yaml` with your configuration (
+Blocky supports single or multiple YAML files as configuration. Create new `config.yml` with your configuration (
 see [Configuration](configuration.md) for more details and all configuration options).
 
 Simple configuration file, which enables only basic features:
@@ -57,7 +57,7 @@ Default value is "/app/config.yml".
 
 Execute following command from the command line:
 
-```    
+```
 docker run --name blocky -v /path/to/config.yml:/app/config.yml -p 4000:4000 -p 53:53/udp spx01/blocky
 ```
 
@@ -125,7 +125,7 @@ volumes:
     driver_opts:
       type: cifs
       o: username=USER,password=PASSWORD,rw
-      device: //NAS_HOSTNAME/blocky  
+      device: //NAS_HOSTNAME/blocky
 ```
 
 #### Multiple configuration files


### PR DESCRIPTION
This PR adds a basic yet working `config.yml.example` to make getting started a little easier. I also fixed a few `config.yaml` -> `config.yml` references in the docs 🙂

Perhaps we should include something in the `README.md` or such about copying `config.yml.example` to `config.yml` as well ?

cc @0xERR0R 