### PR TITLE
Fix indentation of heading 'Hosts File'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -624,7 +624,7 @@ example for Database
       logRetentionDays: 7
     ```
 
-### Hosts file
+## Hosts file
 
 You can enable resolving of entries, located in local hosts file.
 


### PR DESCRIPTION
I think the intention of the heading 'Hosts File' inside the configuration.md file was incorrect.