### PR TITLE
feat(api): Adding parameter to use actual remote address or specific IP

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -38,6 +38,10 @@ type QueryRequest struct {
 	Query string
 	// request type (A, AAAA, ...)
 	Type string
+	// optional : Use remote address : default false
+	UseRemoteAddress bool
+	// optional : Remote address override
+	RemoteAddress string
 }
 
 // QueryResult is a data structure for the DNS result


### PR DESCRIPTION
I'm trying to implement new features : for certains ip I would like to enjoy OpenDNS as a DNS fallback over my rule, but I wanted to switch it off and go back to another DNS (like google or cloudflare) like a disabled group (for parental control at home)
To do so, I need to add some testing endpoint.

It is my first Go contribution in my life (even at work) so, do not hesitate to comment (mainly the way I've done inheritence on `dns.ResponseWriter`)

Also, as it is the [Hacktoberfest](https://hacktoberfest.com/) has begun, could you please add the `hacktoberfest-accepted` label to this PR ?

In advance thank