### PR TITLE
Add /health endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -30,6 +30,9 @@ const (
 
 	// PathDohQuery DoH Url
 	PathDohQuery = "/dns-query"
+
+	// HealthPath Url
+	HealthPath = "/health"
 )
 
 // QueryRequest is a data structure for a DNS request
@@ -60,4 +63,10 @@ type BlockingStatus struct {
 	DisabledGroups []string `json:"disabledGroups"`
 	// If blocking is temporary disabled: amount of seconds until blocking will be enabled
 	AutoEnableInSec uint `json:"autoEnableInSec"`
+}
+
+// HealthStatus represents the current health status
+type HealthStatus struct {
+	// Display version
+	Version string `json:"version"`
 }

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -151,6 +152,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -296,6 +296,12 @@ func (r *BlockingResolver) BlockingStatus() api.BlockingStatus {
 	}
 }
 
+func (r *BlockingResolver) GetHealth() api.HealthStatus {
+	return api.HealthStatus{
+		Version: util.Version,
+	}
+}
+
 // returns groups, which have only whitelist entries
 func determineWhitelistOnlyGroups(cfg *config.BlockingConfig) (result map[string]bool) {
 	result = make(map[string]bool, len(cfg.WhiteLists))


### PR DESCRIPTION
This PR adds a new `/health` endpoint which for now, just displays the version and is designed to be used to determine API health and inform of the running version for diagnostic/informational purposes:

```sh
$ curl -qs http://127.0.0.1:4000/health | jq .
{
  "version": "v0.18-114-gb9384d5"
}
```