### PR TITLE
fix: no initial cache refresh with "fast" start strategy

### DIFF
--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -114,6 +114,9 @@ func NewListCache(t ListCacheType, groupToLinks map[string][]string, refreshPeri
 	var initError error
 	if async {
 		initError = nil
+
+		// start list refresh in the background
+		go b.Refresh()
 	} else {
 		initError = b.refresh(true)
 	}


### PR DESCRIPTION
When startStrategy is "fast", no initial cache refresh was performed

closes #799