### PR TITLE
fix: ignore end of line comments when parsing lists

### DIFF
--- a/cache/stringcache/string_caches.go
+++ b/cache/stringcache/string_caches.go
@@ -179,11 +179,9 @@ type chainedCacheFactory struct {
 	regexCacheFactory  CacheFactory
 }
 
-var regexPattern = regexp.MustCompile("^/.*/$")
-
 func (r *chainedCacheFactory) AddEntry(entry string) {
-	if regexPattern.MatchString(entry) {
-		entry = strings.TrimSpace(strings.Trim(entry, "/"))
+	if strings.HasPrefix(entry, "/") && strings.HasSuffix(entry, "/") {
+		entry = strings.TrimSpace(entry[1 : len(entry)-1])
 		r.regexCacheFactory.AddEntry(entry)
 	} else {
 		r.stringCacheFactory.AddEntry(entry)

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -327,6 +327,11 @@ func processLine(line string) string {
 		return ""
 	}
 
+	// remove end of line comment
+	if idx := strings.IndexRune(line, '#'); idx != -1 {
+		line = line[:idx]
+	}
+
 	if parts := strings.Fields(line); len(parts) > 0 {
 		host := parts[len(parts)-1]
 

--- a/lists/list_cache_test.go
+++ b/lists/list_cache_test.go
@@ -312,6 +312,21 @@ var _ = Describe("ListCache", func() {
 				Expect(group).Should(Equal("gr1"))
 			})
 		})
+		When("file has end of line comment", func() {
+			It("should still parse the domain", func() {
+				lists := map[string][]string{
+					"gr1": {"inlinedomain1.com#a comment\n"},
+				}
+
+				sut, err := NewListCache(ListCacheTypeBlacklist, lists, 0, NewDownloader(),
+					defaultProcessingConcurrency, false)
+				Expect(err).Should(Succeed())
+
+				found, group := sut.Match("inlinedomain1.com", []string{"gr1"})
+				Expect(found).Should(BeTrue())
+				Expect(group).Should(Equal("gr1"))
+			})
+		})
 		When("inline regex content is defined", func() {
 			It("should match", func() {
 				lists := map[string][]string{


### PR DESCRIPTION
Fixes #859.