### PR TITLE
chore(build): fix deprecated configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,15 +31,15 @@ archives:
   - format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      darwin: macOS
-      linux: Linux
-      freebsd: FreeBSD
-      openbsd: OpenBSD
-      netbsd: NetBSD
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
 snapshot:
   name_template: "{{ .Tag }}-{{.ShortCommit}}"
 checksum:


### PR DESCRIPTION
Archive replacement is deprecated in latest goreleaser version, see https://goreleaser.com/deprecations/#archivesreplacements