### PR TITLE
fix: format ipv6 URL for DoH bootstrap request according to RFC3513

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - nilerr
     - nilnil
     - nlreturn
+    - nosprintfhostport
     - prealloc
     - predeclared
     - revive

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
@@ -58,7 +60,7 @@ Complete documentation is available at https://github.com/0xERR0R/blocky`,
 }
 
 func apiURL(path string) string {
-	return fmt.Sprintf("http://%s:%d%s", apiHost, apiPort, path)
+	return fmt.Sprintf("http://%s%s", net.JoinHostPort(apiHost, strconv.Itoa(int(apiPort))), path)
 }
 
 //nolint:gochecknoinits

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -113,7 +113,7 @@ func createUpstreamClient(cfg config.Upstream) upstreamClient {
 }
 
 func (r *httpUpstreamClient) fmtURL(ip net.IP, port uint16, path string) string {
-	return fmt.Sprintf("https://%s:%d%s", ip.String(), port, path)
+	return fmt.Sprintf("https://%s%s", net.JoinHostPort(ip.String(), strconv.Itoa(int(port))), path)
 }
 
 func (r *httpUpstreamClient) callExternal(msg *dns.Msg,
@@ -171,7 +171,7 @@ func (r *httpUpstreamClient) callExternal(msg *dns.Msg,
 	return &response, time.Since(start), nil
 }
 
-func (r *dnsUpstreamClient) fmtURL(ip net.IP, port uint16, _path string) string {
+func (r *dnsUpstreamClient) fmtURL(ip net.IP, port uint16, _ string) string {
 	return net.JoinHostPort(ip.String(), strconv.Itoa(int(port)))
 }
 


### PR DESCRIPTION
It should avoid "magic" timeouts (#701) on Ipv6 bootstrap queries (if DoH is used).