### PR TITLE
refactor(resolver): only build mocks during tests

### DIFF
--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -45,7 +45,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 	var (
 		sut        *BlockingResolver
 		sutConfig  config.BlockingConfig
-		m          *MockResolver
+		m          *mockResolver
 		mockAnswer *dns.Msg
 
 		err  error
@@ -68,7 +68,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 	})
 
 	JustBeforeEach(func() {
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 		tmp, err := NewBlockingResolver(sutConfig, nil, systemResolverBootstrap)
 		Expect(err).Should(Succeed())

--- a/resolver/bootstrap_test.go
+++ b/resolver/bootstrap_test.go
@@ -134,10 +134,10 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 	})
 
 	Describe("resolving", func() {
-		var bootstrapUpstream *MockResolver
+		var bootstrapUpstream *mockResolver
 
 		BeforeEach(func() {
-			bootstrapUpstream = &MockResolver{}
+			bootstrapUpstream = &mockResolver{}
 
 			sutConfig.BootstrapDNS = config.BootstrapConfig{
 				Upstream: config.Upstream{

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -23,7 +23,7 @@ var _ = Describe("CachingResolver", func() {
 	var (
 		sut        ChainedResolver
 		sutConfig  config.CachingConfig
-		m          *MockResolver
+		m          *mockResolver
 		mockAnswer *dns.Msg
 
 		err  error
@@ -45,7 +45,7 @@ var _ = Describe("CachingResolver", func() {
 
 	JustBeforeEach(func() {
 		sut = NewCachingResolver(sutConfig, nil)
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 		sut.Next(m)
 	})
@@ -548,7 +548,7 @@ var _ = Describe("CachingResolver", func() {
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 1000, dns.Type(dns.TypeA), "1.1.1.1")
 
 				sut = NewCachingResolver(sutConfig, redisClient)
-				m = &MockResolver{}
+				m = &mockResolver{}
 				m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 				sut.Next(m)
 			})

--- a/resolver/client_names_resolver_test.go
+++ b/resolver/client_names_resolver_test.go
@@ -18,14 +18,14 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 	var (
 		sut       *ClientNamesResolver
 		sutConfig config.ClientLookupConfig
-		m         *MockResolver
+		m         *mockResolver
 	)
 
 	JustBeforeEach(func() {
 		res, err := NewClientNamesResolver(sutConfig, nil, false)
 		Expect(err).Should(Succeed())
 		sut = res
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
 	})
@@ -263,7 +263,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 			When("Upstream produces error", func() {
 				BeforeEach(func() {
 					sutConfig = config.ClientLookupConfig{}
-					clientMockResolver := &MockResolver{}
+					clientMockResolver := &mockResolver{}
 					clientMockResolver.On("Resolve", mock.Anything).Return(nil, errors.New("error"))
 					sut.externalResolver = clientMockResolver
 				})
@@ -311,7 +311,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 	Describe("Connstruction", func() {
 		When("upstream is invalid", func() {
 			It("errors during construction", func() {
-				b := TestBootstrap(&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
+				b := newTestBootstrap(&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
 
 				r, err := NewClientNamesResolver(config.ClientLookupConfig{
 					Upstream: config.Upstream{Host: "example.com"},

--- a/resolver/conditional_upstream_resolver_test.go
+++ b/resolver/conditional_upstream_resolver_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), func() {
 	var (
 		sut  ChainedResolver
-		m    *MockResolver
+		m    *mockResolver
 		err  error
 		resp *Response
 	)
@@ -56,7 +56,7 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 					".":         {dotTestUpstream.Start()},
 				}},
 		}, nil, false)
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
 	})
@@ -117,7 +117,7 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 
 	When("upstream is invalid", func() {
 		It("errors during construction", func() {
-			b := TestBootstrap(&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
+			b := newTestBootstrap(&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
 
 			r, err := NewConditionalUpstreamResolver(config.ConditionalUpstreamConfig{
 				Mapping: config.ConditionalUpstreamMapping{

--- a/resolver/custom_dns_resolver_test.go
+++ b/resolver/custom_dns_resolver_test.go
@@ -16,7 +16,7 @@ import (
 var _ = Describe("CustomDNSResolver", func() {
 	var (
 		sut  ChainedResolver
-		m    *MockResolver
+		m    *mockResolver
 		err  error
 		resp *Response
 		cfg  config.CustomDNSConfig
@@ -42,7 +42,7 @@ var _ = Describe("CustomDNSResolver", func() {
 
 	JustBeforeEach(func() {
 		sut = NewCustomDNSResolver(cfg)
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
 	})

--- a/resolver/ede_resolver_test.go
+++ b/resolver/ede_resolver_test.go
@@ -16,7 +16,7 @@ var _ = Describe("EdeResolver", func() {
 	var (
 		sut        *EdeResolver
 		sutConfig  config.EdeConfig
-		m          *MockResolver
+		m          *mockResolver
 		mockAnswer *dns.Msg
 	)
 
@@ -26,7 +26,7 @@ var _ = Describe("EdeResolver", func() {
 
 	JustBeforeEach(func() {
 		if m == nil {
-			m = &MockResolver{}
+			m = &mockResolver{}
 			m.On("Resolve", mock.Anything).Return(&model.Response{
 				Res:    mockAnswer,
 				RType:  model.ResponseTypeCUSTOMDNS,
@@ -92,7 +92,7 @@ var _ = Describe("EdeResolver", func() {
 			resolveErr := errors.New("test")
 
 			BeforeEach(func() {
-				m = &MockResolver{}
+				m = &mockResolver{}
 				m.On("Resolve", mock.Anything).Return(nil, resolveErr)
 			})
 

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -14,7 +14,7 @@ var _ = Describe("FilteringResolver", func() {
 	var (
 		sut        *FilteringResolver
 		sutConfig  config.FilteringConfig
-		m          *MockResolver
+		m          *mockResolver
 		mockAnswer *dns.Msg
 	)
 
@@ -24,7 +24,7 @@ var _ = Describe("FilteringResolver", func() {
 
 	JustBeforeEach(func() {
 		sut = NewFilteringResolver(sutConfig).(*FilteringResolver)
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 		sut.Next(m)
 	})

--- a/resolver/fqdn_only_resolver_test.go
+++ b/resolver/fqdn_only_resolver_test.go
@@ -14,7 +14,7 @@ var _ = Describe("FqdnOnlyResolver", func() {
 	var (
 		sut        *FqdnOnlyResolver
 		sutConfig  config.Config
-		m          *MockResolver
+		m          *mockResolver
 		mockAnswer *dns.Msg
 	)
 
@@ -24,7 +24,7 @@ var _ = Describe("FqdnOnlyResolver", func() {
 
 	JustBeforeEach(func() {
 		sut = NewFqdnOnlyResolver(sutConfig).(*FqdnOnlyResolver)
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 		sut.Next(m)
 	})

--- a/resolver/hosts_file_resolver_test.go
+++ b/resolver/hosts_file_resolver_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("HostsFileResolver", func() {
 	var (
 		sut     *HostsFileResolver
-		m       *MockResolver
+		m       *mockResolver
 		err     error
 		resp    *Response
 		tmpDir  *TmpFolder
@@ -41,7 +41,7 @@ var _ = Describe("HostsFileResolver", func() {
 			FilterLoopback: true,
 		}
 		sut = NewHostsFileResolver(cfg).(*HostsFileResolver)
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
 	})
@@ -53,7 +53,7 @@ var _ = Describe("HostsFileResolver", func() {
 					Filepath: fmt.Sprintf("/tmp/blocky/file-%d", rand.Uint64()),
 					HostsTTL: config.Duration(time.Duration(TTL) * time.Second),
 				}).(*HostsFileResolver)
-				m = &MockResolver{}
+				m = &mockResolver{}
 				m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 				sut.Next(m)
 			})
@@ -71,7 +71,7 @@ var _ = Describe("HostsFileResolver", func() {
 		When("Hosts file is not set", func() {
 			BeforeEach(func() {
 				sut = NewHostsFileResolver(config.HostsFileConfig{}).(*HostsFileResolver)
-				m = &MockResolver{}
+				m = &mockResolver{}
 				m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 				sut.Next(m)
 			})

--- a/resolver/metrics_resolver_test.go
+++ b/resolver/metrics_resolver_test.go
@@ -18,14 +18,14 @@ import (
 var _ = Describe("MetricResolver", func() {
 	var (
 		sut  *MetricsResolver
-		m    *MockResolver
+		m    *mockResolver
 		err  error
 		resp *Response
 	)
 
 	BeforeEach(func() {
 		sut = NewMetricsResolver(config.PrometheusConfig{Enable: true}).(*MetricsResolver)
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
 	})
@@ -47,7 +47,7 @@ var _ = Describe("MetricResolver", func() {
 			})
 			When("Error occurs while request processing", func() {
 				BeforeEach(func() {
-					m = &MockResolver{}
+					m = &mockResolver{}
 					m.On("Resolve", mock.Anything).Return(nil, errors.New("error"))
 					sut.Next(m)
 				})

--- a/resolver/mocks_test.go
+++ b/resolver/mocks_test.go
@@ -1,0 +1,133 @@
+package resolver
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/util"
+
+	"github.com/0xERR0R/blocky/model"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockResolver struct {
+	mock.Mock
+	NextResolver
+
+	ResolveFn  func(req *model.Request) (*model.Response, error)
+	ResponseFn func(req *dns.Msg) *dns.Msg
+	AnswerFn   func(t uint16, qName string) *dns.Msg
+}
+
+func (r *mockResolver) Configuration() []string {
+	args := r.Called()
+
+	return args.Get(0).([]string)
+}
+
+func (r *mockResolver) Resolve(req *model.Request) (*model.Response, error) {
+	args := r.Called(req)
+
+	if r.ResolveFn != nil {
+		return r.ResolveFn(req)
+	}
+
+	if r.ResponseFn != nil {
+		return &model.Response{
+			Res:    r.ResponseFn(req.Req),
+			Reason: "",
+			RType:  model.ResponseTypeRESOLVED,
+		}, nil
+	}
+
+	if r.AnswerFn != nil {
+		for _, question := range req.Req.Question {
+			answer := r.AnswerFn(question.Qtype, question.Name)
+			if answer != nil {
+				return &model.Response{
+					Res:    answer,
+					Reason: "",
+					RType:  model.ResponseTypeRESOLVED,
+				}, nil
+			}
+		}
+
+		response := new(dns.Msg)
+		response.SetRcode(req.Req, dns.RcodeBadName)
+
+		return &model.Response{
+			Res:    response,
+			Reason: "",
+			RType:  model.ResponseTypeRESOLVED,
+		}, nil
+	}
+
+	resp, ok := args.Get(0).(*model.Response)
+
+	if ok {
+		return resp, args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
+// newTestBootstrap creates a test Bootstrap
+func newTestBootstrap(response *dns.Msg) *Bootstrap {
+	bootstrapUpstream := &mockResolver{}
+
+	b, err := NewBootstrap(&config.Config{})
+	util.FatalOnError("can't create bootstrap", err)
+
+	b.resolver = bootstrapUpstream
+	b.upstream = bootstrapUpstream
+
+	if response != nil {
+		bootstrapUpstream.
+			On("Resolve", mock.Anything).
+			Return(&model.Response{Res: response}, nil)
+	}
+
+	return b
+}
+
+// newTestDOHUpstream creates a test DoH Upstream
+func newTestDOHUpstream(fn func(request *dns.Msg) (response *dns.Msg),
+	reqFn ...func(w http.ResponseWriter)) config.Upstream {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+
+		util.FatalOnError("can't read request: ", err)
+
+		msg := new(dns.Msg)
+		err = msg.Unpack(body)
+		util.FatalOnError("can't deserialize message: ", err)
+
+		response := fn(msg)
+		response.SetReply(msg)
+
+		b, err := response.Pack()
+
+		util.FatalOnError("can't serialize message: ", err)
+
+		w.Header().Set("content-type", "application/dns-message")
+
+		for _, f := range reqFn {
+			if f != nil {
+				f(w)
+			}
+		}
+		_, err = w.Write(b)
+
+		util.FatalOnError("can't write response: ", err)
+	}))
+
+	upstream, err := config.ParseUpstream(server.URL)
+
+	util.FatalOnError("can't resolve address: ", err)
+
+	return upstream
+}

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -62,7 +62,7 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 		)
 
 		BeforeEach(func() {
-			b = TestBootstrap(&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
+			b = newTestBootstrap(&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
 
 			upstream = map[string][]config.Upstream{
 				upstreamDefaultCfgName: {
@@ -357,7 +357,7 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 
 	When("upstream is invalid", func() {
 		It("errors during construction", func() {
-			b := TestBootstrap(&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
+			b := newTestBootstrap(&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
 
 			r, err := NewParallelBestResolver(map[string][]config.Upstream{"test": {{Host: "example.com"}}}, b, verifyUpstreams)
 

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -41,7 +41,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 		sutConfig  config.QueryLogConfig
 		err        error
 		resp       *Response
-		m          *MockResolver
+		m          *mockResolver
 		tmpDir     *helpertest.TmpFolder
 		mockAnswer *dns.Msg
 	)
@@ -56,7 +56,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 	JustBeforeEach(func() {
 		sut = NewQueryLoggingResolver(sutConfig).(*QueryLoggingResolver)
 		DeferCleanup(func() { close(sut.logChan) })
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer, Reason: "reason"}, nil)
 		sut.Next(m)
 	})

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -20,8 +20,8 @@ var _ = Describe("RewriterResolver", func() {
 	var (
 		sut       ChainedResolver
 		sutConfig config.RewriteConfig
-		mInner    *MockResolver
-		mNext     *MockResolver
+		mInner    *mockResolver
+		mNext     *mockResolver
 
 		fqdnOriginal  string
 		fqdnRewritten string
@@ -30,8 +30,8 @@ var _ = Describe("RewriterResolver", func() {
 	)
 
 	BeforeEach(func() {
-		mInner = &MockResolver{}
-		mNext = &MockResolver{}
+		mInner = &mockResolver{}
+		mNext = &mockResolver{}
 
 		sutConfig = config.RewriteConfig{Rewrite: map[string]string{"original": "rewritten"}}
 	})

--- a/resolver/sudn_resolver_test.go
+++ b/resolver/sudn_resolver_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("SudnResolver", Label("sudnResolver"), func() {
 	var (
 		sut        *SpecialUseDomainNamesResolver
-		m          *MockResolver
+		m          *mockResolver
 		mockAnswer *dns.Msg
 
 		err  error
@@ -25,7 +25,7 @@ var _ = Describe("SudnResolver", Label("sudnResolver"), func() {
 		mockAnswer, err = util.NewMsgWithAnswer("example.com.", 300, dns.Type(dns.TypeA), "123.145.123.145")
 		Expect(err).Should(Succeed())
 
-		m = &MockResolver{}
+		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 
 		sut = NewSpecialUseDomainNamesResolver().(*SpecialUseDomainNamesResolver)

--- a/resolver/upstream_resolver_test.go
+++ b/resolver/upstream_resolver_test.go
@@ -133,7 +133,7 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 		})
 
 		JustBeforeEach(func() {
-			upstream = TestDOHUpstream(respFn, modifyHTTPRespFn)
+			upstream = newTestDOHUpstream(respFn, modifyHTTPRespFn)
 			sut = newUpstreamResolverUnchecked(upstream, nil)
 
 			// use insecure certificates for test doh upstream


### PR DESCRIPTION
This makes iterating with breaking refactors easier as you can also break the mocks without breaking normal compilation.

Also unexport code only used in the resolver package. Only `MockUDPUpstreamServer` is kept as non test and exported as it is used by the server package.