### PR TITLE
feat(bootstrap): support multiple upstreams

### DIFF
--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -10,11 +10,13 @@ import (
 var _ = Describe("Serve command", func() {
 	When("Serve command is called", func() {
 		It("should start DNS server", func() {
-			config.GetConfig().BootstrapDNS = config.BootstrapConfig{
-				Upstream: config.Upstream{
-					Net:  config.NetProtocolTcpTls,
-					Host: "1.1.1.1",
-					Port: 53,
+			config.GetConfig().BootstrapDNS = []config.BootstrappedUpstreamConfig{
+				{
+					Upstream: config.Upstream{
+						Net:  config.NetProtocolTcpTls,
+						Host: "1.1.1.1",
+						Port: 53,
+					},
 				},
 			}
 

--- a/config/config.go
+++ b/config/config.go
@@ -616,6 +616,18 @@ type CachingConfig struct {
 	PrefetchMaxItemsCount int      `yaml:"prefetchMaxItemsCount"`
 }
 
+func (c *CachingConfig) EnablePrefetch() {
+	const day = 24 * time.Hour
+
+	if c.MaxCachingTime == 0 {
+		// make sure resolver gets enabled
+		c.MaxCachingTime = Duration(day)
+	}
+
+	c.Prefetching = true
+	c.PrefetchThreshold = 0
+}
+
 // QueryLogConfig configuration for the query logging
 type QueryLogConfig struct {
 	Target           string          `yaml:"target"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Config", func() {
 		})
 
 		When("bootstrapDns is defined", func() {
-			It("should be backwards compatible", func() {
+			It("should be backwards compatible to 'single IP syntax'", func() {
 				cfg := Config{}
 				data := "bootstrapDns: 0.0.0.0"
 
@@ -262,7 +262,7 @@ var _ = Describe("Config", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(cfg.BootstrapDNS[0].Upstream.Host).Should(Equal("0.0.0.0"))
 			})
-			It("should be backwards compatible", func() {
+			It("should be backwards compatible to 'single item definition'", func() {
 				cfg := Config{}
 				data := `
 bootstrapDns:
@@ -274,6 +274,24 @@ bootstrapDns:
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(cfg.BootstrapDNS[0].Upstream.Host).Should(Equal("dns.example.com"))
 				Expect(cfg.BootstrapDNS[0].IPs).Should(HaveLen(1))
+			})
+			It("should process list of bootstrap items", func() {
+				cfg := Config{}
+				data := `
+bootstrapDns:
+  - upstream: tcp-tls:dns.example.com
+    ips:
+      - 0.0.0.0
+  - upstream: 1.2.3.4
+`
+				err := unmarshalConfig([]byte(data), &cfg)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cfg.BootstrapDNS).Should(HaveLen(2))
+				Expect(cfg.BootstrapDNS[0].Upstream.Host).Should(Equal("dns.example.com"))
+				Expect(cfg.BootstrapDNS[0].Upstream.Net).Should(Equal(NetProtocolTcpTls))
+				Expect(cfg.BootstrapDNS[0].IPs).Should(HaveLen(1))
+				Expect(cfg.BootstrapDNS[1].Upstream.Host).Should(Equal("1.2.3.4"))
+				Expect(cfg.BootstrapDNS[1].Upstream.Net).Should(Equal(NetProtocolTcpUdp))
 			})
 		})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Config", func() {
 
 				err := unmarshalConfig([]byte(data), &cfg)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(cfg.BootstrapDNS.Upstream.Host).Should(Equal("0.0.0.0"))
+				Expect(cfg.BootstrapDNS[0].Upstream.Host).Should(Equal("0.0.0.0"))
 			})
 			It("should be backwards compatible", func() {
 				cfg := Config{}
@@ -272,8 +272,8 @@ bootstrapDns:
 `
 				err := unmarshalConfig([]byte(data), &cfg)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(cfg.BootstrapDNS.Upstream.Host).Should(Equal("dns.example.com"))
-				Expect(cfg.BootstrapDNS.IPs).Should(HaveLen(1))
+				Expect(cfg.BootstrapDNS[0].Upstream.Host).Should(Equal("dns.example.com"))
+				Expect(cfg.BootstrapDNS[0].IPs).Should(HaveLen(1))
 			})
 		})
 

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -216,9 +216,7 @@ minTlsServeVersion: 1.3
 # optional: use these DNS servers to resolve blacklist urls and upstream DNS servers. It is useful if no system DNS resolver is configured, and/or to encrypt the bootstrap queries.
 bootstrapDns:
   - tcp+udp:1.1.1.1
-  - usptream: https://1.1.1.1/dns-query
-    ips:
-      - 1.1.1.1
+  - https://1.1.1.1/dns-query
   - upstream: https://dns.digitale-gesellschaft.ch/dns-query
     ips:
       - 185.95.218.42

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -213,11 +213,18 @@ minTlsServeVersion: 1.3
 # if https port > 0: path to cert and key file for SSL encryption. if not set, self-signed certificate will be generated
 #certFile: server.crt
 #keyFile: server.key
-# optional: use this DNS server to resolve blacklist urls and upstream DNS servers. Useful if no DNS resolver is configured and blocky needs to resolve a host name. Format net:IP:port, net must be udp or tcp
-bootstrapDns: tcp+udp:1.1.1.1
+# optional: use these DNS servers to resolve blacklist urls and upstream DNS servers. It is useful if no system DNS resolver is configured, and/or to encrypt the bootstrap queries.
+bootstrapDns:
+  - tcp+udp:1.1.1.1
+  - usptream: https://1.1.1.1/dns-query
+    ips:
+      - 1.1.1.1
+  - upstream: https://dns.digitale-gesellschaft.ch/dns-query
+    ips:
+      - 185.95.218.42
 
-filtering:
 # optional: drop all queries with following query types. Default: empty
+filtering:
   queryTypes:
     - AAAA
 
@@ -241,7 +248,7 @@ ports:
   # optional: Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as 192.168.0.1:443. Example: 443, :443, 127.0.0.1:443,[::1]:443
   https: 443
   # optional: Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as 192.168.0.1:4000. Example: 4000, :4000, 127.0.0.1:4000,[::1]:4000
-  http: 4000 
+  http: 4000
 
 # optional: logging configuration
 log:
@@ -255,6 +262,6 @@ log:
   privacy: false
 
 # optional: add EDE error codes to dns response
-ede: 
+ede:
   # enabled if true, Default: false
   enable: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ It is useful if no system DNS resolver is configured, and/or to encrypt the boot
 | upstream  | Upstream (see above) | no                          |               |                                      |
 | ips       | List of IPs          | yes, if upstream is DoT/DoH |               | Only valid if upstream is DoH or DoT |
 
-If you only need to specify upstream, you can use the short form: `bootstrapDns: <upstream>`.
+When using an upstream specified by IP, and not by hostname, you can write only the upstream and skip `ips`.
 
 !!! note
 
@@ -168,9 +168,7 @@ If you only need to specify upstream, you can use the short form: `bootstrapDns:
           - upstream: tcp-tls:dns.example.com
             ips:
             - 123.123.123.123
-          - upstream: https://dns2.example.com/dns-query
-            ips:
-            - 234.234.234.234
+          - upstream: https://234.234.234.234/dns-query
     ```
 
 ## Filtering

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,7 @@ All logging port are optional.
 !!! example
 
     ```yaml
-    ports: 
+    ports:
       dns: 53
       http: 4000
       https: 443
@@ -147,12 +147,12 @@ value by setting the `upstreamTimeout` configuration parameter (in **duration fo
 
 ## Bootstrap DNS configuration
 
-This DNS server is used to resolve upstream DoH and DoT servers that are specified as host names.
-Useful if no system DNS resolver is configured, and to encrypt the bootstrap queries.
+These DNS servers are used to resolve upstream DoH and DoT servers that are specified as host names, and list domains.
+It is useful if no system DNS resolver is configured, and/or to encrypt the bootstrap queries.
 
 | Parameter | Type                 | Mandatory                   | Default value | Description                          |
 |-----------|----------------------|-----------------------------|---------------|--------------------------------------|
-| upstream  | Upstream (see below) | no                          |               |                                      |
+| upstream  | Upstream (see above) | no                          |               |                                      |
 | ips       | List of IPs          | yes, if upstream is DoT/DoH |               | Only valid if upstream is DoH or DoT |
 
 If you only need to specify upstream, you can use the short form: `bootstrapDns: <upstream>`.
@@ -165,9 +165,12 @@ If you only need to specify upstream, you can use the short form: `bootstrapDns:
 
     ```yaml
         bootstrapDns:
-          upstream: tcp-tls:dns.example.com
-          ips:
-          - 123.123.123.123
+          - upstream: tcp-tls:dns.example.com
+            ips:
+            - 123.123.123.123
+          - upstream: https://dns2.example.com/dns-query
+            ips:
+            - 234.234.234.234
     ```
 
 ## Filtering

--- a/log/logger.go
+++ b/log/logger.go
@@ -3,12 +3,15 @@ package log
 //go:generate go run github.com/abice/go-enum -f=$GOFILE --marshal --names
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
+
+const prefixField = "prefix"
 
 // Logger is the global logging instance
 //
@@ -60,7 +63,16 @@ func Log() *logrus.Logger {
 
 // PrefixedLog return the global logger with prefix
 func PrefixedLog(prefix string) *logrus.Entry {
-	return logger.WithField("prefix", prefix)
+	return logger.WithField(prefixField, prefix)
+}
+
+// WithPrefix adds the given prefix to the logger.
+func WithPrefix(logger *logrus.Entry, prefix string) *logrus.Entry {
+	if existingPrefix, ok := logger.Data[prefixField]; ok {
+		prefix = fmt.Sprintf("%s.%s", existingPrefix, prefix)
+	}
+
+	return logger.WithField(prefixField, prefix)
 }
 
 // EscapeInput removes line breaks from input

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -164,7 +164,7 @@ func createDownloader(cfg config.BlockingConfig, bootstrap *Bootstrap) *lists.HT
 }
 
 func setupRedisEnabledSubscriber(c *BlockingResolver) {
-	logger := logger("blocking_resolver")
+	logger := log.PrefixedLog("blocking_resolver")
 
 	go func() {
 		for em := range c.redisClient.EnabledChannel {
@@ -410,7 +410,7 @@ func (r *BlockingResolver) handleBlacklist(groupsToCheck []string,
 
 // Resolve checks the query against the blacklist and delegates to next resolver if domain is not blocked
 func (r *BlockingResolver) Resolve(request *model.Request) (*model.Response, error) {
-	logger := withPrefix(request.Log, "blacklist_resolver")
+	logger := log.WithPrefix(request.Log, "blacklist_resolver")
 	groupsToCheck := r.groupsToCheckForClient(request)
 
 	if len(groupsToCheck) > 0 {

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -29,8 +29,7 @@ type Bootstrap struct {
 	log *logrus.Entry
 
 	resolver    Resolver
-	upstream    Resolver // the upstream that's part of the above resolver
-	upstreamIPs []net.IP // IPs for b.upstream
+	bootstraped bootstrapedResolvers
 
 	systemResolver *net.Resolver
 }
@@ -38,47 +37,38 @@ type Bootstrap struct {
 // NewBootstrap creates and returns a new Bootstrap.
 // Internally, it uses a CachingResolver and an UpstreamResolver.
 func NewBootstrap(cfg *config.Config) (b *Bootstrap, err error) {
-	upstream := cfg.BootstrapDNS.Upstream
 	log := log.PrefixedLog("bootstrap")
-
-	var ips []net.IP
-
-	switch {
-	case upstream.IsDefault():
-		log.Infof("bootstrapDns is not configured, will use system resolver")
-	case upstream.Net == config.NetProtocolTcpUdp:
-		ip := net.ParseIP(upstream.Host)
-		if ip == nil {
-			return nil, fmt.Errorf("bootstrapDns uses %s but is not an IP", upstream.Net)
-		}
-
-		ips = append(ips, ip)
-	default:
-		ips = cfg.BootstrapDNS.IPs
-		if len(ips) == 0 {
-			return nil, fmt.Errorf("bootstrapDns.IPs is required when upstream uses %s", upstream.Net)
-		}
-	}
 
 	// Create b in multiple steps: Bootstrap and UpstreamResolver have a cyclic dependency
 	// This also prevents the GC to clean up these two structs, but is not currently an
 	// issue since they stay allocated until the process terminates
 	b = &Bootstrap{
 		log:            log,
-		upstreamIPs:    ips,
 		systemResolver: net.DefaultResolver, // allow replacing it during tests
 	}
 
-	if upstream.IsDefault() {
+	bootstraped, err := newBootstrapedResolvers(b, cfg.BootstrapDNS)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(bootstraped) == 0 {
+		log.Infof("bootstrapDns is not configured, will use system resolver")
+
 		return b, nil
 	}
 
-	b.upstream = newUpstreamResolverUnchecked(upstream, b)
+	parallelResolver, err := newParallelBestResolver(bootstraped.ResolverGroups())
+	if err != nil {
+		return nil, fmt.Errorf("could not create bootstrap ParallelBestResolver: %w", err)
+	}
+
+	b.bootstraped = bootstraped
 
 	b.resolver = Chain(
 		NewFilteringResolver(cfg.Filtering),
 		NewCachingResolver(cfg.Caching, nil),
-		b.upstream,
+		parallelResolver,
 	)
 
 	return b, nil
@@ -116,9 +106,9 @@ func (b *Bootstrap) resolveUpstream(r Resolver, host string) ([]net.IP, error) {
 		return b.systemResolver.LookupIP(ctx, cfg.ConnectIPVersion.Net(), host)
 	}
 
-	if r == b.upstream {
-		// Special path for b.upstream to avoid infinite recursion
-		return b.upstreamIPs, nil
+	if ips, ok := b.bootstraped[r]; ok {
+		// Special path for bootstraped upstreams to avoid infinite recursion
+		return ips, nil
 	}
 
 	return b.resolve(host, v4v6QTypes)
@@ -230,6 +220,74 @@ func (b *Bootstrap) resolveType(hostname string, qType dns.Type) (ips []net.IP, 
 	}
 
 	return ips, nil
+}
+
+// map of bootstraped resolvers their hardcoded IPs
+type bootstrapedResolvers map[Resolver][]net.IP
+
+func newBootstrapedResolvers(b *Bootstrap, cfg config.BootstrapDNSConfig) (bootstrapedResolvers, error) {
+	upstreamIPs := make(bootstrapedResolvers, len(cfg))
+
+	var multiErr *multierror.Error
+
+	for i, upstreamCfg := range cfg {
+		i := i + 1 // user visible index should start at 1
+
+		upstream := upstreamCfg.Upstream
+
+		var ips []net.IP
+
+		switch {
+		case upstream.IsDefault():
+			multiErr = multierror.Append(
+				multiErr,
+				fmt.Errorf("item %d: upstream not configured (ips=%v)", i, upstreamCfg.IPs),
+			)
+			continue
+		case upstream.Net == config.NetProtocolTcpUdp:
+			ip := net.ParseIP(upstream.Host)
+			if ip == nil {
+				multiErr = multierror.Append(
+					multiErr,
+					fmt.Errorf("item %d: '%s': protocol %s must use IP instead of hostname", i, upstream, upstream.Net),
+				)
+				continue
+			}
+
+			ips = append(ips, ip)
+		default:
+			ips = upstreamCfg.IPs
+			if len(ips) == 0 {
+				multiErr = multierror.Append(
+					multiErr,
+					fmt.Errorf("item %d: '%s': protocol %s requires IPs to be set", i, upstream, upstream.Net),
+				)
+				continue
+			}
+		}
+
+		resolver := newUpstreamResolverUnchecked(upstream, b)
+
+		upstreamIPs[resolver] = ips
+	}
+
+	if multiErr != nil {
+		return nil, fmt.Errorf("invalid bootstrapDns configuration: %w", multiErr)
+	}
+
+	return upstreamIPs, nil
+}
+
+func (br bootstrapedResolvers) ResolverGroups() map[string][]Resolver {
+	resolvers := make([]Resolver, 0, len(br))
+
+	for resolver := range br {
+		resolvers = append(resolvers, resolver)
+	}
+
+	return map[string][]Resolver{
+		upstreamDefaultCfgName: resolvers,
+	}
 }
 
 type IPSet struct {

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/0xERR0R/blocky/cache/expirationcache"
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/evt"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/redis"
 	"github.com/0xERR0R/blocky/util"
@@ -79,7 +80,7 @@ func configureCaches(c *CachingResolver, cfg *config.CachingConfig) {
 }
 
 func setupRedisCacheSubscriber(c *CachingResolver) {
-	logger := logger("caching_resolver")
+	logger := log.PrefixedLog("caching_resolver")
 
 	go func() {
 		for rc := range c.redisClient.CacheChannel {
@@ -101,7 +102,7 @@ func (r *CachingResolver) isPrefetchingDomain(cacheKey string) bool {
 func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.Duration) {
 	qType, domainName := util.ExtractCacheKey(cacheKey)
 
-	logger := logger("caching_resolver")
+	logger := log.PrefixedLog("caching_resolver")
 
 	if r.isPrefetchingDomain(cacheKey) {
 		logger.Debugf("prefetching '%s' (%s)", util.Obfuscate(domainName), qType.String())
@@ -151,7 +152,7 @@ func (r *CachingResolver) Configuration() (result []string) {
 // Resolve checks if the current query result is already in the cache and returns it
 // or delegates to the next resolver
 func (r *CachingResolver) Resolve(request *model.Request) (response *model.Response, err error) {
-	logger := withPrefix(request.Log, "caching_resolver")
+	logger := log.WithPrefix(request.Log, "caching_resolver")
 
 	if r.maxCacheTimeSec < 0 {
 		logger.Debug("skip cache")

--- a/resolver/client_names_resolver.go
+++ b/resolver/client_names_resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0xERR0R/blocky/cache/expirationcache"
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 
@@ -101,7 +102,7 @@ func (r *ClientNamesResolver) getClientNames(request *model.Request) []string {
 		}
 	}
 
-	names := r.resolveClientNames(ip, withPrefix(request.Log, "client_names_resolver"))
+	names := r.resolveClientNames(ip, log.WithPrefix(request.Log, "client_names_resolver"))
 	r.cache.Put(ip.String(), names, time.Hour)
 
 	return names

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 
@@ -82,7 +83,7 @@ func (r *ConditionalUpstreamResolver) processRequest(request *model.Request) (bo
 
 // Resolve uses the conditional resolver to resolve the query
 func (r *ConditionalUpstreamResolver) Resolve(request *model.Request) (*model.Response, error) {
-	logger := withPrefix(request.Log, "conditional_resolver")
+	logger := log.WithPrefix(request.Log, "conditional_resolver")
 
 	if len(r.mapping) > 0 {
 		resolved, resp, err := r.processRequest(request)
@@ -100,7 +101,7 @@ func (r *ConditionalUpstreamResolver) internalResolve(reso Resolver, doFQ, do st
 	req *model.Request,
 ) (*model.Response, error) {
 	// internal request resolution
-	logger := withPrefix(req.Log, "conditional_resolver")
+	logger := log.WithPrefix(req.Log, "conditional_resolver")
 
 	req.Req.Question[0].Name = dns.Fqdn(doFQ)
 	response, err := reso.Resolve(req)

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 
@@ -89,7 +90,7 @@ func (r *CustomDNSResolver) handleReverseDNS(request *model.Request) *model.Resp
 }
 
 func (r *CustomDNSResolver) processRequest(request *model.Request) *model.Response {
-	logger := withPrefix(request.Log, "custom_dns_resolver")
+	logger := log.WithPrefix(request.Log, "custom_dns_resolver")
 
 	response := new(dns.Msg)
 	response.SetReply(request.Req)
@@ -138,7 +139,7 @@ func (r *CustomDNSResolver) processRequest(request *model.Request) *model.Respon
 
 // Resolve uses internal mapping to resolve the query
 func (r *CustomDNSResolver) Resolve(request *model.Request) (*model.Response, error) {
-	logger := withPrefix(request.Log, "custom_dns_resolver")
+	logger := log.WithPrefix(request.Log, "custom_dns_resolver")
 
 	reverseResp := r.handleReverseDNS(request)
 	if reverseResp != nil {

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 	"github.com/miekg/dns"
@@ -64,7 +65,7 @@ func (r *HostsFileResolver) handleReverseDNS(request *model.Request) *model.Resp
 }
 
 func (r *HostsFileResolver) Resolve(request *model.Request) (*model.Response, error) {
-	logger := withPrefix(request.Log, hostsFileResolverLogger)
+	logger := log.WithPrefix(request.Log, hostsFileResolverLogger)
 
 	if r.HostsFilePath == "" {
 		return r.next.Resolve(request)
@@ -143,7 +144,7 @@ func NewHostsFileResolver(cfg config.HostsFileConfig) *HostsFileResolver {
 	}
 
 	if err := r.parseHostsFile(); err != nil {
-		logger := logger(hostsFileResolverLogger)
+		logger := log.PrefixedLog(hostsFileResolverLogger)
 		logger.Warnf("cannot parse hosts file: %s, hosts file resolving is disabled", r.HostsFilePath)
 		r.HostsFilePath = ""
 	} else {
@@ -234,7 +235,7 @@ func (r *HostsFileResolver) periodicUpdate() {
 		for {
 			<-ticker.C
 
-			logger := logger(hostsFileResolverLogger)
+			logger := log.PrefixedLog(hostsFileResolverLogger)
 			logger.WithField("file", r.HostsFilePath).Debug("refreshing hosts file")
 
 			util.LogOnError("can't refresh hosts file: ", r.parseHostsFile())

--- a/resolver/mocks_test.go
+++ b/resolver/mocks_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 
@@ -83,7 +84,7 @@ func newTestBootstrap(response *dns.Msg) *Bootstrap {
 	util.FatalOnError("can't create bootstrap", err)
 
 	b.resolver = bootstrapUpstream
-	b.upstream = bootstrapUpstream
+	b.bootstraped = bootstrapedResolvers{bootstrapUpstream: []net.IP{}}
 
 	if response != nil {
 		bootstrapUpstream.

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 	"github.com/miekg/dns"
@@ -78,7 +79,7 @@ func testResolver(r *UpstreamResolver) error {
 func NewParallelBestResolver(
 	upstreamResolvers map[string][]config.Upstream, bootstrap *Bootstrap, shouldVerifyUpstreams bool,
 ) (Resolver, error) {
-	logger := logger(parallelResolverLogger)
+	logger := log.PrefixedLog(parallelResolverLogger)
 
 	resolverGroups := make(map[string][]Resolver, len(upstreamResolvers))
 
@@ -205,7 +206,7 @@ func (r *ParallelBestResolver) resolversForClient(request *model.Request) (resul
 
 // Resolve sends the query request to multiple upstream resolvers and returns the fastest result
 func (r *ParallelBestResolver) Resolve(request *model.Request) (*model.Response, error) {
-	logger := request.Log.WithField("prefix", parallelResolverLogger)
+	logger := log.WithPrefix(request.Log, parallelResolverLogger)
 
 	resolvers := r.resolversForClient(request)
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -124,14 +124,6 @@ type NamedResolver interface {
 	Name() string
 }
 
-func logger(prefix string) *logrus.Entry {
-	return log.PrefixedLog(prefix)
-}
-
-func withPrefix(logger *logrus.Entry, prefix string) *logrus.Entry {
-	return logger.WithField("prefix", prefix)
-}
-
 // Chain creates a chain of resolvers
 func Chain(resolvers ...Resolver) Resolver {
 	for i, res := range resolvers {

--- a/resolver/rewriter_resolver.go
+++ b/resolver/rewriter_resolver.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 
@@ -60,7 +61,7 @@ func (r *RewriterResolver) Configuration() (result []string) {
 
 // Resolve uses the inner resolver to resolve the rewritten query
 func (r *RewriterResolver) Resolve(request *model.Request) (*model.Response, error) {
-	logger := withPrefix(request.Log, "rewriter_resolver")
+	logger := log.WithPrefix(request.Log, "rewriter_resolver")
 
 	original := request.Req
 

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -226,7 +226,7 @@ func (r UpstreamResolver) String() string {
 
 // Resolve calls external resolver
 func (r *UpstreamResolver) Resolve(request *model.Request) (response *model.Response, err error) {
-	logger := withPrefix(request.Log, "upstream_resolver")
+	logger := log.WithPrefix(request.Log, "upstream_resolver")
 
 	ips, err := r.bootstrap.UpstreamIPs(r)
 	if err != nil {


### PR DESCRIPTION
If more than one upstream is configured, they are raced via a `ParallelBestResolver`.

Other improvements:
- feat(bootstrap): support IP only encrypted DNS
  Also make `tcp+udp` upstreams use any IPs provided.
- feat: always prefetch upstream IPs to avoid stalling user queries
  Otherwise, a request to blocky could end up waiting for 2 DNS requests:
    1. lookup the DNS server IP
    2. forward the user request to the server looked-up in 1
- feat: stack log prefixes to differentiate between log emitters
  The goal is to be able to tell apart logs from difference sources, such as `bootstrap.parallel_best_resolver` and `parallel_best_resolver`.

Also includes #781 so the lint passes here.

Fixes #760.