### PR TITLE
Helm Chart: KaH -> TrueCharts and add TrueNAS SCALE Native App

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -150,8 +150,12 @@ For complex setups, splitting the configuration between multiple YAML files migh
 
 ### Run with helm chart on Kubernetes
 
-See [this repo](https://github.com/k8s-at-home/charts/tree/master/charts/stable/blocky)
-or [artifacthub](https://hub.helm.sh/charts/k8s-at-home/blocky) for details about running blocky via helm in kubernetes.
+See [this repo](https://github.com/truecharts/charts/tree/master/charts/enterprise/blocky)
+or [truecharts.org](https://truecharts.org/docs/charts/blocky) for details about running blocky via helm in kubernetes.
+
+### Run as an App for TrueNAS SCALE
+
+See [truecharts.org](https://truecharts.org/docs/charts/blocky) for details about running blocky as a native App for TrueNAS SCALE
 
 ### AUR package for Arch Linux
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -150,12 +150,15 @@ For complex setups, splitting the configuration between multiple YAML files migh
 
 ### Run with helm chart on Kubernetes
 
-See [this repo](https://github.com/truecharts/charts/tree/master/charts/enterprise/blocky)
-or [truecharts.org](https://truecharts.org/docs/charts/blocky) for details about running blocky via helm in kubernetes.
+See [this repo](https://github.com/truecharts/charts/tree/master/charts/enterprise/blocky),
+the [documentation](https://truecharts.org/docs/charts/enterprise/blocky/)
+and [the configuration instructions](https://truecharts.org/docs/charts/enterprise/blocky/installation-notes) for details about running blocky via helm in kubernetes.
 
 ### Run as an App for TrueNAS SCALE
 
-See [truecharts.org](https://truecharts.org/docs/charts/blocky) for details about running blocky as a native App for TrueNAS SCALE
+You can find the App in the TrueCharts [App Catalog](https://truecharts.org/docs/manual/SCALE%20Apps/Adding-TrueCharts)
+or read the [documentation](https://truecharts.org/docs/charts/enterprise/blocky/)
+and [ configuration instructions](https://truecharts.org/docs/charts/enterprise/blocky/installation-notes) for details about running blocky as a native TrueNAS SCALE App.
 
 ### AUR package for Arch Linux
 


### PR DESCRIPTION
# Background

- The k8s-at-home project has deprecated all it's helm charts, including blocky.
- We, as TrueCharts, cover most of the applications previously covered by k8s-at-home (and a lot more)
- We've, as TrueCharts, decided to invest heavily into blocky as our adviced go-to solutions for all cases of "DNS-Enhancement" and filtering
- We've integrated k8s_gateway to allow for easy split-DNS (local-external) setup on kubernetes.
- We've rebuild a Helm Chart from scratch, which includes support for 2 different styles of entering any Blocky config directly into `values.yaml`
- We've also designed a complete GUI for TrueNAS SCALE based on the same helm chart

# PR

Hence we would request/suggest:
- The helm-chart URL to be changed to ours (as there is no support/updates over at k8s-at-home)
- The SCALE App also being added in the list of, downstream, supported platforms