### PR TITLE
Config restructuring

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,7 +86,7 @@ func initConfig() {
 		util.FatalOnError("unable to load configuration: ", err)
 	}
 
-	log.ConfigureLogger(cfg.LogLevel, cfg.LogFormat, cfg.LogTimestamp)
+	log.ConfigureLogger(&cfg.Log)
 
 	if len(cfg.HTTPPorts) != 0 {
 		split := strings.Split(cfg.HTTPPorts[0], ":")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -38,7 +38,7 @@ func startServer(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to load configuration: %w", err)
 	}
 
-	log.ConfigureLogger(cfg.LogLevel, cfg.LogFormat, cfg.LogTimestamp)
+	log.ConfigureLogger(&cfg.Log)
 
 	signals := make(chan os.Signal, 1)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,4 @@ coverage:
 ignore:
   - "resolver/mocks.go"
   - "**/*_enum.go"
+  - "e2e/*.go"

--- a/config/config.go
+++ b/config/config.go
@@ -754,7 +754,13 @@ func validateConfig(cfg *Config) {
 		}
 	}
 
-	// backwards compatibility for logging options
+	fixDeprecatedLog(cfg)
+
+	fixDeprecatedPorts(cfg)
+}
+
+// fixDeprecatedLog ensures backwards compatibility for logging options
+func fixDeprecatedLog(cfg *Config) {
 	if cfg.LogLevel != log.LevelInfo && cfg.Log.Level == log.LevelInfo {
 		log.Log().Warnf("'logLevel' is deprecated. Please use 'log.level' instead.")
 
@@ -778,10 +784,13 @@ func validateConfig(cfg *Config) {
 
 		cfg.Log.Timestamp = cfg.LogTimestamp
 	}
+}
 
-	// backwards compatibility for ports options
-	if (len(cfg.DNSPorts) > 1 || cfg.DNSPorts[0] != "53") &&
-		(len(cfg.Ports.DNS) == 1 && cfg.Ports.DNS[0] == "53") {
+// fixDeprecatedPorts ensures backwards compatibility for ports options
+func fixDeprecatedPorts(cfg *Config) {
+	defaultDNSPort := ListenConfig([]string{"53"})
+	if (len(cfg.DNSPorts) > 1 || (len(cfg.DNSPorts) == 1 && cfg.DNSPorts[0] != defaultDNSPort[0])) &&
+		(len(cfg.Ports.DNS) == 1 && cfg.Ports.DNS[0] == defaultDNSPort[0]) {
 		log.Log().Warnf("'port' is deprecated. Please use 'ports.dns' instead.")
 
 		cfg.Ports.DNS = cfg.DNSPorts

--- a/config/config.go
+++ b/config/config.go
@@ -461,10 +461,7 @@ type Config struct {
 	Prometheus          PrometheusConfig          `yaml:"prometheus"`
 	Redis               RedisConfig               `yaml:"redis"`
 	Log                 log.Config                `yaml:"log"`
-	DNSPorts            ListenConfig              `yaml:"port" default:"[\"53\"]"`
-	HTTPPorts           ListenConfig              `yaml:"httpPort"`
-	HTTPSPorts          ListenConfig              `yaml:"httpsPort"`
-	TLSPorts            ListenConfig              `yaml:"tlsPort"`
+	Ports               PortsConfig               `yaml:"ports"`
 	DoHUserAgent        string                    `yaml:"dohUserAgent"`
 	MinTLSServeVer      string                    `yaml:"minTlsServeVersion" default:"1.2"`
 	StartVerifyUpstream bool                      `yaml:"startVerifyUpstream" default:"false"`
@@ -485,6 +482,21 @@ type Config struct {
 	LogPrivacy bool `yaml:"logPrivacy" default:"false"`
 	// Deprecated
 	LogTimestamp bool `yaml:"logTimestamp" default:"true"`
+	// Deprecated
+	DNSPorts ListenConfig `yaml:"port" default:"[\"53\"]"`
+	// Deprecated
+	HTTPPorts ListenConfig `yaml:"httpPort"`
+	// Deprecated
+	HTTPSPorts ListenConfig `yaml:"httpsPort"`
+	// Deprecated
+	TLSPorts ListenConfig `yaml:"tlsPort"`
+}
+
+type PortsConfig struct {
+	DNS   ListenConfig `yaml:"dns" default:"[\"53\"]"`
+	HTTP  ListenConfig `yaml:"http"`
+	HTTPS ListenConfig `yaml:"https"`
+	TLS   ListenConfig `yaml:"tls"`
 }
 
 type BootstrapConfig bootstrapConfig // to avoid infinite recursion. See BootstrapConfig.UnmarshalYAML.
@@ -765,6 +777,32 @@ func validateConfig(cfg *Config) {
 		log.Log().Warnf("'logTimestamp' is deprecated. Please use 'log.timestamp' instead.")
 
 		cfg.Log.Timestamp = cfg.LogTimestamp
+	}
+
+	// backwards compatibility for ports options
+	if (len(cfg.DNSPorts) > 1 || cfg.DNSPorts[0] != "53") &&
+		(len(cfg.Ports.DNS) == 1 && cfg.Ports.DNS[0] == "53") {
+		log.Log().Warnf("'port' is deprecated. Please use 'ports.dns' instead.")
+
+		cfg.Ports.DNS = cfg.DNSPorts
+	}
+
+	if len(cfg.HTTPPorts) > 0 && len(cfg.Ports.HTTP) == 0 {
+		log.Log().Warnf("'httpPort' is deprecated. Please use 'ports.http' instead.")
+
+		cfg.Ports.HTTP = cfg.HTTPPorts
+	}
+
+	if len(cfg.HTTPSPorts) > 0 && len(cfg.Ports.HTTPS) == 0 {
+		log.Log().Warnf("'httpsPort' is deprecated. Please use 'ports.https' instead.")
+
+		cfg.Ports.HTTPS = cfg.HTTPSPorts
+	}
+
+	if len(cfg.TLSPorts) > 0 && len(cfg.Ports.TLS) == 0 {
+		log.Log().Warnf("'tlsPort' is deprecated. Please use 'ports.tls' instead.")
+
+		cfg.Ports.TLS = cfg.TLSPorts
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -460,10 +460,7 @@ type Config struct {
 	QueryLog            QueryLogConfig            `yaml:"queryLog"`
 	Prometheus          PrometheusConfig          `yaml:"prometheus"`
 	Redis               RedisConfig               `yaml:"redis"`
-	LogLevel            log.Level                 `yaml:"logLevel" default:"info"`
-	LogFormat           log.FormatType            `yaml:"logFormat" default:"text"`
-	LogPrivacy          bool                      `yaml:"logPrivacy" default:"false"`
-	LogTimestamp        bool                      `yaml:"logTimestamp" default:"true"`
+	Log                 log.Config                `yaml:"log"`
 	DNSPorts            ListenConfig              `yaml:"port" default:"[\"53\"]"`
 	HTTPPorts           ListenConfig              `yaml:"httpPort"`
 	HTTPSPorts          ListenConfig              `yaml:"httpsPort"`
@@ -471,15 +468,23 @@ type Config struct {
 	DoHUserAgent        string                    `yaml:"dohUserAgent"`
 	MinTLSServeVer      string                    `yaml:"minTlsServeVersion" default:"1.2"`
 	StartVerifyUpstream bool                      `yaml:"startVerifyUpstream" default:"false"`
+	CertFile            string                    `yaml:"certFile"`
+	KeyFile             string                    `yaml:"keyFile"`
+	BootstrapDNS        BootstrapConfig           `yaml:"bootstrapDns"`
+	HostsFile           HostsFileConfig           `yaml:"hostsFile"`
+	FqdnOnly            bool                      `yaml:"fqdnOnly" default:"false"`
+	Filtering           FilteringConfig           `yaml:"filtering"`
+	Ede                 EdeConfig                 `yaml:"ede"`
 	// Deprecated
-	DisableIPv6  bool            `yaml:"disableIPv6" default:"false"`
-	CertFile     string          `yaml:"certFile"`
-	KeyFile      string          `yaml:"keyFile"`
-	BootstrapDNS BootstrapConfig `yaml:"bootstrapDns"`
-	HostsFile    HostsFileConfig `yaml:"hostsFile"`
-	FqdnOnly     bool            `yaml:"fqdnOnly" default:"false"`
-	Filtering    FilteringConfig `yaml:"filtering"`
-	Ede          EdeConfig       `yaml:"ede"`
+	DisableIPv6 bool `yaml:"disableIPv6" default:"false"`
+	// Deprecated
+	LogLevel log.Level `yaml:"logLevel" default:"info"`
+	// Deprecated
+	LogFormat log.FormatType `yaml:"logFormat" default:"text"`
+	// Deprecated
+	LogPrivacy bool `yaml:"logPrivacy" default:"false"`
+	// Deprecated
+	LogTimestamp bool `yaml:"logTimestamp" default:"true"`
 }
 
 type BootstrapConfig bootstrapConfig // to avoid infinite recursion. See BootstrapConfig.UnmarshalYAML.
@@ -735,6 +740,31 @@ func validateConfig(cfg *Config) {
 		} else if cfg.Blocking.StartStrategy == StartStrategyTypeFast {
 			log.Log().Warnf("'blocking.startStrategy' with 'fast' will ignore 'blocking.failStartOnListError'.")
 		}
+	}
+
+	// backwards compatibility for logging options
+	if cfg.LogLevel != log.LevelInfo && cfg.Log.Level == log.LevelInfo {
+		log.Log().Warnf("'logLevel' is deprecated. Please use 'log.level' instead.")
+
+		cfg.Log.Level = cfg.LogLevel
+	}
+
+	if cfg.LogFormat != log.FormatTypeText && cfg.Log.Format == log.FormatTypeText {
+		log.Log().Warnf("'logFormat' is deprecated. Please use 'log.format' instead.")
+
+		cfg.Log.Format = cfg.LogFormat
+	}
+
+	if cfg.LogPrivacy && !cfg.Log.Privacy {
+		log.Log().Warnf("'logPrivacy' is deprecated. Please use 'log.privacy' instead.")
+
+		cfg.Log.Privacy = cfg.LogPrivacy
+	}
+
+	if !cfg.LogTimestamp && cfg.Log.Timestamp {
+		log.Log().Warnf("'logTimestamp' is deprecated. Please use 'log.timestamp' instead.")
+
+		cfg.Log.Timestamp = cfg.LogTimestamp
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/creasty/defaults"
 	"github.com/miekg/dns"
 
 	"github.com/0xERR0R/blocky/helpertest"
@@ -23,6 +24,111 @@ var _ = Describe("Config", func() {
 		tmpDir = helpertest.NewTmpFolder("config")
 		Expect(tmpDir.Error).Should(Succeed())
 		DeferCleanup(tmpDir.Clean)
+	})
+
+	Describe("Deprecated parameters are converted", func() {
+		var (
+			c Config
+		)
+		BeforeEach(func() {
+			err := defaults.Set(&c)
+			Expect(err).Should(Succeed())
+		})
+
+		When("parameter 'disableIPv6' is set", func() {
+			It("should add 'AAAA' to filter.queryTypes", func() {
+				c.DisableIPv6 = true
+				validateConfig(&c)
+				Expect(c.Filtering.QueryTypes).Should(HaveKey(QType(dns.TypeAAAA)))
+				Expect(c.Filtering.QueryTypes.Contains(dns.Type(dns.TypeAAAA))).Should(BeTrue())
+			})
+		})
+
+		When("parameter 'failStartOnListError' is set", func() {
+			BeforeEach(func() {
+				c.Blocking = BlockingConfig{
+					FailStartOnListError: true,
+					StartStrategy:        StartStrategyTypeBlocking,
+				}
+			})
+			It("should change StartStrategy blocking to failOnError", func() {
+				validateConfig(&c)
+				Expect(c.Blocking.StartStrategy).Should(Equal(StartStrategyTypeFailOnError))
+			})
+			It("shouldn't change StartStrategy if set to fast", func() {
+				c.Blocking.StartStrategy = StartStrategyTypeFast
+				validateConfig(&c)
+				Expect(c.Blocking.StartStrategy).Should(Equal(StartStrategyTypeFast))
+			})
+		})
+
+		When("parameter 'logLevel' is set", func() {
+			It("should convert to log.level", func() {
+				c.LogLevel = log.LevelDebug
+				validateConfig(&c)
+				Expect(c.Log.Level).Should(Equal(log.LevelDebug))
+			})
+		})
+
+		When("parameter 'logFormat' is set", func() {
+			It("should convert to log.format", func() {
+				c.LogFormat = log.FormatTypeJson
+				validateConfig(&c)
+				Expect(c.Log.Format).Should(Equal(log.FormatTypeJson))
+			})
+		})
+
+		When("parameter 'logPrivacy' is set", func() {
+			It("should convert to log.privacy", func() {
+				c.LogPrivacy = true
+				validateConfig(&c)
+				Expect(c.Log.Privacy).Should(BeTrue())
+			})
+		})
+
+		When("parameter 'logTimestamp' is set", func() {
+			It("should convert to log.timestamp", func() {
+				c.LogTimestamp = false
+				validateConfig(&c)
+				Expect(c.Log.Timestamp).Should(BeFalse())
+			})
+		})
+
+		When("parameter 'port' is set", func() {
+			It("should convert to ports.dns", func() {
+				ports := ListenConfig([]string{"5333"})
+				c.DNSPorts = ports
+				validateConfig(&c)
+				Expect(c.Ports.DNS).Should(Equal(ports))
+			})
+		})
+
+		When("parameter 'httpPort' is set", func() {
+			It("should convert to ports.http", func() {
+				ports := ListenConfig([]string{"5333"})
+				c.HTTPPorts = ports
+				validateConfig(&c)
+				Expect(c.Ports.HTTP).Should(Equal(ports))
+			})
+		})
+
+		When("parameter 'httpsPort' is set", func() {
+			It("should convert to ports.https", func() {
+				ports := ListenConfig([]string{"5333"})
+				c.HTTPSPorts = ports
+				validateConfig(&c)
+				Expect(c.Ports.HTTPS).Should(Equal(ports))
+			})
+		})
+
+		When("parameter 'tlsPort' is set", func() {
+			It("should convert to ports.tls", func() {
+				ports := ListenConfig([]string{"5333"})
+				c.TLSPorts = ports
+				validateConfig(&c)
+				Expect(c.Ports.TLS).Should(Equal(ports))
+			})
+		})
 	})
 
 	Describe("Creation of Config", func() {
@@ -155,7 +261,7 @@ var _ = Describe("Config", func() {
 		})
 
 		When("bootstrapDns is defined", func() {
-			It("should is backwards compatible", func() {
+			It("should be backwards compatible", func() {
 				cfg := Config{}
 				data := "bootstrapDns: 0.0.0.0"
 
@@ -163,7 +269,7 @@ var _ = Describe("Config", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(cfg.BootstrapDNS.Upstream.Host).Should(Equal("0.0.0.0"))
 			})
-			It("should is backwards compatible", func() {
+			It("should be backwards compatible", func() {
 				cfg := Config{}
 				data := `
 bootstrapDns:
@@ -186,80 +292,6 @@ bootstrapDns:
 				err := unmarshalConfig([]byte(data), &cfg)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("cannot unmarshal !!str `///`"))
-			})
-		})
-
-		When("Deprecated parameter 'disableIPv6' is set", func() {
-			It("should add 'AAAA' to filter.queryTypes", func() {
-				c := &Config{
-					DisableIPv6: true,
-				}
-				validateConfig(c)
-				Expect(c.Filtering.QueryTypes).Should(HaveKey(QType(dns.TypeAAAA)))
-				Expect(c.Filtering.QueryTypes.Contains(dns.Type(dns.TypeAAAA))).Should(BeTrue())
-			})
-		})
-
-		When("Deprecated parameter 'failStartOnListError' is set", func() {
-			var (
-				c Config
-			)
-			BeforeEach(func() {
-				c = Config{
-					Blocking: BlockingConfig{
-						FailStartOnListError: true,
-						StartStrategy:        StartStrategyTypeBlocking,
-					},
-				}
-			})
-			It("should change StartStrategy blocking to failOnError", func() {
-				validateConfig(&c)
-				Expect(c.Blocking.StartStrategy).Should(Equal(StartStrategyTypeFailOnError))
-			})
-			It("shouldn't change StartStrategy if set to fast", func() {
-				c.Blocking.StartStrategy = StartStrategyTypeFast
-				validateConfig(&c)
-				Expect(c.Blocking.StartStrategy).Should(Equal(StartStrategyTypeFast))
-			})
-		})
-
-		When("Deprecated parameter 'logLevel' is set", func() {
-			It("should convert to log.level", func() {
-				c := &Config{
-					LogLevel: log.LevelDebug,
-				}
-				validateConfig(c)
-				Expect(c.Log.Level).Should(Equal(log.LevelDebug))
-			})
-		})
-
-		When("Deprecated parameter 'logFormat' is set", func() {
-			It("should convert to log.format", func() {
-				c := &Config{
-					LogFormat: log.FormatTypeJson,
-				}
-				validateConfig(c)
-				Expect(c.Log.Format).Should(Equal(log.FormatTypeJson))
-			})
-		})
-
-		When("Deprecated parameter 'logPrivacy' is set", func() {
-			It("should convert to log.privacy", func() {
-				c := &Config{
-					LogPrivacy: true,
-				}
-				validateConfig(c)
-				Expect(c.Log.Privacy).Should(BeTrue())
-			})
-		})
-
-		When("Deprecated parameter 'logTimestamp' is set", func() {
-			It("should convert to log.timestamp", func() {
-				c := &Config{
-					LogTimestamp: false,
-				}
-				validateConfig(c)
-				Expect(c.Log.Timestamp).Should(BeFalse())
 			})
 		})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/miekg/dns"
 
 	"github.com/0xERR0R/blocky/helpertest"
-	. "github.com/0xERR0R/blocky/log"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -223,6 +223,46 @@ bootstrapDns:
 			})
 		})
 
+		When("Deprecated parameter 'logLevel' is set", func() {
+			It("should convert to log.level", func() {
+				c := &Config{
+					LogLevel: log.LevelDebug,
+				}
+				validateConfig(c)
+				Expect(c.Log.Level).Should(Equal(log.LevelDebug))
+			})
+		})
+
+		When("Deprecated parameter 'logFormat' is set", func() {
+			It("should convert to log.format", func() {
+				c := &Config{
+					LogFormat: log.FormatTypeJson,
+				}
+				validateConfig(c)
+				Expect(c.Log.Format).Should(Equal(log.FormatTypeJson))
+			})
+		})
+
+		When("Deprecated parameter 'logPrivacy' is set", func() {
+			It("should convert to log.privacy", func() {
+				c := &Config{
+					LogPrivacy: true,
+				}
+				validateConfig(c)
+				Expect(c.Log.Privacy).Should(BeTrue())
+			})
+		})
+
+		When("Deprecated parameter 'logTimestamp' is set", func() {
+			It("should convert to log.timestamp", func() {
+				c := &Config{
+					LogTimestamp: false,
+				}
+				validateConfig(c)
+				Expect(c.Log.Timestamp).Should(BeFalse())
+			})
+		})
+
 		When("config directory does not exist", func() {
 			It("should return error", func() {
 				_, err = LoadConfig(tmpDir.JoinPath("config.yml"), true)
@@ -235,7 +275,7 @@ bootstrapDns:
 				_, err = LoadConfig(tmpDir.JoinPath("config.yml"), false)
 
 				Expect(err).Should(Succeed())
-				Expect(config.LogLevel).Should(Equal(LevelInfo))
+				Expect(config.LogLevel).Should(Equal(log.LevelInfo))
 			})
 		})
 	})

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -204,13 +204,6 @@ redis:
     - redis-sentinel2:26379
     - redis-sentinel3:26379
 
-# optional: DNS listener port(s) and bind ip address(es), default 53 (UDP and TCP). Example: 53, :53, "127.0.0.1:5353,[::1]:5353"
-port: 53
-# optional: Port(s) and bind ip address(es) for DoT (DNS-over-TLS) listener. Example: 853, 127.0.0.1:853
-#tlsPort: 853
-# optional: HTTPS listener port(s) and bind ip address(es), default empty = no http listener. If > 0, will be used for prometheus metrics, pprof, REST API, DoH... Example: 443, :443, 127.0.0.1:443
-httpPort: 4000
-#httpsPort: 443
 # optional: Mininal TLS version that the DoH and DoT server will use
 minTlsServeVersion: 1.3
 # if https port > 0: path to cert and key file for SSL encryption. if not set, self-signed certificate will be generated
@@ -234,6 +227,16 @@ hostsFile:
   refreshPeriod: 30m
   # optional: Whether loopback hosts addresses (127.0.0.0/8 and ::1) should be filtered or not, default: false
   filterLoopback: true
+
+# optional: ports configuration
+ports:
+  # optional: DNS listener port(s) and bind ip address(es), default 53 (UDP and TCP). Example: 53, :53, "127.0.0.1:5353,[::1]:5353"
+  dns: 53
+  # optional: Port(s) and bind ip address(es) for DoT (DNS-over-TLS) listener. Example: 853, 127.0.0.1:853
+  tls: 853
+  # optional: HTTPS listener port(s) and bind ip address(es), default empty = no http listener. If > 0, will be used for prometheus metrics, pprof, REST API, DoH... Example: 443, :443, 127.0.0.1:443
+  https: 443
+  # http: 4000 
 
 # optional: logging configuration
 log:

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -236,7 +236,8 @@ ports:
   tls: 853
   # optional: Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as 192.168.0.1:443. Example: 443, :443, 127.0.0.1:443,[::1]:443
   https: 443
-  # http: 4000 
+  # optional: Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as 192.168.0.1:4000. Example: 4000, :4000, 127.0.0.1:4000,[::1]:4000
+  http: 4000 
 
 # optional: logging configuration
 log:

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -234,7 +234,7 @@ ports:
   dns: 53
   # optional: Port(s) and bind ip address(es) for DoT (DNS-over-TLS) listener. Example: 853, 127.0.0.1:853
   tls: 853
-  # optional: HTTPS listener port(s) and bind ip address(es), default empty = no http listener. If > 0, will be used for prometheus metrics, pprof, REST API, DoH... Example: 443, :443, 127.0.0.1:443
+  # optional: Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as 192.168.0.1:443. Example: 443, :443, 127.0.0.1:443,[::1]:443
   https: 443
   # http: 4000 
 

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -234,14 +234,17 @@ hostsFile:
   refreshPeriod: 30m
   # optional: Whether loopback hosts addresses (127.0.0.0/8 and ::1) should be filtered or not, default: false
   filterLoopback: true
-# optional: Log level (one from debug, info, warn, error). Default: info
-logLevel: info
-# optional: Log format (text or json). Default: text
-logFormat: text
-# optional: log timestamps. Default: true
-logTimestamp: true
-# optional: obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy. Default: false
-logPrivacy: false
+
+# optional: logging configuration
+log:
+  # optional: Log level (one from debug, info, warn, error). Default: info
+  level: info
+  # optional: Log format (text or json). Default: text
+  format: text
+  # optional: log timestamps. Default: true
+  timestamp: true
+  # optional: obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy. Default: false
+  privacy: false
 
 # optional: add EDE error codes to dns response
 ede: 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,35 +11,52 @@ configuration properties as [JSON](config.yml).
 
 ## Basic configuration
 
-| Parameter           | Type                   | Mandatory | Default value | Description                                                                                                                                                                                                                                       |
-|---------------------|------------------------|-----------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| port                | [IP]:port[,[IP]:port]* | no        | 53            | Port(s) and optional bind ip address(es) to serve DNS endpoint (TCP and UDP). If you wish to specify a specific IP, you can do so such as `192.168.0.1:53`. Example: `53`, `:53`, `127.0.0.1:53,[::1]:53`                                         |
-| tlsPort             | [IP]:port[,[IP]:port]* | no        |               | Port(s) and optional bind ip address(es) to serve DoT DNS endpoint (DNS-over-TLS). If you wish to specify a specific IP, you can do so such as `192.168.0.1:853`. Example: `83`, `:853`, `127.0.0.1:853,[::1]:853`                                |
-| httpPort            | [IP]:port[,[IP]:port]* | no        |               | Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:4000`. Example: `4000`, `:4000`, `127.0.0.1:4000,[::1]:4000` |
-| httpsPort           | [IP]:port[,[IP]:port]* | no        |               | Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:443`. Example: `443`, `:443`, `127.0.0.1:443,[::1]:443`     |
-| certFile            | path                   | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated                                                                                                                                        |
-| keyFile             | path                   | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated                                                                                                                                        |
-| dohUserAgent        | string                 | no        |               | HTTP User Agent for DoH upstreams                                                                                                                                                                                                                 |
-| minTlsServeVersion  | string                 | no        | 1.2           | Minimum TLS version that the DoT and DoH server use to serve those encrypted DNS requests                                                                                                                                                         |
-| startVerifyUpstream | bool                   | no        | false         | If true, blocky will fail to start unless at least one upstream server per group is reachable.                                                                                                                                                    |
-| connectIPVersion    | enum (dual, v4, v6)    | no        | dual          | IP version to use for outgoing connections (dual, v4, v6)                                                                                                                                                                                         |
+| Parameter           | Type                | Mandatory | Default value | Description                                                                                                |
+|---------------------|---------------------|-----------|---------------|------------------------------------------------------------------------------------------------------------|
+| certFile            | path                | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated |
+| keyFile             | path                | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated |
+| dohUserAgent        | string              | no        |               | HTTP User Agent for DoH upstreams                                                                          |
+| minTlsServeVersion  | string              | no        | 1.2           | Minimum TLS version that the DoT and DoH server use to serve those encrypted DNS requests                  |
+| startVerifyUpstream | bool                | no        | false         | If true, blocky will fail to start unless at least one upstream server per group is reachable.             |
+| connectIPVersion    | enum (dual, v4, v6) | no        | dual          | IP version to use for outgoing connections (dual, v4, v6)                                                  |
 
 !!! example
 
     ```yaml
-    port: 53
-    httpPort: 4000
-    httpsPort: 443
+    minTlsServeVersion: 1.1
+    connectIPVersion: v4
+    ```
+
+## Ports configuration
+
+All logging port are optional.
+
+| Parameter  | Type                   | Default value | Description                                                                                                                                                                                                                                       |
+|------------|------------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ports.dns   | [IP]:port[,[IP]:port]* | 53            | Port(s) and optional bind ip address(es) to serve DNS endpoint (TCP and UDP). If you wish to specify a specific IP, you can do so such as `192.168.0.1:53`. Example: `53`, `:53`, `127.0.0.1:53,[::1]:53`                                         |
+| ports.tls   | [IP]:port[,[IP]:port]* |               | Port(s) and optional bind ip address(es) to serve DoT DNS endpoint (DNS-over-TLS). If you wish to specify a specific IP, you can do so such as `192.168.0.1:853`. Example: `83`, `:853`, `127.0.0.1:853,[::1]:853`                                |
+| ports.http  | [IP]:port[,[IP]:port]* |               | Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:4000`. Example: `4000`, `:4000`, `127.0.0.1:4000,[::1]:4000` |
+| ports.https | [IP]:port[,[IP]:port]* |               | Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:443`. Example: `443`, `:443`, `127.0.0.1:443,[::1]:443`     |
+
+!!! example
+
+    ```yaml
+    ports: 
+      dns: 53
+      http: 4000
+      https: 443
     ```
 
 ## Logging configuration
 
-| Parameter     | Type                            | Mandatory | Default value | Description                                                                                                                                      |
-|---------------|---------------------------------|-----------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| log.level     | enum (debug, info, warn, error) | no        | info          | Log level                                                                                                                                        |
-| log.format    | enum (text, json)               | no        | text          | Log format (text or json).                                                                                                                       |
-| log.timestamp | bool                            | no        | true          | Log time stamps (true or false).                                                                                                                 |
-| log.privacy   | bool                            | no        | false         | Obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy. |
+All logging options are optional.
+
+| Parameter     | Type                            | Default value | Description                                                                                                                                      |
+|---------------|---------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| log.level     | enum (debug, info, warn, error) | info          | Log level                                                                                                                                        |
+| log.format    | enum (text, json)               | text          | Log format (text or json).                                                                                                                       |
+| log.timestamp | bool                            | true          | Log time stamps (true or false).                                                                                                                 |
+| log.privacy   | bool                            | false         | Obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy. |
 
 !!! example
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,22 +11,18 @@ configuration properties as [JSON](config.yml).
 
 ## Basic configuration
 
-| Parameter           | Type                            | Mandatory | Default value | Description                                                                                                                                                                                                                                       |
-|---------------------|---------------------------------|-----------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| port                | [IP]:port[,[IP]:port]*          | no        | 53            | Port(s) and optional bind ip address(es) to serve DNS endpoint (TCP and UDP). If you wish to specify a specific IP, you can do so such as `192.168.0.1:53`. Example: `53`, `:53`, `127.0.0.1:53,[::1]:53`                                         |
-| tlsPort             | [IP]:port[,[IP]:port]*          | no        |               | Port(s) and optional bind ip address(es) to serve DoT DNS endpoint (DNS-over-TLS). If you wish to specify a specific IP, you can do so such as `192.168.0.1:853`. Example: `83`, `:853`, `127.0.0.1:853,[::1]:853`                                |
-| httpPort            | [IP]:port[,[IP]:port]*          | no        |               | Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:4000`. Example: `4000`, `:4000`, `127.0.0.1:4000,[::1]:4000` |
-| httpsPort           | [IP]:port[,[IP]:port]*          | no        |               | Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:443`. Example: `443`, `:443`, `127.0.0.1:443,[::1]:443`     |
-| certFile            | path                            | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated                                                                                                                                        |
-| keyFile             | path                            | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated                                                                                                                                        |
-| logLevel            | enum (debug, info, warn, error) | no        | info          | Log level                                                                                                                                                                                                                                         |
-| logFormat           | enum (text, json)               | no        | text          | Log format (text or json).                                                                                                                                                                                                                        |
-| logTimestamp        | bool                            | no        | true          | Log time stamps (true or false).                                                                                                                                                                                                                  |
-| logPrivacy          | bool                            | no        | false         | Obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy.                                                                                                  |
-| dohUserAgent        | string                          | no        |               | HTTP User Agent for DoH upstreams                                                                                                                                                                                                                 |
-| minTlsServeVersion  | string                          | no        | 1.2           | Minimum TLS version that the DoT and DoH server use to serve those encrypted DNS requests                                                                                                                                                         |
-| startVerifyUpstream | bool                            | no        | false         | If true, blocky will fail to start unless at least one upstream server per group is reachable.                                                                                                                                                    |
-| connectIPVersion    | enum (dual, v4, v6)             | no        | dual          | IP version to use for outgoing connections (dual, v4, v6)                                                                                                                                                                                         |
+| Parameter           | Type                   | Mandatory | Default value | Description                                                                                                                                                                                                                                       |
+|---------------------|------------------------|-----------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| port                | [IP]:port[,[IP]:port]* | no        | 53            | Port(s) and optional bind ip address(es) to serve DNS endpoint (TCP and UDP). If you wish to specify a specific IP, you can do so such as `192.168.0.1:53`. Example: `53`, `:53`, `127.0.0.1:53,[::1]:53`                                         |
+| tlsPort             | [IP]:port[,[IP]:port]* | no        |               | Port(s) and optional bind ip address(es) to serve DoT DNS endpoint (DNS-over-TLS). If you wish to specify a specific IP, you can do so such as `192.168.0.1:853`. Example: `83`, `:853`, `127.0.0.1:853,[::1]:853`                                |
+| httpPort            | [IP]:port[,[IP]:port]* | no        |               | Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:4000`. Example: `4000`, `:4000`, `127.0.0.1:4000,[::1]:4000` |
+| httpsPort           | [IP]:port[,[IP]:port]* | no        |               | Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:443`. Example: `443`, `:443`, `127.0.0.1:443,[::1]:443`     |
+| certFile            | path                   | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated                                                                                                                                        |
+| keyFile             | path                   | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated                                                                                                                                        |
+| dohUserAgent        | string                 | no        |               | HTTP User Agent for DoH upstreams                                                                                                                                                                                                                 |
+| minTlsServeVersion  | string                 | no        | 1.2           | Minimum TLS version that the DoT and DoH server use to serve those encrypted DNS requests                                                                                                                                                         |
+| startVerifyUpstream | bool                   | no        | false         | If true, blocky will fail to start unless at least one upstream server per group is reachable.                                                                                                                                                    |
+| connectIPVersion    | enum (dual, v4, v6)    | no        | dual          | IP version to use for outgoing connections (dual, v4, v6)                                                                                                                                                                                         |
 
 !!! example
 
@@ -34,7 +30,25 @@ configuration properties as [JSON](config.yml).
     port: 53
     httpPort: 4000
     httpsPort: 443
-    logLevel: info
+    ```
+
+## Logging configuration
+
+| Parameter     | Type                            | Mandatory | Default value | Description                                                                                                                                      |
+|---------------|---------------------------------|-----------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| log.level     | enum (debug, info, warn, error) | no        | info          | Log level                                                                                                                                        |
+| log.format    | enum (text, json)               | no        | text          | Log format (text or json).                                                                                                                       |
+| log.timestamp | bool                            | no        | true          | Log time stamps (true or false).                                                                                                                 |
+| log.privacy   | bool                            | no        | false         | Obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy. |
+
+!!! example
+
+    ```yaml
+    log:
+      level: debug
+      format: json
+      timestamp: false
+      privacy: true
     ```
 
 ## Upstream configuration

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -78,7 +78,8 @@ var _ = Describe("Basic functional tests", func() {
 						"upstream:",
 						"  default:",
 						"    - moka1",
-						"httpPort: 4000",
+						"ports:",
+						"  http: 4000",
 					)
 
 					Expect(err).Should(Succeed())

--- a/e2e/blocking_test.go
+++ b/e2e/blocking_test.go
@@ -23,7 +23,8 @@ var _ = Describe("External lists and query blocking", func() {
 			Context("startStrategy = blocking", func() {
 				BeforeEach(func() {
 					blocky, err = createBlockyContainer(tmpDir,
-						"logLevel: warn",
+						"log:",
+						"  level: warn",
 						"upstream:",
 						"  default:",
 						"    - moka",
@@ -53,7 +54,8 @@ var _ = Describe("External lists and query blocking", func() {
 			Context("startStrategy = failOnError", func() {
 				BeforeEach(func() {
 					blocky, err = createBlockyContainer(tmpDir,
-						"logLevel: warn",
+						"log:",
+						"  level: warn",
 						"upstream:",
 						"  default:",
 						"    - moka",
@@ -89,7 +91,8 @@ var _ = Describe("External lists and query blocking", func() {
 				DeferCleanup(httpServer.Terminate)
 
 				blocky, err = createBlockyContainer(tmpDir,
-					"logLevel: warn",
+					"log:",
+					"  level: warn",
 					"upstream:",
 					"  default:",
 					"    - moka",

--- a/e2e/metrics_test.go
+++ b/e2e/metrics_test.go
@@ -47,7 +47,8 @@ var _ = Describe("Metrics functional tests", func() {
 				"      - http://httpserver1:8080/list1.txt",
 				"    group2:",
 				"      - http://httpserver2:8080/list2.txt",
-				"httpPort: 4000",
+				"ports:",
+				"  http: 4000",
 				"prometheus:",
 				"  enable: true",
 			)

--- a/e2e/querylog_test.go
+++ b/e2e/querylog_test.go
@@ -34,7 +34,8 @@ var _ = Describe("Query logs functional tests", func() {
 			DeferCleanup(database.Terminate)
 
 			blocky, err = createBlockyContainer(tmpDir,
-				"logLevel: warn",
+				"log:",
+				"  level: warn",
 				"upstream:",
 				"  default:",
 				"    - moka1",
@@ -108,7 +109,8 @@ var _ = Describe("Query logs functional tests", func() {
 			DeferCleanup(database.Terminate)
 
 			blocky, err = createBlockyContainer(tmpDir,
-				"logLevel: warn",
+				"log:",
+				"  level: warn",
 				"upstream:",
 				"  default:",
 				"    - moka1",

--- a/e2e/redis_test.go
+++ b/e2e/redis_test.go
@@ -45,7 +45,8 @@ var _ = Describe("Redis configuration tests", func() {
 		When("Redis and 2 blocky instances are configured", func() {
 			BeforeEach(func() {
 				blocky1, err = createBlockyContainer(tmpDir,
-					"logLevel: warn",
+					"log:",
+					"  level: warn",
 					"upstream:",
 					"  default:",
 					"    - moka1",
@@ -57,7 +58,8 @@ var _ = Describe("Redis configuration tests", func() {
 				DeferCleanup(blocky1.Terminate)
 
 				blocky2, err = createBlockyContainer(tmpDir,
-					"logLevel: warn",
+					"log:",
+					"  level: warn",
 					"upstream:",
 					"  default:",
 					"    - moka1",
@@ -98,7 +100,8 @@ var _ = Describe("Redis configuration tests", func() {
 		When("Redis and 1 blocky instance are configured", func() {
 			BeforeEach(func() {
 				blocky1, err = createBlockyContainer(tmpDir,
-					"logLevel: warn",
+					"log:",
+					"  level: warn",
 					"upstream:",
 					"  default:",
 					"    - moka1",
@@ -121,7 +124,8 @@ var _ = Describe("Redis configuration tests", func() {
 
 				By("start other instance of blocky now -> it should load the cache from redis", func() {
 					blocky2, err = createBlockyContainer(tmpDir,
-						"logLevel: warn",
+						"log:",
+						"  level: warn",
 						"upstream:",
 						"  default:",
 						"    - moka1",

--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -17,7 +17,8 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 		When("'startVerifyUpstream' is false and upstream server as IP is not reachable", func() {
 			BeforeEach(func() {
 				blocky, err = createBlockyContainer(tmpDir,
-					"logLevel: warn",
+					"log:",
+					"  level: warn",
 					"upstream:",
 					"  default:",
 					"    - 192.192.192.192",
@@ -35,7 +36,8 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 		When("'startVerifyUpstream' is false and upstream server as host name is not reachable", func() {
 			BeforeEach(func() {
 				blocky, err = createBlockyContainer(tmpDir,
-					"logLevel: warn",
+					"log:",
+					"  level: warn",
 					"upstream:",
 					"  default:",
 					"    - some.wrong.host",

--- a/log/logger.go
+++ b/log/logger.go
@@ -30,11 +30,26 @@ type FormatType int
 // )
 type Level int
 
+// Config defines all logging configurations
+type Config struct {
+	Level     Level      `yaml:"level" default:"info"`
+	Format    FormatType `yaml:"format" default:"text"`
+	Privacy   bool       `yaml:"privacy" default:"false"`
+	Timestamp bool       `yaml:"timestamp" default:"true"`
+}
+
 // nolint:gochecknoinits
 func init() {
 	logger = logrus.New()
 
-	ConfigureLogger(LevelInfo, FormatTypeText, true)
+	defaultConfig := &Config{
+		Level:     LevelInfo,
+		Format:    FormatTypeText,
+		Privacy:   false,
+		Timestamp: true,
+	}
+
+	ConfigureLogger(defaultConfig)
 }
 
 // Log returns the global logger
@@ -56,14 +71,14 @@ func EscapeInput(input string) string {
 }
 
 // ConfigureLogger applies configuration to the global logger
-func ConfigureLogger(logLevel Level, formatType FormatType, logTimestamp bool) {
-	if level, err := logrus.ParseLevel(logLevel.String()); err != nil {
-		logger.Fatalf("invalid log level %s %v", logLevel, err)
+func ConfigureLogger(cfg *Config) {
+	if level, err := logrus.ParseLevel(cfg.Level.String()); err != nil {
+		logger.Fatalf("invalid log level %s %v", cfg.Level, err)
 	} else {
 		logger.SetLevel(level)
 	}
 
-	switch formatType {
+	switch cfg.Format {
 	case FormatTypeText:
 		logFormatter := &prefixed.TextFormatter{
 			TimestampFormat:  "2006-01-02 15:04:05",
@@ -71,7 +86,7 @@ func ConfigureLogger(logLevel Level, formatType FormatType, logTimestamp bool) {
 			ForceFormatting:  true,
 			ForceColors:      false,
 			QuoteEmptyFields: true,
-			DisableTimestamp: !logTimestamp}
+			DisableTimestamp: !cfg.Timestamp}
 
 		logFormatter.SetColorScheme(&prefixed.ColorScheme{
 			PrefixStyle:    "blue+b",

--- a/server/server.go
+++ b/server/server.go
@@ -114,7 +114,7 @@ func retrieveCertificate(cfg *config.Config) (cert tls.Certificate, err error) {
 // NewServer creates new server instance with passed config
 // nolint:funlen
 func NewServer(cfg *config.Config) (server *Server, err error) {
-	log.ConfigureLogger(cfg.LogLevel, cfg.LogFormat, cfg.LogTimestamp)
+	log.ConfigureLogger(&cfg.Log)
 
 	var cert tls.Certificate
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -150,12 +150,14 @@ var _ = BeforeSuite(func() {
 			Upstream: upstreamClient,
 		},
 
-		DNSPorts:   config.ListenConfig{"55555"},
-		TLSPorts:   config.ListenConfig{"8853"},
-		CertFile:   certPem.Path,
-		KeyFile:    keyPem.Path,
-		HTTPPorts:  config.ListenConfig{"4000"},
-		HTTPSPorts: config.ListenConfig{"4443"},
+		Ports: config.PortsConfig{
+			DNS:   config.ListenConfig{"55555"},
+			TLS:   config.ListenConfig{"8853"},
+			HTTP:  config.ListenConfig{"4000"},
+			HTTPS: config.ListenConfig{"4443"},
+		},
+		CertFile: certPem.Path,
+		KeyFile:  keyPem.Path,
 		Prometheus: config.PrometheusConfig{
 			Enable: true,
 			Path:   "/metrics",
@@ -594,7 +596,9 @@ var _ = Describe("Running DNS server", func() {
 							},
 						}},
 					Blocking: config.BlockingConfig{BlockType: "zeroIp"},
-					DNSPorts: config.ListenConfig{":55556"},
+					Ports: config.PortsConfig{
+						DNS: config.ListenConfig{":55556"},
+					},
 				})
 
 				Expect(err).Should(Succeed())
@@ -632,7 +636,9 @@ var _ = Describe("Running DNS server", func() {
 							},
 						}},
 					Blocking: config.BlockingConfig{BlockType: "zeroIp"},
-					DNSPorts: config.ListenConfig{"127.0.0.1:55557"},
+					Ports: config.PortsConfig{
+						DNS: config.ListenConfig{"127.0.0.1:55557"},
+					},
 				})
 
 				Expect(err).Should(Succeed())
@@ -693,7 +699,9 @@ var _ = Describe("Running DNS server", func() {
 		It("should create self-signed certificate if key/cert files are not provided", func() {
 			cfg.KeyFile = ""
 			cfg.CertFile = ""
-			cfg.HTTPSPorts = []string{":14443"}
+			cfg.Ports = config.PortsConfig{
+				HTTPS: []string{":14443"},
+			}
 
 			sut, err := NewServer(&cfg)
 			Expect(err).Should(Succeed())

--- a/util/common.go
+++ b/util/common.go
@@ -20,7 +20,7 @@ var alphanumeric = regexp.MustCompile("[a-zA-Z0-9]")
 
 // Obfuscate replaces all alphanumeric characters with * to obfuscate user sensitive data if LogPrivacy is enabled
 func Obfuscate(in string) string {
-	if config.GetConfig().LogPrivacy {
+	if config.GetConfig().Log.Privacy {
 		return alphanumeric.ReplaceAllString(in, "*")
 	}
 


### PR DESCRIPTION
To declutter the global top level config options  i propose the grouping of ports and logging options as child options of top level options.

Example:
```YAML
ports:
  dns: 43
  http: 4000
  https: 4443
  tls: 853

log:
  level: warn
  format: json
  privacy: true
  timestamp: false
```

Full backward compatibility is provided through `validateConfig` and subsequently `fixDeprecatedLog` and `fixDeprecatedPorts`.

The documentation an unit tests are modified to use the new structure as default.