### PR TITLE
chore: add dependabot configuration for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
   open-pull-requests-limit: 10
   assignees:
   - 0xERR0R
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
closes #713 