### PR TITLE
fix: wrong prefetch metrics if bootstrap is enabled (#891)

### DIFF
--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -81,9 +81,13 @@ func NewBootstrap(cfg *config.Config) (b *Bootstrap, err error) {
 
 	b.bootstraped = bootstraped
 
+	cachingResolver := NewCachingResolver(cachingCfg, nil)
+	// don't emit any metrics
+	cachingResolver.emitMetricEvents = false
+
 	b.resolver = Chain(
 		NewFilteringResolver(cfg.Filtering),
-		NewCachingResolver(cachingCfg, nil),
+		cachingResolver,
 		parallelResolver,
 	)
 


### PR DESCRIPTION
fixes #891

Current bootstrap implementation also uses the caching resolver with prefetching. This resolver also produces metrics (with the same name). I disabled metrics for bootstrap.