### PR TITLE
chore: customize codecov project status, disable threshold for PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 80%
+    patch:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        base: auto 
+        only_pulls: true
 ignore:
   - "resolver/mocks.go"
   - "**/*_enum.go"


### PR DESCRIPTION
codecov results are sometimes inaccurate.