### PR TITLE
fix(resolver): reduce upstream retry delay

### DIFF
--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -56,6 +56,7 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 			return err
 		},
 		retry.Attempts(uint(cfg.CreationAttempts)),
+		retry.DelayType(retry.FixedDelay),
 		retry.Delay(time.Duration(cfg.CreationCooldown)),
 		retry.OnRetry(func(n uint, err error) {
 			logger(queryLoggingResolverPrefix).Warnf("Error occurred on query writer creation, "+

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -265,6 +265,7 @@ func (r *UpstreamResolver) Resolve(request *model.Request) (response *model.Resp
 		},
 		retry.Attempts(retryAttempts),
 		retry.DelayType(retry.FixedDelay),
+		retry.Delay(1*time.Millisecond),
 		retry.LastErrorOnly(true),
 		retry.RetryIf(func(err error) bool {
 			var netErr net.Error


### PR DESCRIPTION
Default delay is 100ms which is way too much for query retries.

Also checked the other `retry` uses.