### PR TITLE
always report group name when populating failed.

### DIFF
--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -236,12 +236,11 @@ func (b *ListCache) refresh(init bool) error {
 			b.groupCaches[group] = cacheForGroup
 			b.lock.Unlock()
 		} else {
-			if init {
-				msg := "Populating group cache failed for group " + group
-				logger().Warn(msg)
-			} else {
-				logger().Warn("Populating of group cache failed, leaving items from last successful download in cache")
+			msg := "Populating group cache failed for group " + group
+			if !init {
+				msg = msg + ", leaving items from last successful download in cache"
 			}
+			logger().Warn(msg)
 		}
 
 		if cacheForGroup != nil {

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -238,7 +238,7 @@ func (b *ListCache) refresh(init bool) error {
 		} else {
 			msg := "Populating group cache failed for group " + group
 			if !init {
-				msg = msg + ", leaving items from last successful download in cache"
+				msg += ", leaving items from last successful download in cache"
 			}
 			logger().Warn(msg)
 		}

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -236,11 +236,15 @@ func (b *ListCache) refresh(init bool) error {
 			b.groupCaches[group] = cacheForGroup
 			b.lock.Unlock()
 		} else {
-			msg := "Populating group cache failed for group " + group
-			if !init {
-				msg += ", leaving items from last successful download in cache"
+			logger := logger().WithFields(logrus.Fields{
+				"group": group,
+			})
+
+			if init {
+				logger.Warn("Populating of group cache failed, cache will be empty until refresh succeeds")
+			} else {
+				logger.Warn("Populating of group cache failed, using existing cache, if any")
 			}
-			logger().Warn(msg)
 		}
 
 		if cacheForGroup != nil {


### PR DESCRIPTION
a small cleanup on error messages