### PR TITLE
Use either /etc/localtime or TZ in Docker containers

### DIFF
--- a/main_static.go
+++ b/main_static.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"time"
 	_ "time/tzdata"
@@ -16,12 +15,27 @@ import (
 func init() {
 	go reaper.Reap()
 
-	if tz := os.Getenv("TZ"); tz != "" {
-		var err error
-		time.Local, err = time.LoadLocation(tz)
+	setLocaltime()
+}
 
-		if err != nil {
-			fmt.Printf("error loading location '%s': %v\n", tz, err)
+// set localtime to /etc/localtime if available
+// or modify the system time with the TZ environment variable if it is provided
+func setLocaltime() {
+	// load /etc/localtime without modifying it
+	if lt, err := os.ReadFile("/etc/localtime"); err == nil {
+		if t, err := time.LoadLocationFromTZData("", lt); err == nil {
+			time.Local = t
+
+			return
+		}
+	}
+
+	// use zoneinfo from time/tzdata and set location with the TZ environment variable
+	if tz := os.Getenv("TZ"); tz != "" {
+		if t, err := time.LoadLocation(tz); err == nil {
+			time.Local = t
+
+			return
 		}
 	}
 }


### PR DESCRIPTION
If /etc/localtime is mounted as volume and the TZ variable is also defined the the container time is wrong as the hour offset of TZ is added to localtime.


Example of 4h offset to the docker host:
```YAML
services:
  blocky:
    image: ghcr.io/0xerr0r/blocky:development
    volumes:
      - /etc/localtime:/etc/localtime:ro
    environment:
      - TZ=Europe/Astrakhan
```

The primary reason to mount /etc/localtime is to ensure that localtime inside of containers is the same as the docker host.
Adding the TZ offset results in an incorrect localtime inside the container.  
<br/>
This PR switches between /etc/localtime and the TZ environment variable.  

Order:
1. If /etc/localtime is found it is used without any offset
2. If TZ isn't empty it's offset is used to get the localtime