### PR TITLE
queryLog: log instance hostname or identifier to distinguish log entries in multi-instance installation(#319)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,6 +79,10 @@ services:
     environment:
       - TZ=Europe/Berlin # Optional to synchronize the log timestamp with host
     volumes:
+      # Optional to synchronize the log timestamp with host
+      - /etc/localtime:/etc/localtime:ro
+      # Optional to synchronize the hostname with host
+      - /etc/hostname:/etc/hostname:ro
       # config file
       - ./config.yml:/app/config.yml
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,6 +72,8 @@ services:
     image: spx01/blocky
     container_name: blocky
     restart: unless-stopped
+    # Optional the instance hostname for logging purpose
+    hostname: blocky-hostname
     ports:
       - "53:53/tcp"
       - "53:53/udp"
@@ -81,8 +83,6 @@ services:
     volumes:
       # Optional to synchronize the log timestamp with host
       - /etc/localtime:/etc/localtime:ro
-      # Optional to synchronize the hostname with host
-      - /etc/hostname:/etc/hostname:ro
       # config file
       - ./config.yml:/app/config.yml
 ```

--- a/querylog/database_writer.go
+++ b/querylog/database_writer.go
@@ -31,6 +31,7 @@ type logEntry struct {
 	EffectiveTLDP string
 	Answer        string
 	ResponseCode  string
+	Hostname      string
 }
 
 type DatabaseWriter struct {
@@ -140,6 +141,7 @@ func (d *DatabaseWriter) Write(entry *LogEntry) {
 		EffectiveTLDP: eTLD,
 		Answer:        util.AnswerToString(entry.Response.Res.Answer),
 		ResponseCode:  dns.RcodeToString[entry.Response.Res.Rcode],
+		Hostname:      util.HostnameString(),
 	}
 
 	d.lock.Lock()

--- a/querylog/file_writer.go
+++ b/querylog/file_writer.go
@@ -114,6 +114,7 @@ func createQueryLogRow(logEntry *LogEntry) []string {
 		util.QuestionToString(request.Req.Question),
 		util.AnswerToString(response.Res.Answer),
 		dns.RcodeToString[response.Res.Rcode],
+		util.HostnameString(),
 	}
 }
 

--- a/querylog/file_writer_test.go
+++ b/querylog/file_writer_test.go
@@ -186,7 +186,6 @@ var _ = Describe("FileWriter", func() {
 						DurationMs: 20,
 					})
 				})
-				fmt.Println(tmpDir.Path)
 
 				Eventually(func(g Gomega) int {
 					filesCount, err := tmpDir.CountFiles()

--- a/querylog/logger_writer.go
+++ b/querylog/logger_writer.go
@@ -29,6 +29,7 @@ func (d *LoggerWriter) Write(entry *LogEntry) {
 			"response_code":   dns.RcodeToString[entry.Response.Res.Rcode],
 			"answer":          util.AnswerToString(entry.Response.Res.Answer),
 			"duration_ms":     entry.DurationMs,
+			"hostname":        util.HostnameString(),
 		},
 	).Infof("query resolved")
 }

--- a/util/hostname.go
+++ b/util/hostname.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"os"
+	"strings"
+)
+
+//nolint:gochecknoglobals
+var (
+	hostname    string
+	hostnameErr error
+)
+
+const hostnameFile string = "/etc/hostname"
+
+//nolint:gochecknoinits
+func init() {
+	getHostname(hostnameFile)
+}
+
+func Hostname() (string, error) {
+	return hostname, hostnameErr
+}
+
+func getHostname(location string) {
+	hostname, hostnameErr = os.Hostname()
+
+	if hn, err := os.ReadFile(location); err == nil {
+		hostname = strings.TrimSpace(string(hn))
+		hostnameErr = nil
+
+		return
+	}
+}

--- a/util/hostname.go
+++ b/util/hostname.go
@@ -18,8 +18,14 @@ func init() {
 	getHostname(hostnameFile)
 }
 
+// Direct replacement for os.Hostname
 func Hostname() (string, error) {
 	return hostname, hostnameErr
+}
+
+// Only return the hostname(may be empty if there was an error)
+func HostnameString() string {
+	return hostname
 }
 
 func getHostname(location string) {

--- a/util/hostname_test.go
+++ b/util/hostname_test.go
@@ -40,13 +40,13 @@ var _ = Describe("Hostname function tests", func() {
 		It("should use os.Hostname", func() {
 			getHostname("/does-not-exist")
 
-			hn, err := Hostname()
+			_, err := Hostname()
 			Expect(err).Should(Succeed())
 
 			ohn, err := os.Hostname()
 			Expect(err).Should(Succeed())
 
-			Expect(hn).Should(Equal(ohn))
+			Expect(HostnameString()).Should(Equal(ohn))
 		})
 	})
 })

--- a/util/hostname_test.go
+++ b/util/hostname_test.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"os"
+	"strings"
+
+	"github.com/0xERR0R/blocky/helpertest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Hostname function tests", func() {
+	When("file is present", func() {
+		var (
+			tmpDir *helpertest.TmpFolder
+		)
+
+		BeforeEach(func() {
+			tmpDir = helpertest.NewTmpFolder("hostname")
+			Expect(tmpDir.Error).Should(Succeed())
+			DeferCleanup(tmpDir.Clean)
+		})
+
+		It("should be used", func() {
+			tmpFile := tmpDir.CreateStringFile("filetest1", "TestName ")
+			Expect(tmpFile.Error).Should(Succeed())
+			getHostname(tmpFile.Path)
+
+			fhn, err := os.ReadFile(tmpFile.Path)
+			Expect(err).Should(Succeed())
+
+			hn, err := Hostname()
+			Expect(err).Should(Succeed())
+
+			Expect(hn).Should(Equal(strings.TrimSpace(string(fhn))))
+		})
+	})
+
+	When("file is not present", func() {
+		It("should use os.Hostname", func() {
+			getHostname("/does-not-exist")
+
+			hn, err := Hostname()
+			Expect(err).Should(Succeed())
+
+			ohn, err := os.Hostname()
+			Expect(err).Should(Succeed())
+
+			Expect(hn).Should(Equal(ohn))
+		})
+	})
+})


### PR DESCRIPTION
Adds hostname field to querylog entry.

If `/etc/hostname` is present the content of this file will be used as hostname.
Otherwise os.Hostname is used.

Closes #319

**Table migration is untested but should work gorm.db.AutoMigrate**