### PR TITLE
fix: change network names (#703)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,9 +48,9 @@ func (ipv IPVersion) Net() string {
 	case IPVersionDual:
 		return "ip"
 	case IPVersionV4:
-		return "ipv4"
+		return "ip4"
 	case IPVersionV6:
-		return "ipv6"
+		return "ip6"
 	}
 
 	panic(fmt.Errorf("bad value: %s", ipv))


### PR DESCRIPTION
Changed network names, according to https://pkg.go.dev/net#Resolver.LookupIP

closes #703 