### PR TITLE
refactor: `config.Duration`, and config use and printing

### DIFF
--- a/config/blocking.go
+++ b/config/blocking.go
@@ -24,12 +24,13 @@ type BlockingConfig struct {
 	StartStrategy         StartStrategyType `yaml:"startStrategy" default:"blocking"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *BlockingConfig) IsEnabled() bool {
 	return len(c.ClientGroupsBlock) != 0
 }
 
-func (c *BlockingConfig) LogValues(logger *logrus.Entry) {
+// IsEnabled implements `config.Configurable`.
+func (c *BlockingConfig) LogConfig(logger *logrus.Entry) {
 	logger.Info("clientGroupsBlock:")
 
 	for key, val := range c.ClientGroupsBlock {

--- a/config/blocking.go
+++ b/config/blocking.go
@@ -34,10 +34,10 @@ func (c *BlockingConfig) LogConfig(logger *logrus.Entry) {
 	logger.Info("clientGroupsBlock:")
 
 	for key, val := range c.ClientGroupsBlock {
-		logger.Infof("  %s = %q", key, strings.Join(val, ";"))
+		logger.Infof("  %s = %v", key, val)
 	}
 
-	logger.Infof("blockType = %q", c.BlockType)
+	logger.Infof("blockType = %s", c.BlockType)
 
 	if c.BlockType != "NXDOMAIN" {
 		logger.Infof("blockTTL = %s", c.BlockTTL)
@@ -48,9 +48,9 @@ func (c *BlockingConfig) LogConfig(logger *logrus.Entry) {
 	logger.Infof("failStartOnListError = %t", c.FailStartOnListError)
 
 	if c.RefreshPeriod > 0 {
-		logger.Infof("refresh: every %s", c.RefreshPeriod)
+		logger.Infof("refresh = every %s", c.RefreshPeriod)
 	} else {
-		logger.Infof("refresh: disabled")
+		logger.Debug("refresh = disabled")
 	}
 
 	logger.Info("blacklist:")
@@ -69,11 +69,13 @@ func (c *BlockingConfig) logListGroups(logger *logrus.Entry, listGroups map[stri
 		logger.Infof("%s:", group)
 
 		for _, link := range links {
-			if strings.Contains(link, "\n") {
-				link = "[INLINE DEFINITION]"
-			}
+			if idx := strings.IndexRune(link, '\n'); idx != -1 && idx < len(link) { // found and not last char
+				link = link[:idx] // first line only
 
-			logger.Infof("   - %s", link)
+				logger.Infof("   - %s [...]", link)
+			} else {
+				logger.Infof("   - %s", link)
+			}
 		}
 	}
 }

--- a/config/blocking.go
+++ b/config/blocking.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/0xERR0R/blocky/log"
+	"github.com/sirupsen/logrus"
+)
+
+// BlockingConfig configuration for query blocking
+type BlockingConfig struct {
+	BlackLists        map[string][]string `yaml:"blackLists"`
+	WhiteLists        map[string][]string `yaml:"whiteLists"`
+	ClientGroupsBlock map[string][]string `yaml:"clientGroupsBlock"`
+	BlockType         string              `yaml:"blockType" default:"ZEROIP"`
+	BlockTTL          Duration            `yaml:"blockTTL" default:"6h"`
+	DownloadTimeout   Duration            `yaml:"downloadTimeout" default:"60s"`
+	DownloadAttempts  uint                `yaml:"downloadAttempts" default:"3"`
+	DownloadCooldown  Duration            `yaml:"downloadCooldown" default:"1s"`
+	RefreshPeriod     Duration            `yaml:"refreshPeriod" default:"4h"`
+	// Deprecated
+	FailStartOnListError  bool              `yaml:"failStartOnListError" default:"false"`
+	ProcessingConcurrency uint              `yaml:"processingConcurrency" default:"4"`
+	StartStrategy         StartStrategyType `yaml:"startStrategy" default:"blocking"`
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *BlockingConfig) IsEnabled() bool {
+	return len(c.ClientGroupsBlock) != 0
+}
+
+func (c *BlockingConfig) LogValues(logger *logrus.Entry) {
+	logger.Info("clientGroupsBlock:")
+
+	for key, val := range c.ClientGroupsBlock {
+		logger.Infof("  %s = %q", key, strings.Join(val, ";"))
+	}
+
+	logger.Infof("blockType = %q", c.BlockType)
+
+	if c.BlockType != "NXDOMAIN" {
+		logger.Infof("blockTTL = %s", c.BlockTTL)
+	}
+
+	logger.Infof("downloadTimeout = %s", c.DownloadTimeout)
+
+	logger.Infof("failStartOnListError = %t", c.FailStartOnListError)
+
+	if c.RefreshPeriod > 0 {
+		logger.Infof("refresh: every %s", c.RefreshPeriod)
+	} else {
+		logger.Infof("refresh: disabled")
+	}
+
+	logger.Info("blacklist:")
+	log.WithIndent(logger, "  ", func(logger *logrus.Entry) {
+		c.logListGroups(logger, c.BlackLists)
+	})
+
+	logger.Info("whitelist:")
+	log.WithIndent(logger, "  ", func(logger *logrus.Entry) {
+		c.logListGroups(logger, c.WhiteLists)
+	})
+}
+
+func (c *BlockingConfig) logListGroups(logger *logrus.Entry, listGroups map[string][]string) {
+	for group, links := range listGroups {
+		logger.Infof("%s:", group)
+
+		for _, link := range links {
+			if strings.Contains(link, "\n") {
+				link = "[INLINE DEFINITION]"
+			}
+
+			logger.Infof("   - %s", link)
+		}
+	}
+}

--- a/config/blocking_test.go
+++ b/config/blocking_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"time"
+
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BlockingConfig", func() {
+	var (
+		cfg BlockingConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = BlockingConfig{
+			BlockType: "ZEROIP",
+			BlockTTL:  Duration(time.Minute),
+			BlackLists: map[string][]string{
+				"gr1": {"/a/file/path"},
+			},
+			ClientGroupsBlock: map[string][]string{
+				"default": {"gr1"},
+			},
+			RefreshPeriod: Duration(time.Hour),
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := BlockingConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := BlockingConfig{
+					BlockTTL: Duration(-1),
+				}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages[0]).Should(Equal("clientGroupsBlock:"))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("refresh: every 1 hour")))
+		})
+		When("refresh is disabled", func() {
+			It("should reflect that", func() {
+				cfg.RefreshPeriod = Duration(-1)
+
+				cfg.LogConfig(logger)
+
+				Expect(hook.Calls).ShouldNot(BeEmpty())
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("refresh: disabled")))
+			})
+		})
+	})
+})

--- a/config/blocking_test.go
+++ b/config/blocking_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/creasty/defaults"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("BlockingConfig", func() {
@@ -60,16 +61,25 @@ var _ = Describe("BlockingConfig", func() {
 
 			Expect(hook.Calls).ShouldNot(BeEmpty())
 			Expect(hook.Messages[0]).Should(Equal("clientGroupsBlock:"))
-			Expect(hook.Messages).Should(ContainElement(ContainSubstring("refresh: every 1 hour")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("refresh = every 1 hour")))
 		})
 		When("refresh is disabled", func() {
 			It("should reflect that", func() {
 				cfg.RefreshPeriod = Duration(-1)
 
+				logger.Logger.Level = logrus.InfoLevel
+
 				cfg.LogConfig(logger)
 
 				Expect(hook.Calls).ShouldNot(BeEmpty())
-				Expect(hook.Messages).Should(ContainElement(ContainSubstring("refresh: disabled")))
+				Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("refresh = disabled")))
+
+				logger.Logger.Level = logrus.TraceLevel
+
+				cfg.LogConfig(logger)
+
+				Expect(hook.Calls).ShouldNot(BeEmpty())
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("refresh = disabled")))
 			})
 		})
 	})

--- a/config/caching.go
+++ b/config/caching.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CachingConfig configuration for domain caching
+type CachingConfig struct {
+	MinCachingTime        Duration `yaml:"minTime"`
+	MaxCachingTime        Duration `yaml:"maxTime"`
+	CacheTimeNegative     Duration `yaml:"cacheTimeNegative" default:"30m"`
+	MaxItemsCount         int      `yaml:"maxItemsCount"`
+	Prefetching           bool     `yaml:"prefetching"`
+	PrefetchExpires       Duration `yaml:"prefetchExpires" default:"2h"`
+	PrefetchThreshold     int      `yaml:"prefetchThreshold" default:"5"`
+	PrefetchMaxItemsCount int      `yaml:"prefetchMaxItemsCount"`
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *CachingConfig) IsEnabled() bool {
+	return c.MaxCachingTime > 0
+}
+
+// LogValues implements `config.ValueLogger`.
+func (c *CachingConfig) LogValues(logger *logrus.Entry) {
+	logger.Infof("minCacheTimeInSec = %d", c.MinCachingTime)
+
+	logger.Infof("maxCacheTimeSec = %d", c.MaxCachingTime)
+
+	logger.Infof("cacheTimeNegative = %s", c.CacheTimeNegative)
+
+	logger.Infof("prefetching = %t", c.Prefetching)
+
+	if c.Prefetching {
+		logger.Infof("prefetchExpires = %s", c.PrefetchExpires)
+		logger.Infof("prefetchThreshold = %d", c.PrefetchThreshold)
+		logger.Infof("prefetchMaxItemsCount = %d", c.PrefetchMaxItemsCount)
+	}
+}
+
+func (c *CachingConfig) EnablePrefetch() {
+	const day = Duration(24 * time.Hour)
+
+	if c.MaxCachingTime.IsZero() {
+		// make sure resolver gets enabled
+		c.MaxCachingTime = day
+	}
+
+	c.Prefetching = true
+	c.PrefetchThreshold = 0
+}

--- a/config/caching.go
+++ b/config/caching.go
@@ -18,13 +18,13 @@ type CachingConfig struct {
 	PrefetchMaxItemsCount int      `yaml:"prefetchMaxItemsCount"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *CachingConfig) IsEnabled() bool {
 	return c.MaxCachingTime > 0
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *CachingConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *CachingConfig) LogConfig(logger *logrus.Entry) {
 	logger.Infof("minCacheTimeInSec = %d", c.MinCachingTime)
 
 	logger.Infof("maxCacheTimeSec = %d", c.MaxCachingTime)

--- a/config/caching.go
+++ b/config/caching.go
@@ -25,18 +25,17 @@ func (c *CachingConfig) IsEnabled() bool {
 
 // LogConfig implements `config.Configurable`.
 func (c *CachingConfig) LogConfig(logger *logrus.Entry) {
-	logger.Infof("minCacheTimeInSec = %d", c.MinCachingTime)
-
-	logger.Infof("maxCacheTimeSec = %d", c.MaxCachingTime)
-
+	logger.Infof("minTime = %s", c.MinCachingTime)
+	logger.Infof("maxTime = %s", c.MaxCachingTime)
 	logger.Infof("cacheTimeNegative = %s", c.CacheTimeNegative)
 
-	logger.Infof("prefetching = %t", c.Prefetching)
-
 	if c.Prefetching {
-		logger.Infof("prefetchExpires = %s", c.PrefetchExpires)
-		logger.Infof("prefetchThreshold = %d", c.PrefetchThreshold)
-		logger.Infof("prefetchMaxItemsCount = %d", c.PrefetchMaxItemsCount)
+		logger.Infof("prefetching:")
+		logger.Infof("  expires   = %s", c.PrefetchExpires)
+		logger.Infof("  threshold = %d", c.PrefetchThreshold)
+		logger.Infof("  maxItems  = %d", c.PrefetchMaxItemsCount)
+	} else {
+		logger.Debug("prefetching: disabled")
 	}
 }
 

--- a/config/caching_test.go
+++ b/config/caching_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"time"
+
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CachingConfig", func() {
+	var (
+		cfg CachingConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = CachingConfig{
+			MaxCachingTime: Duration(time.Hour),
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := CachingConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("the config is enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("the config is disabled", func() {
+			It("should be false", func() {
+				cfg := CachingConfig{
+					MaxCachingTime: Duration(-1),
+				}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		When("prefetching is enabled", func() {
+			BeforeEach(func() {
+				cfg = CachingConfig{
+					Prefetching: true,
+				}
+			})
+
+			It("should return configuration", func() {
+				cfg.LogConfig(logger)
+
+				Expect(hook.Calls).ShouldNot(BeEmpty())
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetching = true")))
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetchExpires = ")))
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetchThreshold = ")))
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetchMaxItemsCount = ")))
+			})
+		})
+	})
+})

--- a/config/caching_test.go
+++ b/config/caching_test.go
@@ -58,10 +58,7 @@ var _ = Describe("CachingConfig", func() {
 				cfg.LogConfig(logger)
 
 				Expect(hook.Calls).ShouldNot(BeEmpty())
-				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetching = true")))
-				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetchExpires = ")))
-				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetchThreshold = ")))
-				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetchMaxItemsCount = ")))
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("prefetching:")))
 			})
 		})
 	})

--- a/config/client_lookup.go
+++ b/config/client_lookup.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"net"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ClientLookupConfig configuration for the client lookup
+type ClientLookupConfig struct {
+	ClientnameIPMapping map[string][]net.IP `yaml:"clients"`
+	Upstream            Upstream            `yaml:"upstream"`
+	SingleNameOrder     []uint              `yaml:"singleNameOrder"`
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *ClientLookupConfig) IsEnabled() bool {
+	return !c.Upstream.IsDefault() || len(c.ClientnameIPMapping) != 0
+}
+
+// LogValues implements `config.ValueLogger`.
+func (c *ClientLookupConfig) LogValues(logger *logrus.Entry) {
+	logger.Infof("singleNameOrder = \"%v\"", c.SingleNameOrder)
+
+	if !c.Upstream.IsDefault() {
+		logger.Infof("upstream = %q", c.Upstream)
+	}
+
+	if len(c.ClientnameIPMapping) > 0 {
+		logger.Infof("client IP mapping:")
+
+		for k, v := range c.ClientnameIPMapping {
+			logger.Infof("%s -> %s", k, v)
+		}
+	}
+}

--- a/config/client_lookup.go
+++ b/config/client_lookup.go
@@ -13,13 +13,13 @@ type ClientLookupConfig struct {
 	SingleNameOrder     []uint              `yaml:"singleNameOrder"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *ClientLookupConfig) IsEnabled() bool {
 	return !c.Upstream.IsDefault() || len(c.ClientnameIPMapping) != 0
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *ClientLookupConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *ClientLookupConfig) LogConfig(logger *logrus.Entry) {
 	logger.Infof("singleNameOrder = \"%v\"", c.SingleNameOrder)
 
 	if !c.Upstream.IsDefault() {

--- a/config/client_lookup.go
+++ b/config/client_lookup.go
@@ -20,17 +20,17 @@ func (c *ClientLookupConfig) IsEnabled() bool {
 
 // LogConfig implements `config.Configurable`.
 func (c *ClientLookupConfig) LogConfig(logger *logrus.Entry) {
-	logger.Infof("singleNameOrder = \"%v\"", c.SingleNameOrder)
-
 	if !c.Upstream.IsDefault() {
-		logger.Infof("upstream = %q", c.Upstream)
+		logger.Infof("upstream = %s", c.Upstream)
 	}
+
+	logger.Infof("singleNameOrder = %v", c.SingleNameOrder)
 
 	if len(c.ClientnameIPMapping) > 0 {
 		logger.Infof("client IP mapping:")
 
 		for k, v := range c.ClientnameIPMapping {
-			logger.Infof("%s -> %s", k, v)
+			logger.Infof("  %s = %s", k, v)
 		}
 	}
 }

--- a/config/client_lookup_test.go
+++ b/config/client_lookup_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"net"
+
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ClientLookupConfig", func() {
+	var (
+		cfg ClientLookupConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = ClientLookupConfig{
+			Upstream:        Upstream{Net: NetProtocolTcpUdp, Host: "host"},
+			SingleNameOrder: []uint{1, 2},
+			ClientnameIPMapping: map[string][]net.IP{
+				"client8": {net.ParseIP("1.2.3.5")},
+			},
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg = ClientLookupConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				By("upstream", func() {
+					cfg := ClientLookupConfig{
+						Upstream:            Upstream{Net: NetProtocolTcpUdp, Host: "host"},
+						ClientnameIPMapping: nil,
+					}
+
+					Expect(cfg.IsEnabled()).Should(BeTrue())
+				})
+
+				By("mapping", func() {
+					cfg := ClientLookupConfig{
+						ClientnameIPMapping: map[string][]net.IP{
+							"client8": {net.ParseIP("1.2.3.5")},
+						},
+					}
+
+					Expect(cfg.IsEnabled()).Should(BeTrue())
+				})
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("client IP mapping:")))
+		})
+	})
+})

--- a/config/conditional_upstream.go
+++ b/config/conditional_upstream.go
@@ -26,10 +26,8 @@ func (c *ConditionalUpstreamConfig) IsEnabled() bool {
 // LogConfig implements `config.Configurable`.
 func (c *ConditionalUpstreamConfig) LogConfig(logger *logrus.Entry) {
 	for key, val := range c.Mapping.Upstreams {
-		logger.Infof("%s = %q", key, val)
+		logger.Infof("%s = %v", key, val)
 	}
-
-	c.RewriterConfig.LogConfig(logger)
 }
 
 // UnmarshalYAML implements `yaml.Unmarshaler`.

--- a/config/conditional_upstream.go
+++ b/config/conditional_upstream.go
@@ -18,18 +18,18 @@ type ConditionalUpstreamMapping struct {
 	Upstreams map[string][]Upstream
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *ConditionalUpstreamConfig) IsEnabled() bool {
 	return len(c.Mapping.Upstreams) != 0
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *ConditionalUpstreamConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *ConditionalUpstreamConfig) LogConfig(logger *logrus.Entry) {
 	for key, val := range c.Mapping.Upstreams {
 		logger.Infof("%s = %q", key, val)
 	}
 
-	c.RewriteConfig.LogValues(logger)
+	c.RewriteConfig.LogConfig(logger)
 }
 
 // UnmarshalYAML implements `yaml.Unmarshaler`.

--- a/config/conditional_upstream.go
+++ b/config/conditional_upstream.go
@@ -9,8 +9,8 @@ import (
 
 // ConditionalUpstreamConfig conditional upstream configuration
 type ConditionalUpstreamConfig struct {
-	RewriteConfig `yaml:",inline"`
-	Mapping       ConditionalUpstreamMapping `yaml:"mapping"`
+	RewriterConfig `yaml:",inline"`
+	Mapping        ConditionalUpstreamMapping `yaml:"mapping"`
 }
 
 // ConditionalUpstreamMapping mapping for conditional configuration
@@ -29,7 +29,7 @@ func (c *ConditionalUpstreamConfig) LogConfig(logger *logrus.Entry) {
 		logger.Infof("%s = %q", key, val)
 	}
 
-	c.RewriteConfig.LogConfig(logger)
+	c.RewriterConfig.LogConfig(logger)
 }
 
 // UnmarshalYAML implements `yaml.Unmarshaler`.

--- a/config/conditional_upstream_test.go
+++ b/config/conditional_upstream_test.go
@@ -58,7 +58,6 @@ var _ = Describe("ConditionalUpstreamConfig", func() {
 
 			Expect(hook.Calls).ShouldNot(BeEmpty())
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("fritz.box = ")))
-			Expect(hook.Messages).Should(ContainElement(ContainSubstring("rewrite:")))
 		})
 	})
 

--- a/config/conditional_upstream_test.go
+++ b/config/conditional_upstream_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ConditionalUpstreamConfig", func() {
+	var (
+		cfg ConditionalUpstreamConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = ConditionalUpstreamConfig{
+			Mapping: ConditionalUpstreamMapping{
+				Upstreams: map[string][]Upstream{
+					"fritz.box": {Upstream{Net: NetProtocolTcpUdp, Host: "fbTest"}},
+					"other.box": {Upstream{Net: NetProtocolTcpUdp, Host: "otherTest"}},
+					".":         {Upstream{Net: NetProtocolTcpUdp, Host: "dotTest"}},
+				},
+			},
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := ConditionalUpstreamConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := ConditionalUpstreamConfig{
+					Mapping: ConditionalUpstreamMapping{Upstreams: map[string][]Upstream{}},
+				}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("fritz.box = ")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("rewrite:")))
+		})
+	})
+
+	Describe("UnmarshalYAML", func() {
+		It("Should parse config as map", func() {
+			c := &ConditionalUpstreamMapping{}
+			err := c.UnmarshalYAML(func(i interface{}) error {
+				*i.(*map[string]string) = map[string]string{"key": "1.2.3.4"}
+
+				return nil
+			})
+			Expect(err).Should(Succeed())
+			Expect(c.Upstreams).Should(HaveLen(1))
+			Expect(c.Upstreams["key"]).Should(HaveLen(1))
+			Expect(c.Upstreams["key"][0]).Should(Equal(Upstream{
+				Net: NetProtocolTcpUdp, Host: "1.2.3.4", Port: 53,
+			}))
+		})
+
+		It("should fail if wrong YAML format", func() {
+			c := &ConditionalUpstreamMapping{}
+			err := c.UnmarshalYAML(func(i interface{}) error {
+				return errors.New("some err")
+			})
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(MatchError("some err"))
+		})
+	})
+})

--- a/config/config.go
+++ b/config/config.go
@@ -447,7 +447,7 @@ func extractNet(upstream string) (NetProtocol, string) {
 //nolint:maligned
 type Config struct {
 	Upstream            UpstreamConfig            `yaml:"upstream"`
-	UpstreamTimeout     Duration                  `yaml:"upstreamTimeout" default:"\"2s\""`
+	UpstreamTimeout     Duration                  `yaml:"upstreamTimeout" default:"2s"`
 	ConnectIPVersion    IPVersion                 `yaml:"connectIPVersion"`
 	CustomDNS           CustomDNSConfig           `yaml:"customDNS"`
 	Conditional         ConditionalUpstreamConfig `yaml:"conditional"`
@@ -531,7 +531,7 @@ type RewriteConfig struct {
 // CustomDNSConfig custom DNS configuration
 type CustomDNSConfig struct {
 	RewriteConfig       `yaml:",inline"`
-	CustomTTL           Duration         `yaml:"customTTL" default:"\"1h\""`
+	CustomTTL           Duration         `yaml:"customTTL" default:"1h"`
 	Mapping             CustomDNSMapping `yaml:"mapping"`
 	FilterUnmappedTypes bool             `yaml:"filterUnmappedTypes" default:"true"`
 }
@@ -558,11 +558,11 @@ type BlockingConfig struct {
 	WhiteLists        map[string][]string `yaml:"whiteLists"`
 	ClientGroupsBlock map[string][]string `yaml:"clientGroupsBlock"`
 	BlockType         string              `yaml:"blockType" default:"ZEROIP"`
-	BlockTTL          Duration            `yaml:"blockTTL" default:"\"6h\""`
-	DownloadTimeout   Duration            `yaml:"downloadTimeout" default:"\"60s\""`
+	BlockTTL          Duration            `yaml:"blockTTL" default:"6h"`
+	DownloadTimeout   Duration            `yaml:"downloadTimeout" default:"60s"`
 	DownloadAttempts  uint                `yaml:"downloadAttempts" default:"3"`
-	DownloadCooldown  Duration            `yaml:"downloadCooldown" default:"\"1s\""`
-	RefreshPeriod     Duration            `yaml:"refreshPeriod" default:"\"4h\""`
+	DownloadCooldown  Duration            `yaml:"downloadCooldown" default:"1s"`
+	RefreshPeriod     Duration            `yaml:"refreshPeriod" default:"4h"`
 	// Deprecated
 	FailStartOnListError  bool              `yaml:"failStartOnListError" default:"false"`
 	ProcessingConcurrency uint              `yaml:"processingConcurrency" default:"4"`
@@ -580,10 +580,10 @@ type ClientLookupConfig struct {
 type CachingConfig struct {
 	MinCachingTime        Duration `yaml:"minTime"`
 	MaxCachingTime        Duration `yaml:"maxTime"`
-	CacheTimeNegative     Duration `yaml:"cacheTimeNegative" default:"\"30m\""`
+	CacheTimeNegative     Duration `yaml:"cacheTimeNegative" default:"30m"`
 	MaxItemsCount         int      `yaml:"maxItemsCount"`
 	Prefetching           bool     `yaml:"prefetching"`
-	PrefetchExpires       Duration `yaml:"prefetchExpires" default:"\"2h\""`
+	PrefetchExpires       Duration `yaml:"prefetchExpires" default:"2h"`
 	PrefetchThreshold     int      `yaml:"prefetchThreshold" default:"5"`
 	PrefetchMaxItemsCount int      `yaml:"prefetchMaxItemsCount"`
 }
@@ -593,7 +593,7 @@ func (c *CachingConfig) EnablePrefetch() {
 
 	if c.MaxCachingTime.IsZero() {
 		// make sure resolver gets enabled
-		c.MaxCachingTime = NewDuration(day)
+		c.MaxCachingTime = Duration(day)
 	}
 
 	c.Prefetching = true
@@ -606,7 +606,7 @@ type QueryLogConfig struct {
 	Type             QueryLogType    `yaml:"type"`
 	LogRetentionDays uint64          `yaml:"logRetentionDays"`
 	CreationAttempts int             `yaml:"creationAttempts" default:"3"`
-	CreationCooldown Duration        `yaml:"creationCooldown" default:"\"2s\""`
+	CreationCooldown Duration        `yaml:"creationCooldown" default:"2s"`
 	Fields           []QueryLogField `yaml:"fields"`
 }
 
@@ -618,7 +618,7 @@ type RedisConfig struct {
 	Database           int      `yaml:"database" default:"0"`
 	Required           bool     `yaml:"required" default:"false"`
 	ConnectionAttempts int      `yaml:"connectionAttempts" default:"3"`
-	ConnectionCooldown Duration `yaml:"connectionCooldown" default:"\"1s\""`
+	ConnectionCooldown Duration `yaml:"connectionCooldown" default:"1s"`
 	SentinelUsername   string   `yaml:"sentinelUsername" default:""`
 	SentinelPassword   string   `yaml:"sentinelPassword" default:""`
 	SentinelAddresses  []string `yaml:"sentinelAddresses"`

--- a/config/config.go
+++ b/config/config.go
@@ -26,14 +26,14 @@ const (
 	httpsPort = 443
 )
 
-type ValueLogger interface {
+type Configurable interface {
 	// IsEnabled returns true when the receiver is configured.
 	IsEnabled() bool
 
-	// LogValues logs the receiver's configuration.
+	// LogConfig logs the receiver's configuration.
 	//
 	// Calling this method when `IsEnabled` returns false is undefined.
-	LogValues(*logrus.Entry) // TODO: LogConfiguration
+	LogConfig(*logrus.Entry)
 }
 
 // NetProtocol resolver protocol ENUM(
@@ -409,13 +409,13 @@ type toEnable struct {
 	Enable bool `yaml:"enable" default:"false"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *toEnable) IsEnabled() bool {
 	return c.Enable
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *toEnable) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *toEnable) LogConfig(logger *logrus.Entry) {
 	logger.Info("enabled")
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -321,7 +321,7 @@ func extractNet(upstream string) (NetProtocol, string) {
 //
 //nolint:maligned
 type Config struct {
-	Upstream            UpstreamConfig            `yaml:"upstream"`
+	Upstream            ParallelBestConfig        `yaml:"upstream"`
 	UpstreamTimeout     Duration                  `yaml:"upstreamTimeout" default:"2s"`
 	ConnectIPVersion    IPVersion                 `yaml:"connectIPVersion"`
 	CustomDNS           CustomDNSConfig           `yaml:"customDNS"`

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
 
 	"github.com/0xERR0R/blocky/log"
 	"github.com/creasty/defaults"
@@ -26,6 +27,10 @@ const (
 	tlsPort   = 853
 	httpsPort = 443
 )
+
+type ValueLogger interface {
+	LogValues(log *logrus.Entry)
+}
 
 // NetProtocol resolver protocol ENUM(
 // tcp+udp // TCP and UDP protocols
@@ -617,13 +622,6 @@ type RedisConfig struct {
 	SentinelUsername   string   `yaml:"sentinelUsername" default:""`
 	SentinelPassword   string   `yaml:"sentinelPassword" default:""`
 	SentinelAddresses  []string `yaml:"sentinelAddresses"`
-}
-
-type HostsFileConfig struct {
-	Filepath       string   `yaml:"filePath"`
-	HostsTTL       Duration `yaml:"hostsTTL" default:"\"1h\""`
-	RefreshPeriod  Duration `yaml:"refreshPeriod" default:"\"1h\""`
-	FilterLoopback bool     `yaml:"filterLoopback"`
 }
 
 type FilteringConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -154,12 +154,9 @@ func (u Upstream) String() string {
 	return sb.String()
 }
 
-// UnmarshalYAML creates Upstream from YAML
-func (u *Upstream) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var s string
-	if err := unmarshal(&s); err != nil {
-		return err
-	}
+// UnmarshalText implements `encoding.TextUnmarshaler`.
+func (u *Upstream) UnmarshalText(data []byte) error {
+	s := string(data)
 
 	upstream, err := ParseUpstream(s)
 	if err != nil {
@@ -174,12 +171,9 @@ func (u *Upstream) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // ListenConfig is a list of address(es) to listen on
 type ListenConfig []string
 
-// UnmarshalYAML creates ListenConfig from YAML
-func (l *ListenConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var addresses string
-	if err := unmarshal(&addresses); err != nil {
-		return err
-	}
+// UnmarshalText implements `encoding.TextUnmarshaler`.
+func (l *ListenConfig) UnmarshalText(data []byte) error {
+	addresses := string(data)
 
 	*l = strings.Split(addresses, ",")
 
@@ -355,7 +349,7 @@ type Config struct {
 	// Deprecated
 	LogTimestamp bool `yaml:"logTimestamp" default:"true"`
 	// Deprecated
-	DNSPorts ListenConfig `yaml:"port" default:"[\"53\"]"`
+	DNSPorts ListenConfig `yaml:"port" default:"\"53\""`
 	// Deprecated
 	HTTPPorts ListenConfig `yaml:"httpPort"`
 	// Deprecated
@@ -365,7 +359,7 @@ type Config struct {
 }
 
 type PortsConfig struct {
-	DNS   ListenConfig `yaml:"dns" default:"[\"53\"]"`
+	DNS   ListenConfig `yaml:"dns" default:"\"53\""`
 	HTTP  ListenConfig `yaml:"http"`
 	HTTPS ListenConfig `yaml:"https"`
 	TLS   ListenConfig `yaml:"tls"`

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -104,70 +103,6 @@ var netDefaultPort = map[NetProtocol]uint16{
 	NetProtocolHttps:  httpsPort,
 }
 
-// Upstream is the definition of external DNS server
-type Upstream struct {
-	Net        NetProtocol
-	Host       string
-	Port       uint16
-	Path       string
-	CommonName string // Common Name to use for certificate verification; optional. "" uses .Host
-}
-
-// IsDefault returns true if u is the default value
-func (u *Upstream) IsDefault() bool {
-	return *u == Upstream{}
-}
-
-// String returns the string representation of u
-func (u Upstream) String() string {
-	if u.IsDefault() {
-		return "no upstream"
-	}
-
-	var sb strings.Builder
-
-	sb.WriteString(u.Net.String())
-	sb.WriteRune(':')
-
-	if u.Net == NetProtocolHttps {
-		sb.WriteString("//")
-	}
-
-	isIPv6 := strings.ContainsRune(u.Host, ':')
-	if isIPv6 {
-		sb.WriteRune('[')
-		sb.WriteString(u.Host)
-		sb.WriteRune(']')
-	} else {
-		sb.WriteString(u.Host)
-	}
-
-	if u.Port != netDefaultPort[u.Net] {
-		sb.WriteRune(':')
-		sb.WriteString(fmt.Sprint(u.Port))
-	}
-
-	if u.Path != "" {
-		sb.WriteString(u.Path)
-	}
-
-	return sb.String()
-}
-
-// UnmarshalText implements `encoding.TextUnmarshaler`.
-func (u *Upstream) UnmarshalText(data []byte) error {
-	s := string(data)
-
-	upstream, err := ParseUpstream(s)
-	if err != nil {
-		return fmt.Errorf("can't convert upstream '%s': %w", s, err)
-	}
-
-	*u = upstream
-
-	return nil
-}
-
 // ListenConfig is a list of address(es) to listen on
 type ListenConfig []string
 
@@ -217,98 +152,6 @@ func (b *BootstrappedUpstreamConfig) UnmarshalYAML(unmarshal func(interface{}) e
 	*b = BootstrappedUpstreamConfig(c)
 
 	return nil
-}
-
-var validDomain = regexp.MustCompile(
-	`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
-
-// ParseUpstream creates new Upstream from passed string in format [net]:host[:port][/path][#commonname]
-func ParseUpstream(upstream string) (Upstream, error) {
-	var path string
-
-	var port uint16
-
-	commonName, upstream := extractCommonName(upstream)
-
-	n, upstream := extractNet(upstream)
-
-	path, upstream = extractPath(upstream)
-
-	host, portString, err := net.SplitHostPort(upstream)
-
-	// string contains host:port
-	if err == nil {
-		p, err := ConvertPort(portString)
-		if err != nil {
-			err = fmt.Errorf("can't convert port to number (1 - 65535) %w", err)
-
-			return Upstream{}, err
-		}
-
-		port = p
-	} else {
-		// only host, use default port
-		host = upstream
-		port = netDefaultPort[n]
-
-		// trim any IPv6 brackets
-		host = strings.TrimPrefix(host, "[")
-		host = strings.TrimSuffix(host, "]")
-	}
-
-	// validate hostname or ip
-	if ip := net.ParseIP(host); ip == nil {
-		// is not IP
-		if !validDomain.MatchString(host) {
-			return Upstream{}, fmt.Errorf("wrong host name '%s'", host)
-		}
-	}
-
-	return Upstream{
-		Net:        n,
-		Host:       host,
-		Port:       port,
-		Path:       path,
-		CommonName: commonName,
-	}, nil
-}
-
-func extractCommonName(in string) (string, string) {
-	upstream, cn, _ := strings.Cut(in, "#")
-
-	return cn, upstream
-}
-
-func extractPath(in string) (path, upstream string) {
-	slashIdx := strings.Index(in, "/")
-
-	if slashIdx >= 0 {
-		path = in[slashIdx:]
-		upstream = in[:slashIdx]
-	} else {
-		upstream = in
-	}
-
-	return
-}
-
-func extractNet(upstream string) (NetProtocol, string) {
-	tcpUDPPrefix := NetProtocolTcpUdp.String() + ":"
-	if strings.HasPrefix(upstream, tcpUDPPrefix) {
-		return NetProtocolTcpUdp, upstream[len(tcpUDPPrefix):]
-	}
-
-	tcpTLSPrefix := NetProtocolTcpTls.String() + ":"
-	if strings.HasPrefix(upstream, tcpTLSPrefix) {
-		return NetProtocolTcpTls, upstream[len(tcpTLSPrefix):]
-	}
-
-	httpsPrefix := NetProtocolHttps.String() + ":"
-	if strings.HasPrefix(upstream, httpsPrefix) {
-		return NetProtocolHttps, strings.TrimPrefix(upstream[len(httpsPrefix):], "//")
-	}
-
-	return NetProtocolTcpUdp, upstream
 }
 
 // Config main configuration

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/abice/go-enum -f=$GOFILE --marshal --names
+//go:generate go run github.com/abice/go-enum -f=$GOFILE --marshal --names --values
 package config
 
 import (

--- a/config/config.go
+++ b/config/config.go
@@ -208,6 +208,13 @@ type PortsConfig struct {
 	TLS   ListenConfig `yaml:"tls"`
 }
 
+func (c *PortsConfig) LogConfig(logger *logrus.Entry) {
+	logger.Infof("DNS   = %s", c.DNS)
+	logger.Infof("TLS   = %s", c.TLS)
+	logger.Infof("HTTP  = %s", c.HTTP)
+	logger.Infof("HTTPS = %s", c.HTTPS)
+}
+
 // split in two types to avoid infinite recursion. See `BootstrapDNSConfig.UnmarshalYAML`.
 type (
 	BootstrapDNSConfig bootstrapDNSConfig

--- a/config/config.go
+++ b/config/config.go
@@ -591,7 +591,7 @@ type CachingConfig struct {
 func (c *CachingConfig) EnablePrefetch() {
 	const day = 24 * time.Hour
 
-	if c.MaxCachingTime == (Duration{}) {
+	if c.MaxCachingTime.IsZero() {
 		// make sure resolver gets enabled
 		c.MaxCachingTime = NewDuration(day)
 	}

--- a/config/config_enum.go
+++ b/config/config_enum.go
@@ -40,6 +40,15 @@ func IPVersionNames() []string {
 	return tmp
 }
 
+// IPVersionValues returns a list of the values for IPVersion
+func IPVersionValues() []IPVersion {
+	return []IPVersion{
+		IPVersionDual,
+		IPVersionV4,
+		IPVersionV6,
+	}
+}
+
 var _IPVersionMap = map[IPVersion]string{
 	IPVersionDual: _IPVersionName[0:4],
 	IPVersionV4:   _IPVersionName[4:6],
@@ -111,6 +120,15 @@ func NetProtocolNames() []string {
 	tmp := make([]string, len(_NetProtocolNames))
 	copy(tmp, _NetProtocolNames)
 	return tmp
+}
+
+// NetProtocolValues returns a list of the values for NetProtocol
+func NetProtocolValues() []NetProtocol {
+	return []NetProtocol{
+		NetProtocolTcpUdp,
+		NetProtocolTcpTls,
+		NetProtocolHttps,
+	}
 }
 
 var _NetProtocolMap = map[NetProtocol]string{
@@ -188,6 +206,18 @@ func QueryLogFieldNames() []string {
 	tmp := make([]string, len(_QueryLogFieldNames))
 	copy(tmp, _QueryLogFieldNames)
 	return tmp
+}
+
+// QueryLogFieldValues returns a list of the values for QueryLogField
+func QueryLogFieldValues() []QueryLogField {
+	return []QueryLogField{
+		QueryLogFieldClientIP,
+		QueryLogFieldClientName,
+		QueryLogFieldResponseReason,
+		QueryLogFieldResponseAnswer,
+		QueryLogFieldQuestion,
+		QueryLogFieldDuration,
+	}
 }
 
 // String implements the Stringer interface.
@@ -274,6 +304,18 @@ func QueryLogTypeNames() []string {
 	return tmp
 }
 
+// QueryLogTypeValues returns a list of the values for QueryLogType
+func QueryLogTypeValues() []QueryLogType {
+	return []QueryLogType{
+		QueryLogTypeConsole,
+		QueryLogTypeNone,
+		QueryLogTypeMysql,
+		QueryLogTypePostgresql,
+		QueryLogTypeCsv,
+		QueryLogTypeCsvClient,
+	}
+}
+
 var _QueryLogTypeMap = map[QueryLogType]string{
 	QueryLogTypeConsole:    _QueryLogTypeName[0:7],
 	QueryLogTypeNone:       _QueryLogTypeName[7:11],
@@ -351,6 +393,15 @@ func StartStrategyTypeNames() []string {
 	tmp := make([]string, len(_StartStrategyTypeNames))
 	copy(tmp, _StartStrategyTypeNames)
 	return tmp
+}
+
+// StartStrategyTypeValues returns a list of the values for StartStrategyType
+func StartStrategyTypeValues() []StartStrategyType {
+	return []StartStrategyType{
+		StartStrategyTypeBlocking,
+		StartStrategyTypeFailOnError,
+		StartStrategyTypeFast,
+	}
 }
 
 var _StartStrategyTypeMap = map[StartStrategyType]string{

--- a/config/config_suite_test.go
+++ b/config/config_suite_test.go
@@ -6,10 +6,22 @@ import (
 	"github.com/0xERR0R/blocky/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	logger *logrus.Entry
+	hook   *log.MockLoggerHook
 )
 
 func TestConfig(t *testing.T) {
 	log.Silence()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
+}
+
+func suiteBeforeEach() {
+	BeforeEach(func() {
+		logger, hook = log.NewMockEntry()
+	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -364,83 +364,6 @@ bootstrapDns:
 				Expect(err).Should(HaveOccurred())
 			})
 		})
-		Context("ConditionalUpstreamMapping", func() {
-			It("Should parse config as map", func() {
-				c := &ConditionalUpstreamMapping{}
-				err := c.UnmarshalYAML(func(i interface{}) error {
-					*i.(*map[string]string) = map[string]string{"key": "1.2.3.4"}
-
-					return nil
-				})
-				Expect(err).Should(Succeed())
-				Expect(c.Upstreams).Should(HaveLen(1))
-				Expect(c.Upstreams["key"]).Should(HaveLen(1))
-				Expect(c.Upstreams["key"][0]).Should(Equal(Upstream{
-					Net: NetProtocolTcpUdp, Host: "1.2.3.4", Port: 53,
-				}))
-			})
-			It("should fail if wrong YAML format", func() {
-				c := &ConditionalUpstreamMapping{}
-				err := c.UnmarshalYAML(func(i interface{}) error {
-					return errors.New("some err")
-				})
-				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError("some err"))
-			})
-		})
-		Context("CustomDNSMapping", func() {
-			It("Should parse config as map", func() {
-				c := &CustomDNSMapping{}
-				err := c.UnmarshalYAML(func(i interface{}) error {
-					*i.(*map[string]string) = map[string]string{"key": "1.2.3.4"}
-
-					return nil
-				})
-				Expect(err).Should(Succeed())
-				Expect(c.HostIPs).Should(HaveLen(1))
-				Expect(c.HostIPs["key"]).Should(HaveLen(1))
-				Expect(c.HostIPs["key"][0]).Should(Equal(net.ParseIP("1.2.3.4")))
-			})
-			It("should fail if wrong YAML format", func() {
-				c := &CustomDNSMapping{}
-				err := c.UnmarshalYAML(func(i interface{}) error {
-					return errors.New("some err")
-				})
-				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError("some err"))
-			})
-		})
-		Context("QueryTyoe", func() {
-			It("Should parse existing DNS type as string", func() {
-				t := QType(0)
-				err := t.UnmarshalYAML(func(i interface{}) error {
-					*i.(*string) = "AAAA"
-
-					return nil
-				})
-				Expect(err).Should(Succeed())
-				Expect(t).Should(Equal(QType(dns.TypeAAAA)))
-				Expect(t.String()).Should(Equal("AAAA"))
-			})
-			It("should fail if DNS type does not exist", func() {
-				t := QType(0)
-				err := t.UnmarshalYAML(func(i interface{}) error {
-					*i.(*string) = "WRONGTYPE"
-
-					return nil
-				})
-				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("unknown DNS query type: 'WRONGTYPE'"))
-			})
-			It("should fail if wrong YAML format", func() {
-				d := QType(0)
-				err := d.UnmarshalYAML(func(i interface{}) error {
-					return errors.New("some err")
-				})
-				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError("some err"))
-			})
-		})
 	})
 
 	DescribeTable("Upstream parsing",
@@ -620,29 +543,6 @@ bootstrapDns:
 			"tcp-tls:[fd00::6cd4:d7e0:d99d:2952]",
 		),
 	)
-
-	Describe("QTypeSet", func() {
-		It("new should insert given qTypes", func() {
-			set := NewQTypeSet(dns.Type(dns.TypeA))
-			Expect(set).Should(HaveKey(QType(dns.TypeA)))
-			Expect(set.Contains(dns.Type(dns.TypeA))).Should(BeTrue())
-
-			Expect(set).ShouldNot(HaveKey(QType(dns.TypeAAAA)))
-			Expect(set.Contains(dns.Type(dns.TypeAAAA))).ShouldNot(BeTrue())
-		})
-
-		It("should insert given qTypes", func() {
-			set := NewQTypeSet()
-
-			Expect(set).ShouldNot(HaveKey(QType(dns.TypeAAAA)))
-			Expect(set.Contains(dns.Type(dns.TypeAAAA))).ShouldNot(BeTrue())
-
-			set.Insert(dns.Type(dns.TypeAAAA))
-
-			Expect(set).Should(HaveKey(QType(dns.TypeAAAA)))
-			Expect(set.Contains(dns.Type(dns.TypeAAAA))).Should(BeTrue())
-		})
-	})
 })
 
 func defaultTestFileConfig() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -665,8 +665,8 @@ func defaultTestFileConfig() {
 	Expect(config.Blocking.BlackLists).Should(HaveLen(2))
 	Expect(config.Blocking.WhiteLists).Should(HaveLen(1))
 	Expect(config.Blocking.ClientGroupsBlock).Should(HaveLen(2))
-	Expect(config.Blocking.BlockTTL).Should(Equal(NewDuration(time.Minute)))
-	Expect(config.Blocking.RefreshPeriod).Should(Equal(NewDuration(2 * time.Hour)))
+	Expect(config.Blocking.BlockTTL).Should(Equal(Duration(time.Minute)))
+	Expect(config.Blocking.RefreshPeriod).Should(Equal(Duration(2 * time.Hour)))
 	Expect(config.Filtering.QueryTypes).Should(HaveLen(2))
 
 	Expect(config.Caching.MaxCachingTime.IsZero()).Should(BeTrue())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -364,37 +364,6 @@ bootstrapDns:
 				Expect(err).Should(HaveOccurred())
 			})
 		})
-		Context("Duration", func() {
-			It("should parse duration with unit", func() {
-				d := Duration(0)
-				err := d.UnmarshalYAML(func(i interface{}) error {
-					*i.(*string) = "1m20s"
-
-					return nil
-				})
-				Expect(err).Should(Succeed())
-				Expect(d).Should(Equal(Duration(80 * time.Second)))
-				Expect(d.String()).Should(Equal("1 minute 20 seconds"))
-			})
-			It("should fail if duration is in wrong format", func() {
-				d := Duration(0)
-				err := d.UnmarshalYAML(func(i interface{}) error {
-					*i.(*string) = "wrong"
-
-					return nil
-				})
-				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError("time: invalid duration \"wrong\""))
-			})
-			It("should fail if wrong YAML format", func() {
-				d := Duration(0)
-				err := d.UnmarshalYAML(func(i interface{}) error {
-					return errors.New("some err")
-				})
-				Expect(err).Should(HaveOccurred())
-				Expect(err).Should(MatchError("some err"))
-			})
-		})
 		Context("ConditionalUpstreamMapping", func() {
 			It("Should parse config as map", func() {
 				c := &ConditionalUpstreamMapping{}
@@ -696,12 +665,12 @@ func defaultTestFileConfig() {
 	Expect(config.Blocking.BlackLists).Should(HaveLen(2))
 	Expect(config.Blocking.WhiteLists).Should(HaveLen(1))
 	Expect(config.Blocking.ClientGroupsBlock).Should(HaveLen(2))
-	Expect(config.Blocking.BlockTTL).Should(Equal(Duration(time.Minute)))
-	Expect(config.Blocking.RefreshPeriod).Should(Equal(Duration(2 * time.Hour)))
+	Expect(config.Blocking.BlockTTL).Should(Equal(NewDuration(time.Minute)))
+	Expect(config.Blocking.RefreshPeriod).Should(Equal(NewDuration(2 * time.Hour)))
 	Expect(config.Filtering.QueryTypes).Should(HaveLen(2))
 
-	Expect(config.Caching.MaxCachingTime).Should(Equal(Duration(0)))
-	Expect(config.Caching.MinCachingTime).Should(Equal(Duration(0)))
+	Expect(config.Caching.MaxCachingTime.IsZero()).Should(BeTrue())
+	Expect(config.Caching.MinCachingTime.IsZero()).Should(BeTrue())
 
 	Expect(config.DoHUserAgent).Should(Equal("testBlocky"))
 	Expect(config.MinTLSServeVer).Should(Equal("1.3"))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"net"
 	"time"
 
@@ -321,15 +320,11 @@ bootstrapDns:
 		})
 	})
 
-	Describe("YAML parsing", func() {
+	Describe("Parsing", func() {
 		Context("upstream", func() {
 			It("should create the upstream struct with data", func() {
 				u := &Upstream{}
-				err := u.UnmarshalYAML(func(i interface{}) error {
-					*i.(*string) = "tcp+udp:1.2.3.4"
-
-					return nil
-				})
+				err := u.UnmarshalText([]byte("tcp+udp:1.2.3.4"))
 				Expect(err).Should(Succeed())
 				Expect(u.Net).Should(Equal(NetProtocolTcpUdp))
 				Expect(u.Host).Should(Equal("1.2.3.4"))
@@ -338,30 +333,17 @@ bootstrapDns:
 
 			It("should fail if the upstream is in wrong format", func() {
 				u := &Upstream{}
-				err := u.UnmarshalYAML(func(i interface{}) error {
-					return errors.New("some err")
-				})
+				err := u.UnmarshalText([]byte("invalid!"))
 				Expect(err).Should(HaveOccurred())
 			})
 		})
 		Context("ListenConfig", func() {
 			It("should parse and split valid string config", func() {
 				l := &ListenConfig{}
-				err := l.UnmarshalYAML(func(i interface{}) error {
-					*i.(*string) = "55,:56"
-
-					return nil
-				})
+				err := l.UnmarshalText([]byte("55,:56"))
 				Expect(err).Should(Succeed())
 				Expect(*l).Should(HaveLen(2))
 				Expect(*l).Should(ContainElements("55", ":56"))
-			})
-			It("should fail on error", func() {
-				l := &ListenConfig{}
-				err := l.UnmarshalYAML(func(i interface{}) error {
-					return errors.New("some err")
-				})
-				Expect(err).Should(HaveOccurred())
 			})
 		})
 	})

--- a/config/custom_dns.go
+++ b/config/custom_dns.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CustomDNSConfig custom DNS configuration
+type CustomDNSConfig struct {
+	RewriteConfig       `yaml:",inline"`
+	CustomTTL           Duration         `yaml:"customTTL" default:"1h"`
+	Mapping             CustomDNSMapping `yaml:"mapping"`
+	FilterUnmappedTypes bool             `yaml:"filterUnmappedTypes" default:"true"`
+}
+
+// CustomDNSMapping mapping for the custom DNS configuration
+type CustomDNSMapping struct {
+	HostIPs map[string][]net.IP `yaml:"hostIPs"`
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *CustomDNSConfig) IsEnabled() bool {
+	return len(c.Mapping.HostIPs) != 0
+}
+
+// LogValues implements `config.ValueLogger`.
+func (c *CustomDNSConfig) LogValues(logger *logrus.Entry) {
+	for key, val := range c.Mapping.HostIPs {
+		logger.Infof("%s = %q", key, val)
+	}
+
+	c.RewriteConfig.LogValues(logger)
+}
+
+// UnmarshalYAML implements `yaml.Unmarshaler`.
+func (c *CustomDNSMapping) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var input map[string]string
+	if err := unmarshal(&input); err != nil {
+		return err
+	}
+
+	result := make(map[string][]net.IP, len(input))
+
+	for k, v := range input {
+		var ips []net.IP
+
+		for _, part := range strings.Split(v, ",") {
+			ip := net.ParseIP(strings.TrimSpace(part))
+			if ip == nil {
+				return fmt.Errorf("invalid IP address '%s'", part)
+			}
+
+			ips = append(ips, ip)
+		}
+
+		result[k] = ips
+	}
+
+	c.HostIPs = result
+
+	return nil
+}

--- a/config/custom_dns.go
+++ b/config/custom_dns.go
@@ -10,7 +10,7 @@ import (
 
 // CustomDNSConfig custom DNS configuration
 type CustomDNSConfig struct {
-	RewriteConfig       `yaml:",inline"`
+	RewriterConfig      `yaml:",inline"`
 	CustomTTL           Duration         `yaml:"customTTL" default:"1h"`
 	Mapping             CustomDNSMapping `yaml:"mapping"`
 	FilterUnmappedTypes bool             `yaml:"filterUnmappedTypes" default:"true"`
@@ -32,7 +32,7 @@ func (c *CustomDNSConfig) LogConfig(logger *logrus.Entry) {
 		logger.Infof("%s = %q", key, val)
 	}
 
-	c.RewriteConfig.LogConfig(logger)
+	c.RewriterConfig.LogConfig(logger)
 }
 
 // UnmarshalYAML implements `yaml.Unmarshaler`.

--- a/config/custom_dns.go
+++ b/config/custom_dns.go
@@ -21,18 +21,18 @@ type CustomDNSMapping struct {
 	HostIPs map[string][]net.IP `yaml:"hostIPs"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *CustomDNSConfig) IsEnabled() bool {
 	return len(c.Mapping.HostIPs) != 0
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *CustomDNSConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *CustomDNSConfig) LogConfig(logger *logrus.Entry) {
 	for key, val := range c.Mapping.HostIPs {
 		logger.Infof("%s = %q", key, val)
 	}
 
-	c.RewriteConfig.LogValues(logger)
+	c.RewriteConfig.LogConfig(logger)
 }
 
 // UnmarshalYAML implements `yaml.Unmarshaler`.

--- a/config/custom_dns.go
+++ b/config/custom_dns.go
@@ -28,11 +28,14 @@ func (c *CustomDNSConfig) IsEnabled() bool {
 
 // LogConfig implements `config.Configurable`.
 func (c *CustomDNSConfig) LogConfig(logger *logrus.Entry) {
-	for key, val := range c.Mapping.HostIPs {
-		logger.Infof("%s = %q", key, val)
-	}
+	logger.Debugf("TTL = %s", c.CustomTTL)
+	logger.Debugf("filterUnmappedTypes = %t", c.FilterUnmappedTypes)
 
-	c.RewriterConfig.LogConfig(logger)
+	logger.Info("mapping:")
+
+	for key, val := range c.Mapping.HostIPs {
+		logger.Infof("  %s = %s", key, val)
+	}
 }
 
 // UnmarshalYAML implements `yaml.Unmarshaler`.

--- a/config/custom_dns_test.go
+++ b/config/custom_dns_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"errors"
+	"net"
+
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CustomDNSConfig", func() {
+	var (
+		cfg CustomDNSConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = CustomDNSConfig{
+			Mapping: CustomDNSMapping{
+				HostIPs: map[string][]net.IP{
+					"custom.domain": {net.ParseIP("192.168.143.123")},
+					"ip6.domain":    {net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")},
+					"multiple.ips": {
+						net.ParseIP("192.168.143.123"),
+						net.ParseIP("192.168.143.125"),
+						net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+					},
+				},
+			},
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := CustomDNSConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := CustomDNSConfig{}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("custom.domain = ")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("multiple.ips = ")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("rewrite:")))
+		})
+	})
+
+	Describe("UnmarshalYAML", func() {
+		It("Should parse config as map", func() {
+			c := &CustomDNSMapping{}
+			err := c.UnmarshalYAML(func(i interface{}) error {
+				*i.(*map[string]string) = map[string]string{"key": "1.2.3.4"}
+
+				return nil
+			})
+			Expect(err).Should(Succeed())
+			Expect(c.HostIPs).Should(HaveLen(1))
+			Expect(c.HostIPs["key"]).Should(HaveLen(1))
+			Expect(c.HostIPs["key"][0]).Should(Equal(net.ParseIP("1.2.3.4")))
+		})
+
+		It("should fail if wrong YAML format", func() {
+			c := &CustomDNSMapping{}
+			err := c.UnmarshalYAML(func(i interface{}) error {
+				return errors.New("some err")
+			})
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(MatchError("some err"))
+		})
+	})
+})

--- a/config/custom_dns_test.go
+++ b/config/custom_dns_test.go
@@ -62,7 +62,6 @@ var _ = Describe("CustomDNSConfig", func() {
 			Expect(hook.Calls).ShouldNot(BeEmpty())
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("custom.domain = ")))
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("multiple.ips = ")))
-			Expect(hook.Messages).Should(ContainElement(ContainSubstring("rewrite:")))
 		})
 	})
 

--- a/config/duration.go
+++ b/config/duration.go
@@ -23,6 +23,10 @@ func (c Duration) IsZero() bool {
 	return c.Duration == 0
 }
 
+func (c Duration) SecondsU32() uint32 {
+	return uint32(c.Seconds())
+}
+
 func (c Duration) String() string {
 	return durafmt.Parse(c.Cast()).String()
 }

--- a/config/duration.go
+++ b/config/duration.go
@@ -15,20 +15,20 @@ func NewDuration[T constraints.Integer | time.Duration](value T) Duration {
 	return Duration{Duration: time.Duration(value)}
 }
 
-func (c Duration) Cast() time.Duration {
+func (c Duration) ToDuration() time.Duration {
 	return c.Duration
 }
 
 func (c Duration) IsZero() bool {
-	return c.Duration == 0
+	return c.ToDuration() == 0
 }
 
 func (c Duration) SecondsU32() uint32 {
-	return uint32(c.Seconds())
+	return uint32(c.ToDuration().Seconds())
 }
 
 func (c Duration) String() string {
-	return durafmt.Parse(c.Cast()).String()
+	return durafmt.Parse(c.ToDuration()).String()
 }
 
 func (c *Duration) UnmarshalText(data []byte) error {

--- a/config/duration.go
+++ b/config/duration.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/0xERR0R/blocky/log"
+	"github.com/hako/durafmt"
+	"golang.org/x/exp/constraints"
+)
+
+type Duration struct{ time.Duration }
+
+func NewDuration[T constraints.Integer | time.Duration](value T) Duration {
+	return Duration{Duration: time.Duration(value)}
+}
+
+func (c Duration) Cast() time.Duration {
+	return c.Duration
+}
+
+func (c Duration) IsZero() bool {
+	return c.Duration == 0
+}
+
+func (c Duration) String() string {
+	return durafmt.Parse(c.Cast()).String()
+}
+
+func (c *Duration) UnmarshalText(data []byte) error {
+	input := string(data)
+
+	if minutes, err := strconv.Atoi(input); err == nil {
+		// number without unit: use minutes to ensure back compatibility
+		*c = NewDuration(time.Duration(minutes) * time.Minute)
+
+		log.Log().Warnf("Setting a duration without a unit is deprecated. Please use '%s min' instead.", input)
+
+		return nil
+	}
+
+	duration, err := time.ParseDuration(input)
+	if err == nil {
+		*c = NewDuration(duration)
+
+		return nil
+	}
+
+	return err
+}

--- a/config/duration.go
+++ b/config/duration.go
@@ -6,37 +6,37 @@ import (
 
 	"github.com/0xERR0R/blocky/log"
 	"github.com/hako/durafmt"
-	"golang.org/x/exp/constraints"
 )
 
-type Duration struct{ time.Duration }
-
-func NewDuration[T constraints.Integer | time.Duration](value T) Duration {
-	return Duration{Duration: time.Duration(value)}
-}
+type Duration time.Duration
 
 func (c Duration) ToDuration() time.Duration {
-	return c.Duration
+	return time.Duration(c)
 }
 
 func (c Duration) IsZero() bool {
 	return c.ToDuration() == 0
 }
 
+func (c Duration) Seconds() float64 {
+	return c.ToDuration().Seconds()
+}
+
 func (c Duration) SecondsU32() uint32 {
-	return uint32(c.ToDuration().Seconds())
+	return uint32(c.Seconds())
 }
 
 func (c Duration) String() string {
 	return durafmt.Parse(c.ToDuration()).String()
 }
 
+// UnmarshalText implements `encoding.TextUnmarshaler`.
 func (c *Duration) UnmarshalText(data []byte) error {
 	input := string(data)
 
 	if minutes, err := strconv.Atoi(input); err == nil {
 		// number without unit: use minutes to ensure back compatibility
-		*c = NewDuration(time.Duration(minutes) * time.Minute)
+		*c = Duration(time.Duration(minutes) * time.Minute)
 
 		log.Log().Warnf("Setting a duration without a unit is deprecated. Please use '%s min' instead.", input)
 
@@ -45,7 +45,7 @@ func (c *Duration) UnmarshalText(data []byte) error {
 
 	duration, err := time.ParseDuration(input)
 	if err == nil {
-		*c = NewDuration(duration)
+		*c = Duration(duration)
 
 		return nil
 	}

--- a/config/duration_test.go
+++ b/config/duration_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Duration", func() {
+	var d Duration
+
+	It("should parse duration with unit", func() {
+		err := d.UnmarshalText([]byte("1m20s"))
+		Expect(err).Should(Succeed())
+		Expect(d).Should(Equal(NewDuration(80 * time.Second)))
+		Expect(d.String()).Should(Equal("1 minute 20 seconds"))
+	})
+
+	It("should fail if duration is in wrong format", func() {
+		err := d.UnmarshalText([]byte("wrong"))
+		Expect(err).Should(HaveOccurred())
+		Expect(err).Should(MatchError("time: invalid duration \"wrong\""))
+	})
+})

--- a/config/duration_test.go
+++ b/config/duration_test.go
@@ -10,6 +10,12 @@ import (
 var _ = Describe("Duration", func() {
 	var d Duration
 
+	BeforeEach(func() {
+		var zero Duration
+
+		d = zero
+	})
+
 	It("should parse duration with unit", func() {
 		err := d.UnmarshalText([]byte("1m20s"))
 		Expect(err).Should(Succeed())
@@ -21,5 +27,16 @@ var _ = Describe("Duration", func() {
 		err := d.UnmarshalText([]byte("wrong"))
 		Expect(err).Should(HaveOccurred())
 		Expect(err).Should(MatchError("time: invalid duration \"wrong\""))
+	})
+
+	Describe("IsZero", func() {
+		It("should be true for zero", func() {
+			Expect(d.IsZero()).Should(BeTrue())
+			Expect(Duration(0).IsZero()).Should(BeTrue())
+		})
+
+		It("should be false for non-zero", func() {
+			Expect(Duration(time.Second).IsZero()).Should(BeFalse())
+		})
 	})
 })

--- a/config/duration_test.go
+++ b/config/duration_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Duration", func() {
 	It("should parse duration with unit", func() {
 		err := d.UnmarshalText([]byte("1m20s"))
 		Expect(err).Should(Succeed())
-		Expect(d).Should(Equal(NewDuration(80 * time.Second)))
+		Expect(d).Should(Equal(Duration(80 * time.Second)))
 		Expect(d.String()).Should(Equal("1 minute 20 seconds"))
 	})
 

--- a/config/duration_test.go
+++ b/config/duration_test.go
@@ -16,17 +16,19 @@ var _ = Describe("Duration", func() {
 		d = zero
 	})
 
-	It("should parse duration with unit", func() {
-		err := d.UnmarshalText([]byte("1m20s"))
-		Expect(err).Should(Succeed())
-		Expect(d).Should(Equal(Duration(80 * time.Second)))
-		Expect(d.String()).Should(Equal("1 minute 20 seconds"))
-	})
+	Describe("UnmarshalText", func() {
+		It("should parse duration with unit", func() {
+			err := d.UnmarshalText([]byte("1m20s"))
+			Expect(err).Should(Succeed())
+			Expect(d).Should(Equal(Duration(80 * time.Second)))
+			Expect(d.String()).Should(Equal("1 minute 20 seconds"))
+		})
 
-	It("should fail if duration is in wrong format", func() {
-		err := d.UnmarshalText([]byte("wrong"))
-		Expect(err).Should(HaveOccurred())
-		Expect(err).Should(MatchError("time: invalid duration \"wrong\""))
+		It("should fail if duration is in wrong format", func() {
+			err := d.UnmarshalText([]byte("wrong"))
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(MatchError("time: invalid duration \"wrong\""))
+		})
 	})
 
 	Describe("IsZero", func() {

--- a/config/filtering.go
+++ b/config/filtering.go
@@ -8,13 +8,13 @@ type FilteringConfig struct {
 	QueryTypes QTypeSet `yaml:"queryTypes"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *FilteringConfig) IsEnabled() bool {
 	return len(c.QueryTypes) != 0
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *FilteringConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *FilteringConfig) LogConfig(logger *logrus.Entry) {
 	logger.Info("filtering query Types:")
 
 	for qType := range c.QueryTypes {

--- a/config/filtering.go
+++ b/config/filtering.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type FilteringConfig struct {
+	QueryTypes QTypeSet `yaml:"queryTypes"`
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *FilteringConfig) IsEnabled() bool {
+	return len(c.QueryTypes) != 0
+}
+
+// LogValues implements `config.ValueLogger`.
+func (c *FilteringConfig) LogValues(logger *logrus.Entry) {
+	logger.Info("filtering query Types:")
+
+	for qType := range c.QueryTypes {
+		logger.Infof("  - %s", qType)
+	}
+}

--- a/config/filtering.go
+++ b/config/filtering.go
@@ -15,7 +15,7 @@ func (c *FilteringConfig) IsEnabled() bool {
 
 // LogConfig implements `config.Configurable`.
 func (c *FilteringConfig) LogConfig(logger *logrus.Entry) {
-	logger.Info("filtering query Types:")
+	logger.Info("query types:")
 
 	for qType := range c.QueryTypes {
 		logger.Infof("  - %s", qType)

--- a/config/filtering_test.go
+++ b/config/filtering_test.go
@@ -49,7 +49,7 @@ var _ = Describe("FilteringConfig", func() {
 			cfg.LogConfig(logger)
 
 			Expect(hook.Calls).Should(HaveLen(3))
-			Expect(hook.Messages).Should(ContainElement(ContainSubstring("filtering query Types:")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("query types:")))
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("  - AAAA")))
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("  - MX")))
 		})

--- a/config/filtering_test.go
+++ b/config/filtering_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	. "github.com/0xERR0R/blocky/helpertest"
+
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FilteringConfig", func() {
+	var (
+		cfg FilteringConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = FilteringConfig{
+			QueryTypes: NewQTypeSet(AAAA, MX),
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := FilteringConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := FilteringConfig{}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).Should(HaveLen(3))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("filtering query Types:")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("  - AAAA")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("  - MX")))
+		})
+	})
+})

--- a/config/hosts_file.go
+++ b/config/hosts_file.go
@@ -11,13 +11,15 @@ type HostsFileConfig struct {
 	FilterLoopback bool     `yaml:"filterLoopback"`
 }
 
-func (c *HostsFileConfig) LogValues(log *logrus.Entry) {
-	if c.Filepath == "" {
-		return
-	}
+// IsEnabled implements `config.ValueLogger`.
+func (c *HostsFileConfig) IsEnabled() bool {
+	return len(c.Filepath) != 0
+}
 
-	log.Infof("file path: %s", c.Filepath)
-	log.Infof("TTL: %d", c.HostsTTL.SecondsU32())
-	log.Infof("refresh period: %s", c.RefreshPeriod)
-	log.Infof("filter loopback addresses: %t", c.FilterLoopback)
+// LogValues implements `config.ValueLogger`.
+func (c *HostsFileConfig) LogValues(logger *logrus.Entry) {
+	logger.Infof("file path: %s", c.Filepath)
+	logger.Infof("TTL: %d", c.HostsTTL.SecondsU32())
+	logger.Infof("refresh period: %s", c.RefreshPeriod)
+	logger.Infof("filter loopback addresses: %t", c.FilterLoopback)
 }

--- a/config/hosts_file.go
+++ b/config/hosts_file.go
@@ -19,7 +19,7 @@ func (c *HostsFileConfig) IsEnabled() bool {
 // LogConfig implements `config.Configurable`.
 func (c *HostsFileConfig) LogConfig(logger *logrus.Entry) {
 	logger.Infof("file path: %s", c.Filepath)
-	logger.Infof("TTL: %d", c.HostsTTL.SecondsU32())
+	logger.Infof("TTL: %s", c.HostsTTL)
 	logger.Infof("refresh period: %s", c.RefreshPeriod)
 	logger.Infof("filter loopback addresses: %t", c.FilterLoopback)
 }

--- a/config/hosts_file.go
+++ b/config/hosts_file.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type HostsFileConfig struct {
+	Filepath       string   `yaml:"filePath"`
+	HostsTTL       Duration `yaml:"hostsTTL" default:"\"1h\""`
+	RefreshPeriod  Duration `yaml:"refreshPeriod" default:"\"1h\""`
+	FilterLoopback bool     `yaml:"filterLoopback"`
+}
+
+func (c *HostsFileConfig) LogValues(log *logrus.Entry) {
+	if c.Filepath == "" {
+		return
+	}
+
+	log.Infof("file path: %s", c.Filepath)
+	log.Infof("TTL: %d", c.HostsTTL.SecondsU32())
+	log.Infof("refresh period: %s", c.RefreshPeriod)
+	log.Infof("filter loopback addresses: %t", c.FilterLoopback)
+}

--- a/config/hosts_file.go
+++ b/config/hosts_file.go
@@ -6,8 +6,8 @@ import (
 
 type HostsFileConfig struct {
 	Filepath       string   `yaml:"filePath"`
-	HostsTTL       Duration `yaml:"hostsTTL" default:"\"1h\""`
-	RefreshPeriod  Duration `yaml:"refreshPeriod" default:"\"1h\""`
+	HostsTTL       Duration `yaml:"hostsTTL" default:"1h"`
+	RefreshPeriod  Duration `yaml:"refreshPeriod" default:"1h"`
 	FilterLoopback bool     `yaml:"filterLoopback"`
 }
 

--- a/config/hosts_file.go
+++ b/config/hosts_file.go
@@ -11,13 +11,13 @@ type HostsFileConfig struct {
 	FilterLoopback bool     `yaml:"filterLoopback"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *HostsFileConfig) IsEnabled() bool {
 	return len(c.Filepath) != 0
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *HostsFileConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *HostsFileConfig) LogConfig(logger *logrus.Entry) {
 	logger.Infof("file path: %s", c.Filepath)
 	logger.Infof("TTL: %d", c.HostsTTL.SecondsU32())
 	logger.Infof("refresh period: %s", c.RefreshPeriod)

--- a/config/hosts_file_test.go
+++ b/config/hosts_file_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"time"
+
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HostsFileConfig", func() {
+	var (
+		cfg HostsFileConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = HostsFileConfig{
+			Filepath:       "/dev/null",
+			HostsTTL:       Duration(29 * time.Minute),
+			RefreshPeriod:  Duration(30 * time.Minute),
+			FilterLoopback: true,
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := HostsFileConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := HostsFileConfig{}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("file path: /dev/null")))
+		})
+	})
+})

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -8,12 +8,12 @@ type MetricsConfig struct {
 	Path   string `yaml:"path" default:"/metrics"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *MetricsConfig) IsEnabled() bool {
 	return c.Enable
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *MetricsConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *MetricsConfig) LogConfig(logger *logrus.Entry) {
 	logger.Infof("url path: %s", c.Path)
 }

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -1,0 +1,19 @@
+package config
+
+import "github.com/sirupsen/logrus"
+
+// MetricsConfig contains the config values for prometheus
+type MetricsConfig struct {
+	Enable bool   `yaml:"enable" default:"false"`
+	Path   string `yaml:"path" default:"/metrics"`
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *MetricsConfig) IsEnabled() bool {
+	return c.Enable
+}
+
+// LogValues implements `config.ValueLogger`.
+func (c *MetricsConfig) LogValues(logger *logrus.Entry) {
+	logger.Infof("url path: %s", c.Path)
+}

--- a/config/metrics_test.go
+++ b/config/metrics_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MetricsConfig", func() {
+	var (
+		cfg MetricsConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = MetricsConfig{
+			Enable: true,
+			Path:   "/custom/path",
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := MetricsConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := MetricsConfig{}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).Should(HaveLen(1))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("url path: /custom/path")))
+		})
+	})
+})

--- a/config/parallel_best.go
+++ b/config/parallel_best.go
@@ -6,20 +6,20 @@ import (
 
 const UpstreamDefaultCfgName = "default"
 
-// UpstreamConfig upstream server configuration
-type UpstreamConfig struct {
-	ExternalResolvers UpstreamMapping `yaml:",inline"`
+// ParallelBestConfig upstream server configuration
+type ParallelBestConfig struct {
+	ExternalResolvers ParallelBestMapping `yaml:",inline"`
 }
 
-type UpstreamMapping map[string][]Upstream
+type ParallelBestMapping map[string][]Upstream
 
 // IsEnabled implements `config.Configurable`.
-func (c *UpstreamConfig) IsEnabled() bool {
+func (c *ParallelBestConfig) IsEnabled() bool {
 	return len(c.ExternalResolvers) != 0
 }
 
 // LogConfig implements `config.Configurable`.
-func (c *UpstreamConfig) LogConfig(logger *logrus.Entry) {
+func (c *ParallelBestConfig) LogConfig(logger *logrus.Entry) {
 	logger.Info("upstream resolvers:")
 
 	for name, upstreams := range c.ExternalResolvers {

--- a/config/parallel_best.go
+++ b/config/parallel_best.go
@@ -13,13 +13,13 @@ type UpstreamConfig struct {
 
 type UpstreamMapping map[string][]Upstream
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *UpstreamConfig) IsEnabled() bool {
 	return len(c.ExternalResolvers) != 0
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *UpstreamConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *UpstreamConfig) LogConfig(logger *logrus.Entry) {
 	logger.Info("upstream resolvers:")
 
 	for name, upstreams := range c.ExternalResolvers {

--- a/config/parallel_best.go
+++ b/config/parallel_best.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+const UpstreamDefaultCfgName = "default"
+
+// UpstreamConfig upstream server configuration
+type UpstreamConfig struct {
+	ExternalResolvers UpstreamMapping `yaml:",inline"`
+}
+
+type UpstreamMapping map[string][]Upstream
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *UpstreamConfig) IsEnabled() bool {
+	return len(c.ExternalResolvers) != 0
+}
+
+// LogValues implements `config.ValueLogger`.
+func (c *UpstreamConfig) LogValues(logger *logrus.Entry) {
+	logger.Info("upstream resolvers:")
+
+	for name, upstreams := range c.ExternalResolvers {
+		logger.Infof("  - %s", name)
+
+		for _, upstream := range upstreams {
+			logger.Infof("    - %s", upstream)
+		}
+	}
+}

--- a/config/parallel_best.go
+++ b/config/parallel_best.go
@@ -23,7 +23,7 @@ func (c *ParallelBestConfig) LogConfig(logger *logrus.Entry) {
 	logger.Info("upstream resolvers:")
 
 	for name, upstreams := range c.ExternalResolvers {
-		logger.Infof("  - %s", name)
+		logger.Infof("  %s:", name)
 
 		for _, upstream := range upstreams {
 			logger.Infof("    - %s", upstream)

--- a/config/parallel_best_test.go
+++ b/config/parallel_best_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ParallelBestConfig", func() {
+	var (
+		cfg ParallelBestConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = ParallelBestConfig{
+			ExternalResolvers: ParallelBestMapping{
+				UpstreamDefaultCfgName: {
+					{Host: "host1"},
+					{Host: "host2"},
+				},
+			},
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := ParallelBestConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := ParallelBestConfig{}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("upstream resolvers:")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring(":host2:")))
+		})
+	})
+})

--- a/config/qtype_set.go
+++ b/config/qtype_set.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+type QTypeSet map[QType]struct{}
+
+func NewQTypeSet(qTypes ...dns.Type) QTypeSet {
+	s := make(QTypeSet, len(qTypes))
+
+	for _, qType := range qTypes {
+		s.Insert(qType)
+	}
+
+	return s
+}
+
+func (s QTypeSet) Contains(qType dns.Type) bool {
+	_, found := s[QType(qType)]
+
+	return found
+}
+
+func (s *QTypeSet) Insert(qType dns.Type) {
+	if *s == nil {
+		*s = make(QTypeSet, 1)
+	}
+
+	(*s)[QType(qType)] = struct{}{}
+}
+
+func (s *QTypeSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var input []QType
+	if err := unmarshal(&input); err != nil {
+		return err
+	}
+
+	*s = make(QTypeSet, len(input))
+
+	for _, qType := range input {
+		(*s)[qType] = struct{}{}
+	}
+
+	return nil
+}
+
+type QType dns.Type
+
+func (c QType) String() string {
+	return dns.Type(c).String()
+}
+
+func (c *QType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var input string
+	if err := unmarshal(&input); err != nil {
+		return err
+	}
+
+	t, found := dns.StringToType[input]
+	if !found {
+		types := make([]string, 0, len(dns.StringToType))
+		for k := range dns.StringToType {
+			types = append(types, k)
+		}
+
+		sort.Strings(types)
+
+		return fmt.Errorf("unknown DNS query type: '%s'. Please use following types '%s'",
+			input, strings.Join(types, ", "))
+	}
+
+	*c = QType(t)
+
+	return nil
+}

--- a/config/qtype_set.go
+++ b/config/qtype_set.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
+	"golang.org/x/exp/maps"
 )
 
 type QTypeSet map[QType]struct{}
@@ -55,18 +56,13 @@ func (c QType) String() string {
 	return dns.Type(c).String()
 }
 
-func (c *QType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var input string
-	if err := unmarshal(&input); err != nil {
-		return err
-	}
+// UnmarshalText implements `encoding.TextUnmarshaler`.
+func (c *QType) UnmarshalText(data []byte) error {
+	input := string(data)
 
 	t, found := dns.StringToType[input]
 	if !found {
-		types := make([]string, 0, len(dns.StringToType))
-		for k := range dns.StringToType {
-			types = append(types, k)
-		}
+		types := maps.Keys(dns.StringToType)
 
 		sort.Strings(types)
 

--- a/config/qtype_set_test.go
+++ b/config/qtype_set_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"github.com/miekg/dns"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("QTypeSet", func() {
+	Describe("NewQTypeSet", func() {
+		It("should insert given qTypes", func() {
+			set := NewQTypeSet(dns.Type(dns.TypeA))
+			Expect(set).Should(HaveKey(QType(dns.TypeA)))
+			Expect(set.Contains(dns.Type(dns.TypeA))).Should(BeTrue())
+
+			Expect(set).ShouldNot(HaveKey(QType(dns.TypeAAAA)))
+			Expect(set.Contains(dns.Type(dns.TypeAAAA))).ShouldNot(BeTrue())
+		})
+	})
+
+	Describe("Insert", func() {
+		It("should insert given qTypes", func() {
+			set := NewQTypeSet()
+
+			Expect(set).ShouldNot(HaveKey(QType(dns.TypeAAAA)))
+			Expect(set.Contains(dns.Type(dns.TypeAAAA))).ShouldNot(BeTrue())
+
+			set.Insert(dns.Type(dns.TypeAAAA))
+
+			Expect(set).Should(HaveKey(QType(dns.TypeAAAA)))
+			Expect(set.Contains(dns.Type(dns.TypeAAAA))).Should(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("QType", func() {
+	Describe("UnmarshalText", func() {
+		It("Should parse existing DNS type as string", func() {
+			t := QType(0)
+			err := t.UnmarshalText([]byte("AAAA"))
+			Expect(err).Should(Succeed())
+			Expect(t).Should(Equal(QType(dns.TypeAAAA)))
+			Expect(t.String()).Should(Equal("AAAA"))
+		})
+
+		It("should fail if DNS type does not exist", func() {
+			t := QType(0)
+			err := t.UnmarshalText([]byte("WRONGTYPE"))
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("unknown DNS query type: 'WRONGTYPE'"))
+		})
+
+		It("should fail if wrong YAML format", func() {
+			d := QType(0)
+			err := d.UnmarshalText([]byte("some err"))
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("unknown DNS query type: 'some err'"))
+		})
+	})
+})

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -36,6 +36,6 @@ func (c *QueryLogConfig) LogConfig(logger *logrus.Entry) {
 
 	logger.Infof("logRetentionDays: %d", c.LogRetentionDays)
 	logger.Debugf("creationAttempts: %d", c.CreationAttempts)
-	logger.Debugf("creationCooldown: %d", c.CreationCooldown)
+	logger.Debugf("creationCooldown: %s", c.CreationCooldown)
 	logger.Infof("fields: %s", c.Fields)
 }

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -14,6 +14,13 @@ type QueryLogConfig struct {
 	Fields           []QueryLogField `yaml:"fields"`
 }
 
+// SetDefaults implements `defaults.Setter`.
+func (c *QueryLogConfig) SetDefaults() {
+	// Since the default depends on the enum values, set it dynamically
+	// to avoid having to repeat the values in the annotation.
+	c.Fields = QueryLogFieldValues()
+}
+
 // IsEnabled implements `config.ValueLogger`.
 func (c *QueryLogConfig) IsEnabled() bool {
 	return c.Type != QueryLogTypeNone
@@ -26,4 +33,5 @@ func (c *QueryLogConfig) LogValues(logger *logrus.Entry) {
 	logger.Infof("logRetentionDays: %d", c.LogRetentionDays)
 	logger.Debugf("creationAttempts: %d", c.CreationAttempts)
 	logger.Debugf("creationCooldown: %d", c.CreationCooldown)
+	logger.Infof("fields: %s", c.Fields)
 }

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -28,8 +28,12 @@ func (c *QueryLogConfig) IsEnabled() bool {
 
 // LogConfig implements `config.Configurable`.
 func (c *QueryLogConfig) LogConfig(logger *logrus.Entry) {
-	logger.Infof("type: %q", c.Type)
-	logger.Infof("target: %q", c.Target)
+	logger.Infof("type: %s", c.Type)
+
+	if c.Target != "" {
+		logger.Infof("target: %s", c.Target)
+	}
+
 	logger.Infof("logRetentionDays: %d", c.LogRetentionDays)
 	logger.Debugf("creationAttempts: %d", c.CreationAttempts)
 	logger.Debugf("creationCooldown: %d", c.CreationCooldown)

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// QueryLogConfig configuration for the query logging
+type QueryLogConfig struct {
+	Target           string          `yaml:"target"`
+	Type             QueryLogType    `yaml:"type"`
+	LogRetentionDays uint64          `yaml:"logRetentionDays"`
+	CreationAttempts int             `yaml:"creationAttempts" default:"3"`
+	CreationCooldown Duration        `yaml:"creationCooldown" default:"2s"`
+	Fields           []QueryLogField `yaml:"fields"`
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *QueryLogConfig) IsEnabled() bool {
+	return c.Type != QueryLogTypeNone
+}
+
+// LogValues implements `config.ValueLogger`.
+func (c *QueryLogConfig) LogValues(logger *logrus.Entry) {
+	logger.Infof("type: %q", c.Type)
+	logger.Infof("target: %q", c.Target)
+	logger.Infof("logRetentionDays: %d", c.LogRetentionDays)
+	logger.Debugf("creationAttempts: %d", c.CreationAttempts)
+	logger.Debugf("creationCooldown: %d", c.CreationCooldown)
+}

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -21,13 +21,13 @@ func (c *QueryLogConfig) SetDefaults() {
 	c.Fields = QueryLogFieldValues()
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *QueryLogConfig) IsEnabled() bool {
 	return c.Type != QueryLogTypeNone
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *QueryLogConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *QueryLogConfig) LogConfig(logger *logrus.Entry) {
 	logger.Infof("type: %q", c.Type)
 	logger.Infof("target: %q", c.Target)
 	logger.Infof("logRetentionDays: %d", c.LogRetentionDays)

--- a/config/query_log_test.go
+++ b/config/query_log_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"time"
+
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("QueryLogConfig", func() {
+	var (
+		cfg QueryLogConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = QueryLogConfig{
+			Target:           "/dev/null",
+			Type:             QueryLogTypeCsvClient,
+			LogRetentionDays: 0,
+			CreationAttempts: 1,
+			CreationCooldown: Duration(time.Millisecond),
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be true by default", func() {
+			cfg := QueryLogConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeTrue())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := QueryLogConfig{
+					Type: QueryLogTypeNone,
+				}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("logRetentionDays:")))
+		})
+	})
+
+	Describe("SetDefaults", func() {
+		It("should log configuration", func() {
+			cfg := QueryLogConfig{}
+			Expect(cfg.Fields).Should(BeEmpty())
+
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.Fields).ShouldNot(BeEmpty())
+		})
+	})
+})

--- a/config/rewriter.go
+++ b/config/rewriter.go
@@ -10,13 +10,13 @@ type RewriteConfig struct {
 	FallbackUpstream bool              `yaml:"fallbackUpstream" default:"false"`
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (c *RewriteConfig) IsEnabled() bool {
 	return len(c.Rewrite) != 0
 }
 
-// LogValues implements `config.ValueLogger`.
-func (c *RewriteConfig) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (c *RewriteConfig) LogConfig(logger *logrus.Entry) {
 	logger.Info("rewrite:")
 
 	for key, val := range c.Rewrite {

--- a/config/rewriter.go
+++ b/config/rewriter.go
@@ -4,19 +4,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// RewriteConfig custom DNS configuration
-type RewriteConfig struct {
+// RewriterConfig custom DNS configuration
+type RewriterConfig struct {
 	Rewrite          map[string]string `yaml:"rewrite"`
 	FallbackUpstream bool              `yaml:"fallbackUpstream" default:"false"`
 }
 
 // IsEnabled implements `config.Configurable`.
-func (c *RewriteConfig) IsEnabled() bool {
+func (c *RewriterConfig) IsEnabled() bool {
 	return len(c.Rewrite) != 0
 }
 
 // LogConfig implements `config.Configurable`.
-func (c *RewriteConfig) LogConfig(logger *logrus.Entry) {
+func (c *RewriterConfig) LogConfig(logger *logrus.Entry) {
 	logger.Info("rewrite:")
 
 	for key, val := range c.Rewrite {

--- a/config/rewriter.go
+++ b/config/rewriter.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// RewriteConfig custom DNS configuration
+type RewriteConfig struct {
+	Rewrite          map[string]string `yaml:"rewrite"`
+	FallbackUpstream bool              `yaml:"fallbackUpstream" default:"false"`
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (c *RewriteConfig) IsEnabled() bool {
+	return len(c.Rewrite) != 0
+}
+
+// LogValues implements `config.ValueLogger`.
+func (c *RewriteConfig) LogValues(logger *logrus.Entry) {
+	logger.Info("rewrite:")
+
+	for key, val := range c.Rewrite {
+		logger.Infof("  %s = %q", key, val)
+	}
+}

--- a/config/rewriter.go
+++ b/config/rewriter.go
@@ -17,9 +17,11 @@ func (c *RewriterConfig) IsEnabled() bool {
 
 // LogConfig implements `config.Configurable`.
 func (c *RewriterConfig) LogConfig(logger *logrus.Entry) {
-	logger.Info("rewrite:")
+	logger.Infof("fallbackUpstream = %t", c.FallbackUpstream)
+
+	logger.Info("rules:")
 
 	for key, val := range c.Rewrite {
-		logger.Infof("  %s = %q", key, val)
+		logger.Infof("  %s = %s", key, val)
 	}
 }

--- a/config/rewriter_test.go
+++ b/config/rewriter_test.go
@@ -50,7 +50,7 @@ var _ = Describe("RewriterConfig", func() {
 			cfg.LogConfig(logger)
 
 			Expect(hook.Calls).ShouldNot(BeEmpty())
-			Expect(hook.Messages).Should(ContainElement(ContainSubstring("rewrite:")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("rules:")))
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("original2 =")))
 		})
 	})

--- a/config/rewriter_test.go
+++ b/config/rewriter_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RewriterConfig", func() {
+	var (
+		cfg RewriterConfig
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		cfg = RewriterConfig{
+			Rewrite: map[string]string{
+				"original1": "rewritten1",
+				"original2": "rewritten2",
+			},
+		}
+	})
+
+	Describe("IsEnabled", func() {
+		It("should be false by default", func() {
+			cfg := RewriterConfig{}
+			Expect(defaults.Set(&cfg)).Should(Succeed())
+
+			Expect(cfg.IsEnabled()).Should(BeFalse())
+		})
+
+		When("enabled", func() {
+			It("should be true", func() {
+				Expect(cfg.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		When("disabled", func() {
+			It("should be false", func() {
+				cfg := RewriterConfig{}
+
+				Expect(cfg.IsEnabled()).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log configuration", func() {
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("rewrite:")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("original2 =")))
+		})
+	})
+})

--- a/config/upstream.go
+++ b/config/upstream.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+)
+
+var validDomain = regexp.MustCompile(
+	`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
+
+// Upstream is the definition of external DNS server
+type Upstream struct {
+	Net        NetProtocol
+	Host       string
+	Port       uint16
+	Path       string
+	CommonName string // Common Name to use for certificate verification; optional. "" uses .Host
+}
+
+// IsDefault returns true if u is the default value
+func (u *Upstream) IsDefault() bool {
+	return *u == Upstream{}
+}
+
+// String returns the string representation of u
+func (u Upstream) String() string {
+	if u.IsDefault() {
+		return "no upstream"
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString(u.Net.String())
+	sb.WriteRune(':')
+
+	if u.Net == NetProtocolHttps {
+		sb.WriteString("//")
+	}
+
+	isIPv6 := strings.ContainsRune(u.Host, ':')
+	if isIPv6 {
+		sb.WriteRune('[')
+		sb.WriteString(u.Host)
+		sb.WriteRune(']')
+	} else {
+		sb.WriteString(u.Host)
+	}
+
+	if u.Port != netDefaultPort[u.Net] {
+		sb.WriteRune(':')
+		sb.WriteString(fmt.Sprint(u.Port))
+	}
+
+	if u.Path != "" {
+		sb.WriteString(u.Path)
+	}
+
+	return sb.String()
+}
+
+// UnmarshalText implements `encoding.TextUnmarshaler`.
+func (u *Upstream) UnmarshalText(data []byte) error {
+	s := string(data)
+
+	upstream, err := ParseUpstream(s)
+	if err != nil {
+		return fmt.Errorf("can't convert upstream '%s': %w", s, err)
+	}
+
+	*u = upstream
+
+	return nil
+}
+
+// ParseUpstream creates new Upstream from passed string in format [net]:host[:port][/path][#commonname]
+func ParseUpstream(upstream string) (Upstream, error) {
+	var path string
+
+	var port uint16
+
+	commonName, upstream := extractCommonName(upstream)
+
+	n, upstream := extractNet(upstream)
+
+	path, upstream = extractPath(upstream)
+
+	host, portString, err := net.SplitHostPort(upstream)
+
+	// string contains host:port
+	if err == nil {
+		p, err := ConvertPort(portString)
+		if err != nil {
+			err = fmt.Errorf("can't convert port to number (1 - 65535) %w", err)
+
+			return Upstream{}, err
+		}
+
+		port = p
+	} else {
+		// only host, use default port
+		host = upstream
+		port = netDefaultPort[n]
+
+		// trim any IPv6 brackets
+		host = strings.TrimPrefix(host, "[")
+		host = strings.TrimSuffix(host, "]")
+	}
+
+	// validate hostname or ip
+	if ip := net.ParseIP(host); ip == nil {
+		// is not IP
+		if !validDomain.MatchString(host) {
+			return Upstream{}, fmt.Errorf("wrong host name '%s'", host)
+		}
+	}
+
+	return Upstream{
+		Net:        n,
+		Host:       host,
+		Port:       port,
+		Path:       path,
+		CommonName: commonName,
+	}, nil
+}
+
+func extractCommonName(in string) (string, string) {
+	upstream, cn, _ := strings.Cut(in, "#")
+
+	return cn, upstream
+}
+
+func extractPath(in string) (path, upstream string) {
+	slashIdx := strings.Index(in, "/")
+
+	if slashIdx >= 0 {
+		path = in[slashIdx:]
+		upstream = in[:slashIdx]
+	} else {
+		upstream = in
+	}
+
+	return
+}
+
+func extractNet(upstream string) (NetProtocol, string) {
+	tcpUDPPrefix := NetProtocolTcpUdp.String() + ":"
+	if strings.HasPrefix(upstream, tcpUDPPrefix) {
+		return NetProtocolTcpUdp, upstream[len(tcpUDPPrefix):]
+	}
+
+	tcpTLSPrefix := NetProtocolTcpTls.String() + ":"
+	if strings.HasPrefix(upstream, tcpTLSPrefix) {
+		return NetProtocolTcpTls, upstream[len(tcpTLSPrefix):]
+	}
+
+	httpsPrefix := NetProtocolHttps.String() + ":"
+	if strings.HasPrefix(upstream, httpsPrefix) {
+		return NetProtocolHttps, strings.TrimPrefix(upstream[len(httpsPrefix):], "//")
+	}
+
+	return NetProtocolTcpUdp, upstream
+}

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
+	golang.org/x/exp v0.0.0-20230307190834-24139beb5833
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -473,6 +473,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230307190834-24139beb5833 h1:SChBja7BCQewoTAU7IgvucQKMIXrEpFxNMs0spT3/5s=
+golang.org/x/exp v0.0.0-20230307190834-24139beb5833/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -51,8 +51,8 @@ type ListCache struct {
 	processingConcurrency uint
 }
 
-// LogValues implements `config.ValueLogger`.
-func (b *ListCache) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (b *ListCache) LogConfig(logger *logrus.Entry) {
 	var total int
 
 	b.lock.RLock()

--- a/log/mock_entry.go
+++ b/log/mock_entry.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+)
+
+func NewMockEntry() (*logrus.Entry, *MockLoggerHook) {
+	logger := logrus.New()
+	logger.Out = io.Discard
+
+	entry := logrus.Entry{Logger: logger}
+	hook := MockLoggerHook{}
+
+	entry.Logger.AddHook(&hook)
+
+	hook.On("Fire", mock.Anything).Return(nil)
+
+	return &entry, &hook
+}
+
+type MockLoggerHook struct {
+	mock.Mock
+
+	Messages []string
+}
+
+// Levels implements `logrus.Hook`.
+func (h *MockLoggerHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire implements `logrus.Hook`.
+func (h *MockLoggerHook) Fire(entry *logrus.Entry) error {
+	_ = h.Called()
+
+	h.Messages = append(h.Messages, entry.Message)
+
+	return nil
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,7 +18,7 @@ func RegisterMetric(c prometheus.Collector) {
 }
 
 // Start starts prometheus endpoint
-func Start(router *chi.Mux, cfg config.PrometheusConfig) {
+func Start(router *chi.Mux, cfg config.MetricsConfig) {
 	if cfg.Enable {
 		_ = reg.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 		_ = reg.Register(collectors.NewGoCollector())

--- a/model/models.go
+++ b/model/models.go
@@ -22,6 +22,31 @@ import (
 // )
 type ResponseType int
 
+func (t ResponseType) ToExtendedErrorCode() uint16 {
+	switch t {
+	case ResponseTypeRESOLVED:
+		return dns.ExtendedErrorCodeOther
+	case ResponseTypeCACHED:
+		return dns.ExtendedErrorCodeCachedError
+	case ResponseTypeCONDITIONAL:
+		return dns.ExtendedErrorCodeForgedAnswer
+	case ResponseTypeCUSTOMDNS:
+		return dns.ExtendedErrorCodeForgedAnswer
+	case ResponseTypeHOSTSFILE:
+		return dns.ExtendedErrorCodeForgedAnswer
+	case ResponseTypeNOTFQDN:
+		return dns.ExtendedErrorCodeBlocked
+	case ResponseTypeBLOCKED:
+		return dns.ExtendedErrorCodeBlocked
+	case ResponseTypeFILTERED:
+		return dns.ExtendedErrorCodeFiltered
+	case ResponseTypeSPECIAL:
+		return dns.ExtendedErrorCodeFiltered
+	default:
+		return dns.ExtendedErrorCodeOther
+	}
+}
+
 // Response represents the response of a DNS query
 type Response struct {
 	Res    *dns.Msg

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -83,7 +83,7 @@ func New(cfg *config.RedisConfig) (*Client, error) {
 			Password:         cfg.Password,
 			DB:               cfg.Database,
 			MaxRetries:       cfg.ConnectionAttempts,
-			MaxRetryBackoff:  time.Duration(cfg.ConnectionCooldown),
+			MaxRetryBackoff:  cfg.ConnectionCooldown.Cast(),
 		})
 	} else {
 		rdb = redis.NewClient(&redis.Options{
@@ -92,7 +92,7 @@ func New(cfg *config.RedisConfig) (*Client, error) {
 			Password:        cfg.Password,
 			DB:              cfg.Database,
 			MaxRetries:      cfg.ConnectionAttempts,
-			MaxRetryBackoff: time.Duration(cfg.ConnectionCooldown),
+			MaxRetryBackoff: cfg.ConnectionCooldown.Cast(),
 		})
 	}
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -83,7 +83,7 @@ func New(cfg *config.RedisConfig) (*Client, error) {
 			Password:         cfg.Password,
 			DB:               cfg.Database,
 			MaxRetries:       cfg.ConnectionAttempts,
-			MaxRetryBackoff:  cfg.ConnectionCooldown.Cast(),
+			MaxRetryBackoff:  cfg.ConnectionCooldown.ToDuration(),
 		})
 	} else {
 		rdb = redis.NewClient(&redis.Options{
@@ -92,7 +92,7 @@ func New(cfg *config.RedisConfig) (*Client, error) {
 			Password:        cfg.Password,
 			DB:              cfg.Database,
 			MaxRetries:      cfg.ConnectionAttempts,
-			MaxRetryBackoff: cfg.ConnectionCooldown.Cast(),
+			MaxRetryBackoff: cfg.ConnectionCooldown.ToDuration(),
 		})
 	}
 

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -80,6 +80,7 @@ type status struct {
 type BlockingResolver struct {
 	configurable[*config.BlockingConfig]
 	NextResolver
+	typed
 
 	blacklistMatcher    *lists.ListCache
 	whitelistMatcher    *lists.ListCache
@@ -130,6 +131,7 @@ func NewBlockingResolver(
 
 	res := &BlockingResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("blocking"),
 
 		blockHandler:        blockHandler,
 		blacklistMatcher:    blacklistMatcher,

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -166,19 +166,17 @@ func createDownloader(cfg config.BlockingConfig, bootstrap *Bootstrap) *lists.HT
 }
 
 func setupRedisEnabledSubscriber(c *BlockingResolver) {
-	logger := log.PrefixedLog("blocking_resolver")
-
 	go func() {
 		for em := range c.redisClient.EnabledChannel {
 			if em != nil {
-				logger.Debug("Received state from redis: ", em)
+				c.log().Debug("Received state from redis: ", em)
 
 				if em.State {
 					c.internalEnableBlocking()
 				} else {
 					err := c.internalDisableBlocking(em.Duration, em.Groups)
 					if err != nil {
-						logger.Warn("Blocking couldn't be disabled:", err)
+						c.log().Warn("Blocking couldn't be disabled:", err)
 					}
 				}
 			}
@@ -572,7 +570,7 @@ func (b ipBlockHandler) handleBlock(question dns.Question, response *dns.Msg) {
 }
 
 func (r *BlockingResolver) queryForFQIdentifierIPs(identifier string) (result []net.IP, ttl time.Duration) {
-	prefixedLog := log.PrefixedLog("FQDNClientIdentifierCache")
+	prefixedLog := log.WithPrefix(r.log(), "client_id_cache")
 
 	for _, qType := range []uint16{dns.TypeA, dns.TypeAAAA} {
 		resp, err := r.next.Resolve(&model.Request{

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -78,10 +78,11 @@ type status struct {
 
 // BlockingResolver checks request's question (domain name) against black and white lists
 type BlockingResolver struct {
+	configurable[*config.BlockingConfig]
 	NextResolver
+
 	blacklistMatcher    *lists.ListCache
 	whitelistMatcher    *lists.ListCache
-	cfg                 config.BlockingConfig
 	blockHandler        blockHandler
 	whitelistOnlyGroups map[string]bool
 	status              *status
@@ -128,8 +129,9 @@ func NewBlockingResolver(
 	}
 
 	res := &BlockingResolver{
+		configurable: withConfig(&cfg),
+
 		blockHandler:        blockHandler,
-		cfg:                 cfg,
 		blacklistMatcher:    blacklistMatcher,
 		whitelistMatcher:    whitelistMatcher,
 		whitelistOnlyGroups: whitelistOnlyGroups,
@@ -325,11 +327,6 @@ func (r *BlockingResolver) handleBlocked(logger *logrus.Entry,
 	logger.Debugf("blocking request '%s'", reason)
 
 	return &model.Response{Res: response, RType: model.ResponseTypeBLOCKED, Reason: reason}, nil
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *BlockingResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
 }
 
 // LogConfig implements `config.Configurable`.

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -35,7 +35,7 @@ func createBlockHandler(cfg config.BlockingConfig) (blockHandler, error) {
 		return nxDomainBlockHandler{}, nil
 	}
 
-	blockTime := uint32(time.Duration(cfg.BlockTTL).Seconds())
+	blockTime := uint32(cfg.BlockTTL.Seconds())
 
 	if strings.EqualFold(cfgBlockType, "ZEROIP") {
 		return zeroIPBlockHandler{
@@ -100,7 +100,7 @@ func NewBlockingResolver(
 		return nil, err
 	}
 
-	refreshPeriod := time.Duration(cfg.RefreshPeriod)
+	refreshPeriod := cfg.RefreshPeriod.Cast()
 	downloader := createDownloader(cfg, bootstrap)
 	blacklistMatcher, blErr := lists.NewListCache(lists.ListCacheTypeBlacklist, cfg.BlackLists,
 		refreshPeriod, downloader, cfg.ProcessingConcurrency,
@@ -156,9 +156,9 @@ func NewBlockingResolver(
 
 func createDownloader(cfg config.BlockingConfig, bootstrap *Bootstrap) *lists.HTTPDownloader {
 	return lists.NewDownloader(
-		lists.WithTimeout(time.Duration(cfg.DownloadTimeout)),
+		lists.WithTimeout(cfg.DownloadTimeout.Cast()),
 		lists.WithAttempts(cfg.DownloadAttempts),
-		lists.WithCooldown(time.Duration(cfg.DownloadCooldown)),
+		lists.WithCooldown(cfg.DownloadCooldown.Cast()),
 		lists.WithTransport(bootstrap.NewHTTPTransport()),
 	)
 }

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -327,20 +327,20 @@ func (r *BlockingResolver) handleBlocked(logger *logrus.Entry,
 	return &model.Response{Res: response, RType: model.ResponseTypeBLOCKED, Reason: reason}, nil
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *BlockingResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *BlockingResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *BlockingResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 
 	logger.Info("blacklist cache entries:")
-	log.WithIndent(logger, "  ", r.blacklistMatcher.LogValues)
+	log.WithIndent(logger, "  ", r.blacklistMatcher.LogConfig)
 
 	logger.Info("whitelist cache entries:")
-	log.WithIndent(logger, "  ", r.whitelistMatcher.LogValues)
+	log.WithIndent(logger, "  ", r.whitelistMatcher.LogConfig)
 }
 
 func (r *BlockingResolver) hasWhiteListOnlyAllowed(groupsToCheck []string) bool {

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -35,7 +35,7 @@ func createBlockHandler(cfg config.BlockingConfig) (blockHandler, error) {
 		return nxDomainBlockHandler{}, nil
 	}
 
-	blockTime := uint32(cfg.BlockTTL.Seconds())
+	blockTime := cfg.BlockTTL.SecondsU32()
 
 	if strings.EqualFold(cfgBlockType, "ZEROIP") {
 		return zeroIPBlockHandler{
@@ -100,7 +100,7 @@ func NewBlockingResolver(
 		return nil, err
 	}
 
-	refreshPeriod := cfg.RefreshPeriod.Cast()
+	refreshPeriod := cfg.RefreshPeriod.ToDuration()
 	downloader := createDownloader(cfg, bootstrap)
 	blacklistMatcher, blErr := lists.NewListCache(lists.ListCacheTypeBlacklist, cfg.BlackLists,
 		refreshPeriod, downloader, cfg.ProcessingConcurrency,
@@ -156,9 +156,9 @@ func NewBlockingResolver(
 
 func createDownloader(cfg config.BlockingConfig, bootstrap *Bootstrap) *lists.HTTPDownloader {
 	return lists.NewDownloader(
-		lists.WithTimeout(cfg.DownloadTimeout.Cast()),
+		lists.WithTimeout(cfg.DownloadTimeout.ToDuration()),
 		lists.WithAttempts(cfg.DownloadAttempts),
-		lists.WithCooldown(cfg.DownloadCooldown.Cast()),
+		lists.WithCooldown(cfg.DownloadCooldown.ToDuration()),
 		lists.WithTransport(bootstrap.NewHTTPTransport()),
 	)
 }

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -56,7 +56,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 	BeforeEach(func() {
 		sutConfig = config.BlockingConfig{
 			BlockType: "ZEROIP",
-			BlockTTL:  config.NewDuration(time.Minute),
+			BlockTTL:  config.Duration(time.Minute),
 		}
 
 		mockAnswer = new(dns.Msg)
@@ -75,7 +75,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
 				BlockType: "ZEROIP",
-				BlockTTL:  config.NewDuration(time.Minute),
+				BlockTTL:  config.Duration(time.Minute),
 				BlackLists: map[string][]string{
 					"gr1": {group1File.Path},
 					"gr2": {group2File.Path},
@@ -103,7 +103,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
 				BlockType: "ZEROIP",
-				BlockTTL:  config.NewDuration(time.Minute),
+				BlockTTL:  config.Duration(time.Minute),
 				BlackLists: map[string][]string{
 					"gr1": {group1File.Path},
 					"gr2": {group2File.Path},
@@ -142,7 +142,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
 				BlockType: "ZEROIP",
-				BlockTTL:  config.NewDuration(time.Minute),
+				BlockTTL:  config.Duration(time.Minute),
 				BlackLists: map[string][]string{
 					"gr1": {"\n/regex/"},
 				},
@@ -171,7 +171,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 	Describe("Blocking requests", func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
-				BlockTTL: config.NewDuration(6 * time.Hour),
+				BlockTTL: config.Duration(6 * time.Hour),
 				BlackLists: map[string][]string{
 					"gr1":          {group1File.Path},
 					"gr2":          {group2File.Path},
@@ -377,7 +377,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("BlockType is NxDomain", func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
-					BlockTTL: config.NewDuration(time.Minute),
+					BlockTTL: config.Duration(time.Minute),
 					BlackLists: map[string][]string{
 						"defaultGroup": {defaultGroupFile.Path},
 					},
@@ -410,7 +410,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 					ClientGroupsBlock: map[string][]string{
 						"default": {"defaultGroup"},
 					},
-					BlockTTL: config.NewDuration(time.Second * 1234),
+					BlockTTL: config.Duration(time.Second * 1234),
 				}
 			})
 
@@ -448,7 +448,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("BlockType is custom IP", func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
-					BlockTTL: config.NewDuration(6 * time.Hour),
+					BlockTTL: config.Duration(6 * time.Hour),
 					BlackLists: map[string][]string{
 						"defaultGroup": {defaultGroupFile.Path},
 					},
@@ -494,7 +494,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						"default": {"defaultGroup"},
 					},
 					BlockType: "12.12.12.12",
-					BlockTTL:  config.NewDuration(6 * time.Hour),
+					BlockTTL:  config.Duration(6 * time.Hour),
 				}
 			})
 
@@ -579,7 +579,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType:  "ZEROIP",
-					BlockTTL:   config.NewDuration(time.Minute),
+					BlockTTL:   config.Duration(time.Minute),
 					BlackLists: map[string][]string{"gr1": {group1File.Path}},
 					WhiteLists: map[string][]string{"gr1": {group1File.Path}},
 					ClientGroupsBlock: map[string][]string{
@@ -605,7 +605,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType: "zeroIP",
-					BlockTTL:  config.NewDuration(60 * time.Second),
+					BlockTTL:  config.Duration(60 * time.Second),
 					WhiteLists: map[string][]string{
 						"gr1": {group1File.Path},
 						"gr2": {group2File.Path},
@@ -706,7 +706,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType:  "ZEROIP",
-					BlockTTL:   config.NewDuration(time.Minute),
+					BlockTTL:   config.Duration(time.Minute),
 					BlackLists: map[string][]string{"gr1": {group1File.Path}},
 					WhiteLists: map[string][]string{"gr1": {defaultGroupFile.Path}},
 					ClientGroupsBlock: map[string][]string{
@@ -733,7 +733,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
 				BlockType:  "ZEROIP",
-				BlockTTL:   config.NewDuration(time.Minute),
+				BlockTTL:   config.Duration(time.Minute),
 				BlackLists: map[string][]string{"gr1": {group1File.Path}},
 				ClientGroupsBlock: map[string][]string{
 					"default": {"gr1"},
@@ -759,7 +759,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType: "ZEROIP",
-					BlockTTL:  config.NewDuration(time.Minute),
+					BlockTTL:  config.Duration(time.Minute),
 				}
 			})
 			It("should delegate to next resolver", func() {
@@ -1091,7 +1091,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType:  "ZEROIP",
-					BlockTTL:   config.NewDuration(time.Minute),
+					BlockTTL:   config.Duration(time.Minute),
 					BlackLists: map[string][]string{"gr1": {group1File.Path}},
 					ClientGroupsBlock: map[string][]string{
 						"default": {"gr1"},
@@ -1159,7 +1159,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			Expect(redisClient).ShouldNot(BeNil())
 			sutConfig = config.BlockingConfig{
 				BlockType: "ZEROIP",
-				BlockTTL:  config.NewDuration(time.Minute),
+				BlockTTL:  config.Duration(time.Minute),
 			}
 
 			sut, err = NewBlockingResolver(sutConfig, redisClient, systemResolverBootstrap)

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -56,7 +56,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 	BeforeEach(func() {
 		sutConfig = config.BlockingConfig{
 			BlockType: "ZEROIP",
-			BlockTTL:  config.Duration(time.Minute),
+			BlockTTL:  config.NewDuration(time.Minute),
 		}
 
 		mockAnswer = new(dns.Msg)
@@ -75,7 +75,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
 				BlockType: "ZEROIP",
-				BlockTTL:  config.Duration(time.Minute),
+				BlockTTL:  config.NewDuration(time.Minute),
 				BlackLists: map[string][]string{
 					"gr1": {group1File.Path},
 					"gr2": {group2File.Path},
@@ -103,7 +103,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
 				BlockType: "ZEROIP",
-				BlockTTL:  config.Duration(time.Minute),
+				BlockTTL:  config.NewDuration(time.Minute),
 				BlackLists: map[string][]string{
 					"gr1": {group1File.Path},
 					"gr2": {group2File.Path},
@@ -142,7 +142,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
 				BlockType: "ZEROIP",
-				BlockTTL:  config.Duration(time.Minute),
+				BlockTTL:  config.NewDuration(time.Minute),
 				BlackLists: map[string][]string{
 					"gr1": {"\n/regex/"},
 				},
@@ -171,7 +171,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 	Describe("Blocking requests", func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
-				BlockTTL: config.Duration(6 * time.Hour),
+				BlockTTL: config.NewDuration(6 * time.Hour),
 				BlackLists: map[string][]string{
 					"gr1":          {group1File.Path},
 					"gr2":          {group2File.Path},
@@ -377,7 +377,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("BlockType is NxDomain", func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
-					BlockTTL: config.Duration(time.Minute),
+					BlockTTL: config.NewDuration(time.Minute),
 					BlackLists: map[string][]string{
 						"defaultGroup": {defaultGroupFile.Path},
 					},
@@ -410,7 +410,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 					ClientGroupsBlock: map[string][]string{
 						"default": {"defaultGroup"},
 					},
-					BlockTTL: config.Duration(time.Second * 1234),
+					BlockTTL: config.NewDuration(time.Second * 1234),
 				}
 			})
 
@@ -448,7 +448,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("BlockType is custom IP", func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
-					BlockTTL: config.Duration(6 * time.Hour),
+					BlockTTL: config.NewDuration(6 * time.Hour),
 					BlackLists: map[string][]string{
 						"defaultGroup": {defaultGroupFile.Path},
 					},
@@ -494,7 +494,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						"default": {"defaultGroup"},
 					},
 					BlockType: "12.12.12.12",
-					BlockTTL:  config.Duration(6 * time.Hour),
+					BlockTTL:  config.NewDuration(6 * time.Hour),
 				}
 			})
 
@@ -579,7 +579,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType:  "ZEROIP",
-					BlockTTL:   config.Duration(time.Minute),
+					BlockTTL:   config.NewDuration(time.Minute),
 					BlackLists: map[string][]string{"gr1": {group1File.Path}},
 					WhiteLists: map[string][]string{"gr1": {group1File.Path}},
 					ClientGroupsBlock: map[string][]string{
@@ -605,7 +605,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType: "zeroIP",
-					BlockTTL:  config.Duration(60 * time.Second),
+					BlockTTL:  config.NewDuration(60 * time.Second),
 					WhiteLists: map[string][]string{
 						"gr1": {group1File.Path},
 						"gr2": {group2File.Path},
@@ -706,7 +706,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType:  "ZEROIP",
-					BlockTTL:   config.Duration(time.Minute),
+					BlockTTL:   config.NewDuration(time.Minute),
 					BlackLists: map[string][]string{"gr1": {group1File.Path}},
 					WhiteLists: map[string][]string{"gr1": {defaultGroupFile.Path}},
 					ClientGroupsBlock: map[string][]string{
@@ -733,7 +733,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		BeforeEach(func() {
 			sutConfig = config.BlockingConfig{
 				BlockType:  "ZEROIP",
-				BlockTTL:   config.Duration(time.Minute),
+				BlockTTL:   config.NewDuration(time.Minute),
 				BlackLists: map[string][]string{"gr1": {group1File.Path}},
 				ClientGroupsBlock: map[string][]string{
 					"default": {"gr1"},
@@ -759,7 +759,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType: "ZEROIP",
-					BlockTTL:  config.Duration(time.Minute),
+					BlockTTL:  config.NewDuration(time.Minute),
 				}
 			})
 			It("should delegate to next resolver", func() {
@@ -1091,7 +1091,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			BeforeEach(func() {
 				sutConfig = config.BlockingConfig{
 					BlockType:  "ZEROIP",
-					BlockTTL:   config.Duration(time.Minute),
+					BlockTTL:   config.NewDuration(time.Minute),
 					BlackLists: map[string][]string{"gr1": {group1File.Path}},
 					ClientGroupsBlock: map[string][]string{
 						"default": {"gr1"},
@@ -1159,7 +1159,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			Expect(redisClient).ShouldNot(BeNil())
 			sutConfig = config.BlockingConfig{
 				BlockType: "ZEROIP",
-				BlockTTL:  config.Duration(time.Minute),
+				BlockTTL:  config.NewDuration(time.Minute),
 			}
 
 			sut, err = NewBlockingResolver(sutConfig, redisClient, systemResolverBootstrap)

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/0xERR0R/blocky/evt"
 	. "github.com/0xERR0R/blocky/helpertest"
 	"github.com/0xERR0R/blocky/lists"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/redis"
 	"github.com/0xERR0R/blocky/util"
@@ -51,8 +52,6 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		mockAnswer *dns.Msg
 	)
 
-	systemResolverBootstrap := &Bootstrap{}
-
 	BeforeEach(func() {
 		sutConfig = config.BlockingConfig{
 			BlockType: "ZEROIP",
@@ -69,6 +68,22 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		sut, err = NewBlockingResolver(sutConfig, nil, systemResolverBootstrap)
 		Expect(err).Should(Succeed())
 		sut.Next(m)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is false", func() {
+			Expect(sut.IsEnabled()).Should(BeFalse())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
 	})
 
 	Describe("Events", func() {

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -52,6 +52,12 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		mockAnswer *dns.Msg
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		sutConfig = config.BlockingConfig{
 			BlockType: "ZEROIP",

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -1086,35 +1086,6 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 	})
 
-	Describe("Configuration output", func() {
-		When("resolver is enabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.BlockingConfig{
-					BlockType:  "ZEROIP",
-					BlockTTL:   config.Duration(time.Minute),
-					BlackLists: map[string][]string{"gr1": {group1File.Path}},
-					ClientGroupsBlock: map[string][]string{
-						"default": {"gr1"},
-					},
-				}
-			})
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
-			})
-		})
-
-		When("resolver is disabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.BlockingConfig{}
-			})
-		})
-		It("should return 'disabled'", func() {
-			c := sut.Configuration()
-			Expect(c).Should(ContainElement(configStatusDisabled))
-		})
-	})
-
 	Describe("Create resolver with wrong parameter", func() {
 		When("Wrong blockType is used", func() {
 			It("should return error", func() {

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -76,7 +76,7 @@ func NewBootstrap(cfg *config.Config) (b *Bootstrap, err error) {
 
 	if cachingCfg.MinCachingTime.IsZero() {
 		// Set a min time in case the user didn't to avoid prefetching too often
-		cachingCfg.MinCachingTime = config.NewDuration(time.Hour)
+		cachingCfg.MinCachingTime = config.Duration(time.Hour)
 	}
 
 	b.bootstraped = bootstraped

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -119,7 +119,7 @@ func (b *Bootstrap) resolveUpstream(r Resolver, host string) ([]net.IP, error) {
 		if timeout.IsZero() {
 			var cancel context.CancelFunc
 
-			ctx, cancel = context.WithTimeout(ctx, timeout.Cast())
+			ctx, cancel = context.WithTimeout(ctx, timeout.ToDuration())
 			defer cancel()
 		}
 

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -74,9 +74,9 @@ func NewBootstrap(cfg *config.Config) (b *Bootstrap, err error) {
 	cachingCfg := cfg.Caching
 	cachingCfg.EnablePrefetch()
 
-	if cachingCfg.MinCachingTime == 0 {
+	if cachingCfg.MinCachingTime.IsZero() {
 		// Set a min time in case the user didn't to avoid prefetching too often
-		cachingCfg.MinCachingTime = config.Duration(time.Hour)
+		cachingCfg.MinCachingTime = config.NewDuration(time.Hour)
 	}
 
 	b.bootstraped = bootstraped
@@ -116,10 +116,10 @@ func (b *Bootstrap) resolveUpstream(r Resolver, host string) ([]net.IP, error) {
 		ctx := context.Background()
 
 		timeout := cfg.UpstreamTimeout
-		if timeout != 0 {
+		if timeout.IsZero() {
 			var cancel context.CancelFunc
 
-			ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout))
+			ctx, cancel = context.WithTimeout(ctx, timeout.Cast())
 			defer cancel()
 		}
 

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -64,7 +64,7 @@ func NewBootstrap(cfg *config.Config) (b *Bootstrap, err error) {
 
 	// Bootstrap doesn't have a `LogConfig` method, and since that's the only place
 	// where `ParallelBestResolver` uses its config, we can just use an empty one.
-	pbCfg := config.UpstreamConfig{}
+	pbCfg := config.ParallelBestConfig{}
 
 	parallelResolver, err := newParallelBestResolver(pbCfg, bootstraped.ResolverGroups())
 	if err != nil {

--- a/resolver/bootstrap_test.go
+++ b/resolver/bootstrap_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				Expect(err).ShouldNot(Succeed())
 				Expect(err.Error()).Should(ContainSubstring(resolveErr.Error()))
-				Expect(ips).Should(HaveLen(0))
+				Expect(ips).Should(BeEmpty())
 			})
 		})
 
@@ -296,7 +296,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				Expect(err).ShouldNot(Succeed())
 				Expect(err.Error()).Should(ContainSubstring("no such host"))
-				Expect(ips).Should(HaveLen(0))
+				Expect(ips).Should(BeEmpty())
 			})
 		})
 

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -129,14 +129,14 @@ func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.
 	return nil, 0
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *CachingResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *CachingResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *CachingResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 
 	logger.Infof("cache entries = %d", r.resultCache.TotalCount())
 }

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -45,9 +45,9 @@ type cacheValue struct {
 // NewCachingResolver creates a new resolver instance
 func NewCachingResolver(cfg config.CachingConfig, redis *redis.Client) *CachingResolver {
 	c := &CachingResolver{
-		minCacheTimeSec:   int(time.Duration(cfg.MinCachingTime).Seconds()),
-		maxCacheTimeSec:   int(time.Duration(cfg.MaxCachingTime).Seconds()),
-		cacheTimeNegative: time.Duration(cfg.CacheTimeNegative),
+		minCacheTimeSec:   int(cfg.MinCachingTime.Seconds()),
+		maxCacheTimeSec:   int(cfg.MaxCachingTime.Seconds()),
+		cacheTimeNegative: cfg.CacheTimeNegative.Cast(),
 		redisClient:       redis,
 		redisEnabled:      (redis != nil),
 		emitMetricEvents:  true,
@@ -68,7 +68,7 @@ func configureCaches(c *CachingResolver, cfg *config.CachingConfig) {
 	maxSizeOption := expirationcache.WithMaxSize(uint(cfg.MaxItemsCount))
 
 	if cfg.Prefetching {
-		c.prefetchExpires = time.Duration(cfg.PrefetchExpires)
+		c.prefetchExpires = cfg.PrefetchExpires.Cast()
 
 		c.prefetchThreshold = cfg.PrefetchThreshold
 

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -24,6 +24,7 @@ const defaultCachingCleanUpInterval = 5 * time.Second
 type CachingResolver struct {
 	configurable[*config.CachingConfig]
 	NextResolver
+	typed
 
 	emitMetricEvents bool // disabled by Bootstrap
 
@@ -46,6 +47,7 @@ func NewCachingResolver(cfg config.CachingConfig, redis *redis.Client) *CachingR
 func newCachingResolver(cfg config.CachingConfig, redis *redis.Client, emitMetricEvents bool) *CachingResolver {
 	c := &CachingResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("caching"),
 
 		redisClient:      redis,
 		emitMetricEvents: emitMetricEvents,

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -47,7 +47,7 @@ func NewCachingResolver(cfg config.CachingConfig, redis *redis.Client) *CachingR
 	c := &CachingResolver{
 		minCacheTimeSec:   int(cfg.MinCachingTime.Seconds()),
 		maxCacheTimeSec:   int(cfg.MaxCachingTime.Seconds()),
-		cacheTimeNegative: cfg.CacheTimeNegative.Cast(),
+		cacheTimeNegative: cfg.CacheTimeNegative.ToDuration(),
 		redisClient:       redis,
 		redisEnabled:      (redis != nil),
 		emitMetricEvents:  true,
@@ -68,7 +68,7 @@ func configureCaches(c *CachingResolver, cfg *config.CachingConfig) {
 	maxSizeOption := expirationcache.WithMaxSize(uint(cfg.MaxItemsCount))
 
 	if cfg.Prefetching {
-		c.prefetchExpires = cfg.PrefetchExpires.Cast()
+		c.prefetchExpires = cfg.PrefetchExpires.ToDuration()
 
 		c.prefetchThreshold = cfg.PrefetchThreshold
 

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -84,12 +84,10 @@ func configureCaches(c *CachingResolver, cfg *config.CachingConfig) {
 }
 
 func setupRedisCacheSubscriber(c *CachingResolver) {
-	logger := log.PrefixedLog("caching_resolver")
-
 	go func() {
 		for rc := range c.redisClient.CacheChannel {
 			if rc != nil {
-				logger.Debug("Received key from redis: ", rc.Key)
+				c.log().Debug("Received key from redis: ", rc.Key)
 				c.putInCache(rc.Key, rc.Response, false, false)
 			}
 		}
@@ -110,9 +108,9 @@ func (r *CachingResolver) shouldPrefetch(cacheKey string) bool {
 func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.Duration) {
 	qType, domainName := util.ExtractCacheKey(cacheKey)
 
-	logger := log.PrefixedLog("caching_resolver")
-
 	if r.shouldPrefetch(cacheKey) {
+		logger := r.log()
+
 		logger.Debugf("prefetching '%s' (%s)", util.Obfuscate(domainName), qType)
 
 		req := newRequest(fmt.Sprintf("%s.", domainName), qType, logger)

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -22,9 +22,9 @@ const defaultCachingCleanUpInterval = 5 * time.Second
 // CachingResolver caches answers from dns queries with their TTL time,
 // to avoid external resolver calls for recurrent queries
 type CachingResolver struct {
+	configurable[*config.CachingConfig]
 	NextResolver
 
-	cfg              config.CachingConfig
 	emitMetricEvents bool // disabled by Bootstrap
 
 	resultCache          expirationcache.ExpiringCache
@@ -45,7 +45,8 @@ func NewCachingResolver(cfg config.CachingConfig, redis *redis.Client) *CachingR
 
 func newCachingResolver(cfg config.CachingConfig, redis *redis.Client, emitMetricEvents bool) *CachingResolver {
 	c := &CachingResolver{
-		cfg:              cfg,
+		configurable: withConfig(&cfg),
+
 		redisClient:      redis,
 		emitMetricEvents: emitMetricEvents,
 	}
@@ -127,11 +128,6 @@ func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.
 	}
 
 	return nil, 0
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *CachingResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
 }
 
 // LogConfig implements `config.Configurable`.

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -129,29 +129,16 @@ func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.
 	return nil, 0
 }
 
-// Configuration returns a current resolver configuration
-func (r *CachingResolver) Configuration() (result []string) {
-	if r.cfg.MaxCachingTime < 0 {
-		return configDisabled
-	}
+// IsEnabled implements `config.ValueLogger`.
+func (r *CachingResolver) IsEnabled() bool {
+	return r.cfg.IsEnabled()
+}
 
-	result = append(result, fmt.Sprintf("minCacheTimeInSec = %d", r.cfg.MinCachingTime))
+// LogValues implements `config.ValueLogger`.
+func (r *CachingResolver) LogValues(logger *logrus.Entry) {
+	r.cfg.LogValues(logger)
 
-	result = append(result, fmt.Sprintf("maxCacheTimeSec = %d", r.cfg.MaxCachingTime))
-
-	result = append(result, fmt.Sprintf("cacheTimeNegative = %s", r.cfg.CacheTimeNegative))
-
-	result = append(result, fmt.Sprintf("prefetching = %t", r.prefetchingNameCache != nil))
-
-	if r.prefetchingNameCache != nil {
-		result = append(result, fmt.Sprintf("prefetchExpires = %s", r.cfg.PrefetchExpires))
-
-		result = append(result, fmt.Sprintf("prefetchThreshold = %d", r.cfg.PrefetchThreshold))
-	}
-
-	result = append(result, fmt.Sprintf("cache items count = %d", r.resultCache.TotalCount()))
-
-	return
+	logger.Infof("cache entries = %d", r.resultCache.TotalCount())
 }
 
 // Resolve checks if the current query result is already in the cache and returns it

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -5,8 +5,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hako/durafmt"
-
 	"github.com/0xERR0R/blocky/cache/expirationcache"
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/evt"
@@ -25,15 +23,13 @@ const defaultCachingCleanUpInterval = 5 * time.Second
 // to avoid external resolver calls for recurrent queries
 type CachingResolver struct {
 	NextResolver
-	minCacheTimeSec, maxCacheTimeSec int
-	cacheTimeNegative                time.Duration
-	resultCache                      expirationcache.ExpiringCache
-	prefetchExpires                  time.Duration
-	prefetchThreshold                int
-	prefetchingNameCache             expirationcache.ExpiringCache
-	redisClient                      *redis.Client
-	redisEnabled                     bool
-	emitMetricEvents                 bool
+
+	cfg              config.CachingConfig
+	emitMetricEvents bool // disabled by Bootstrap
+
+	resultCache          expirationcache.ExpiringCache
+	prefetchingNameCache expirationcache.ExpiringCache
+	redisClient          *redis.Client
 }
 
 // cacheValue includes query answer and prefetch flag
@@ -44,18 +40,19 @@ type cacheValue struct {
 
 // NewCachingResolver creates a new resolver instance
 func NewCachingResolver(cfg config.CachingConfig, redis *redis.Client) *CachingResolver {
+	return newCachingResolver(cfg, redis, true)
+}
+
+func newCachingResolver(cfg config.CachingConfig, redis *redis.Client, emitMetricEvents bool) *CachingResolver {
 	c := &CachingResolver{
-		minCacheTimeSec:   int(cfg.MinCachingTime.Seconds()),
-		maxCacheTimeSec:   int(cfg.MaxCachingTime.Seconds()),
-		cacheTimeNegative: cfg.CacheTimeNegative.ToDuration(),
-		redisClient:       redis,
-		redisEnabled:      (redis != nil),
-		emitMetricEvents:  true,
+		cfg:              cfg,
+		redisClient:      redis,
+		emitMetricEvents: emitMetricEvents,
 	}
 
 	configureCaches(c, &cfg)
 
-	if c.redisEnabled {
+	if c.redisClient != nil {
 		setupRedisCacheSubscriber(c)
 		c.redisClient.GetRedisCache()
 	}
@@ -68,10 +65,6 @@ func configureCaches(c *CachingResolver, cfg *config.CachingConfig) {
 	maxSizeOption := expirationcache.WithMaxSize(uint(cfg.MaxItemsCount))
 
 	if cfg.Prefetching {
-		c.prefetchExpires = cfg.PrefetchExpires.ToDuration()
-
-		c.prefetchThreshold = cfg.PrefetchThreshold
-
 		c.prefetchingNameCache = expirationcache.NewCache(
 			expirationcache.WithCleanUpInterval(time.Minute),
 			expirationcache.WithMaxSize(uint(cfg.PrefetchMaxItemsCount)),
@@ -102,13 +95,13 @@ func setupRedisCacheSubscriber(c *CachingResolver) {
 
 // check if domain was queried > threshold in the time window
 func (r *CachingResolver) shouldPrefetch(cacheKey string) bool {
-	if r.prefetchThreshold == 0 {
+	if r.cfg.PrefetchThreshold == 0 {
 		return true
 	}
 
 	cnt, _ := r.prefetchingNameCache.Get(cacheKey)
 
-	return cnt != nil && cnt.(int) > r.prefetchThreshold
+	return cnt != nil && cnt.(int) > r.cfg.PrefetchThreshold
 }
 
 func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.Duration) {
@@ -117,7 +110,7 @@ func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.
 	logger := log.PrefixedLog("caching_resolver")
 
 	if r.shouldPrefetch(cacheKey) {
-		logger.Debugf("prefetching '%s' (%s)", util.Obfuscate(domainName), qType.String())
+		logger.Debugf("prefetching '%s' (%s)", util.Obfuscate(domainName), qType)
 
 		req := newRequest(fmt.Sprintf("%s.", domainName), qType, logger)
 		response, err := r.next.Resolve(req)
@@ -138,22 +131,22 @@ func (r *CachingResolver) onExpired(cacheKey string) (val interface{}, ttl time.
 
 // Configuration returns a current resolver configuration
 func (r *CachingResolver) Configuration() (result []string) {
-	if r.maxCacheTimeSec < 0 {
+	if r.cfg.MaxCachingTime < 0 {
 		return configDisabled
 	}
 
-	result = append(result, fmt.Sprintf("minCacheTimeInSec = %d", r.minCacheTimeSec))
+	result = append(result, fmt.Sprintf("minCacheTimeInSec = %d", r.cfg.MinCachingTime))
 
-	result = append(result, fmt.Sprintf("maxCacheTimeSec = %d", r.maxCacheTimeSec))
+	result = append(result, fmt.Sprintf("maxCacheTimeSec = %d", r.cfg.MaxCachingTime))
 
-	result = append(result, fmt.Sprintf("cacheTimeNegative = %s", durafmt.Parse(r.cacheTimeNegative)))
+	result = append(result, fmt.Sprintf("cacheTimeNegative = %s", r.cfg.CacheTimeNegative))
 
 	result = append(result, fmt.Sprintf("prefetching = %t", r.prefetchingNameCache != nil))
 
 	if r.prefetchingNameCache != nil {
-		result = append(result, fmt.Sprintf("prefetchExpires = %s", durafmt.Parse(r.prefetchExpires)))
+		result = append(result, fmt.Sprintf("prefetchExpires = %s", r.cfg.PrefetchExpires))
 
-		result = append(result, fmt.Sprintf("prefetchThreshold = %d", r.prefetchThreshold))
+		result = append(result, fmt.Sprintf("prefetchThreshold = %d", r.cfg.PrefetchThreshold))
 	}
 
 	result = append(result, fmt.Sprintf("cache items count = %d", r.resultCache.TotalCount()))
@@ -166,7 +159,7 @@ func (r *CachingResolver) Configuration() (result []string) {
 func (r *CachingResolver) Resolve(request *model.Request) (response *model.Response, err error) {
 	logger := log.WithPrefix(request.Log, "caching_resolver")
 
-	if r.maxCacheTimeSec < 0 {
+	if r.cfg.MaxCachingTime < 0 {
 		logger.Debug("skip cache")
 
 		return r.next.Resolve(request)
@@ -214,7 +207,7 @@ func (r *CachingResolver) Resolve(request *model.Request) (response *model.Respo
 		response, err = r.next.Resolve(request)
 
 		if err == nil {
-			r.putInCache(cacheKey, response, false, r.redisEnabled)
+			r.putInCache(cacheKey, response, false, true)
 		}
 	}
 
@@ -228,7 +221,7 @@ func (r *CachingResolver) trackQueryDomainNameCount(domain, cacheKey string, log
 			domainCount = x.(int)
 		}
 		domainCount++
-		r.prefetchingNameCache.Put(cacheKey, domainCount, r.prefetchExpires)
+		r.prefetchingNameCache.Put(cacheKey, domainCount, r.cfg.PrefetchExpires.ToDuration())
 		totalCount := r.prefetchingNameCache.TotalCount()
 
 		logger.Debugf("domain '%s' was requested %d times, "+
@@ -242,9 +235,9 @@ func (r *CachingResolver) putInCache(cacheKey string, response *model.Response, 
 		// put value into cache
 		r.resultCache.Put(cacheKey, cacheValue{response.Res, prefetch}, r.adjustTTLs(response.Res.Answer))
 	} else if response.Res.Rcode == dns.RcodeNameError {
-		if r.cacheTimeNegative > 0 {
+		if r.cfg.CacheTimeNegative > 0 {
 			// put negative cache if result code is NXDOMAIN
-			r.resultCache.Put(cacheKey, cacheValue{response.Res, prefetch}, r.cacheTimeNegative)
+			r.resultCache.Put(cacheKey, cacheValue{response.Res, prefetch}, r.cfg.CacheTimeNegative.ToDuration())
 		}
 	}
 
@@ -264,20 +257,20 @@ func (r *CachingResolver) adjustTTLs(answer []dns.RR) (maxTTL time.Duration) {
 	var max uint32
 
 	if len(answer) == 0 {
-		return r.cacheTimeNegative
+		return r.cfg.CacheTimeNegative.ToDuration()
 	}
 
 	for _, a := range answer {
 		// if TTL < mitTTL -> adjust the value, set minTTL
-		if r.minCacheTimeSec > 0 {
-			if atomic.LoadUint32(&a.Header().Ttl) < uint32(r.minCacheTimeSec) {
-				atomic.StoreUint32(&a.Header().Ttl, uint32(r.minCacheTimeSec))
+		if r.cfg.MinCachingTime > 0 {
+			if atomic.LoadUint32(&a.Header().Ttl) < r.cfg.MinCachingTime.SecondsU32() {
+				atomic.StoreUint32(&a.Header().Ttl, r.cfg.MinCachingTime.SecondsU32())
 			}
 		}
 
-		if r.maxCacheTimeSec > 0 {
-			if atomic.LoadUint32(&a.Header().Ttl) > uint32(r.maxCacheTimeSec) {
-				atomic.StoreUint32(&a.Header().Ttl, uint32(r.maxCacheTimeSec))
+		if r.cfg.MaxCachingTime > 0 {
+			if atomic.LoadUint32(&a.Header().Ttl) > r.cfg.MaxCachingTime.SecondsU32() {
+				atomic.StoreUint32(&a.Header().Ttl, r.cfg.MaxCachingTime.SecondsU32())
 			}
 		}
 

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -364,6 +364,10 @@ var _ = Describe("CachingResolver", func() {
 				})
 
 				It("response should be cached", func() {
+					By("default config should enable negative caching", func() {
+						Expect(sutConfig.CacheTimeNegative).Should(BeNumerically(">", 0))
+					})
+
 					By("first request", func() {
 						Expect(sut.Resolve(newRequest("example.com.", AAAA))).
 							Should(SatisfyAll(

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -47,7 +47,7 @@ var _ = Describe("CachingResolver", func() {
 			BeforeEach(func() {
 				sutConfig = config.CachingConfig{
 					Prefetching:       true,
-					PrefetchExpires:   config.NewDuration(time.Minute * 120),
+					PrefetchExpires:   config.Duration(time.Minute * 120),
 					PrefetchThreshold: 5,
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 2, A, "123.122.121.120")
@@ -107,7 +107,7 @@ var _ = Describe("CachingResolver", func() {
 		When("min caching time is defined", func() {
 			BeforeEach(func() {
 				sutConfig = config.CachingConfig{
-					MinCachingTime: config.NewDuration(time.Minute * 5),
+					MinCachingTime: config.Duration(time.Minute * 5),
 				}
 			})
 			Context("response TTL is bigger than defined min caching time", func() {
@@ -246,7 +246,7 @@ var _ = Describe("CachingResolver", func() {
 			Context("max caching time is negative -> caching is disabled", func() {
 				BeforeEach(func() {
 					sutConfig = config.CachingConfig{
-						MaxCachingTime: config.NewDuration(time.Minute * -1),
+						MaxCachingTime: config.Duration(time.Minute * -1),
 					}
 				})
 
@@ -281,7 +281,7 @@ var _ = Describe("CachingResolver", func() {
 			Context("max caching time is positive", func() {
 				BeforeEach(func() {
 					sutConfig = config.CachingConfig{
-						MaxCachingTime: config.NewDuration(time.Minute * 4),
+						MaxCachingTime: config.Duration(time.Minute * 4),
 					}
 				})
 				It("should cache response and use max caching time as TTL if response TTL is bigger", func() {
@@ -320,7 +320,7 @@ var _ = Describe("CachingResolver", func() {
 			Context("max caching time is defined", func() {
 				BeforeEach(func() {
 					sutConfig = config.CachingConfig{
-						MaxCachingTime: config.NewDuration(time.Minute * 1),
+						MaxCachingTime: config.Duration(time.Minute * 1),
 					}
 				})
 				It("should cache response and return 0 TTL if entry is expired", func() {
@@ -393,7 +393,7 @@ var _ = Describe("CachingResolver", func() {
 				BeforeEach(func() {
 					mockAnswer.Rcode = dns.RcodeNameError
 					sutConfig = config.CachingConfig{
-						CacheTimeNegative: config.NewDuration(time.Minute * -1),
+						CacheTimeNegative: config.Duration(time.Minute * -1),
 					}
 				})
 
@@ -509,7 +509,7 @@ var _ = Describe("CachingResolver", func() {
 		When("resolver is disabled", func() {
 			BeforeEach(func() {
 				sutConfig = config.CachingConfig{
-					MaxCachingTime: config.NewDuration(time.Minute * -1),
+					MaxCachingTime: config.Duration(time.Minute * -1),
 				}
 			})
 			It("should return 'disabled'", func() {
@@ -562,7 +562,7 @@ var _ = Describe("CachingResolver", func() {
 		When("cache", func() {
 			JustBeforeEach(func() {
 				sutConfig = config.CachingConfig{
-					MaxCachingTime: config.NewDuration(time.Second * 10),
+					MaxCachingTime: config.Duration(time.Second * 10),
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 1000, A, "1.1.1.1")
 

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -499,43 +499,6 @@ var _ = Describe("CachingResolver", func() {
 		})
 	})
 
-	Describe("Configuration output", func() {
-		When("resolver is enabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.CachingConfig{}
-			})
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
-			})
-		})
-
-		When("resolver is disabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.CachingConfig{
-					MaxCachingTime: config.Duration(time.Minute * -1),
-				}
-			})
-			It("should return 'disabled'", func() {
-				c := sut.Configuration()
-				Expect(c).Should(ContainElement(configStatusDisabled))
-			})
-		})
-
-		When("prefetching is enabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.CachingConfig{
-					Prefetching: true,
-				}
-			})
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
-				Expect(c).Should(ContainElement(ContainSubstring("prefetchThreshold")))
-			})
-		})
-	})
-
 	Describe("Redis is configured", func() {
 		var (
 			redisServer *miniredis.Miniredis

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -47,7 +47,7 @@ var _ = Describe("CachingResolver", func() {
 			BeforeEach(func() {
 				sutConfig = config.CachingConfig{
 					Prefetching:       true,
-					PrefetchExpires:   config.Duration(time.Minute * 120),
+					PrefetchExpires:   config.NewDuration(time.Minute * 120),
 					PrefetchThreshold: 5,
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 2, A, "123.122.121.120")
@@ -107,7 +107,7 @@ var _ = Describe("CachingResolver", func() {
 		When("min caching time is defined", func() {
 			BeforeEach(func() {
 				sutConfig = config.CachingConfig{
-					MinCachingTime: config.Duration(time.Minute * 5),
+					MinCachingTime: config.NewDuration(time.Minute * 5),
 				}
 			})
 			Context("response TTL is bigger than defined min caching time", func() {
@@ -246,7 +246,7 @@ var _ = Describe("CachingResolver", func() {
 			Context("max caching time is negative -> caching is disabled", func() {
 				BeforeEach(func() {
 					sutConfig = config.CachingConfig{
-						MaxCachingTime: config.Duration(time.Minute * -1),
+						MaxCachingTime: config.NewDuration(time.Minute * -1),
 					}
 				})
 
@@ -281,7 +281,7 @@ var _ = Describe("CachingResolver", func() {
 			Context("max caching time is positive", func() {
 				BeforeEach(func() {
 					sutConfig = config.CachingConfig{
-						MaxCachingTime: config.Duration(time.Minute * 4),
+						MaxCachingTime: config.NewDuration(time.Minute * 4),
 					}
 				})
 				It("should cache response and use max caching time as TTL if response TTL is bigger", func() {
@@ -320,7 +320,7 @@ var _ = Describe("CachingResolver", func() {
 			Context("max caching time is defined", func() {
 				BeforeEach(func() {
 					sutConfig = config.CachingConfig{
-						MaxCachingTime: config.Duration(time.Minute * 1),
+						MaxCachingTime: config.NewDuration(time.Minute * 1),
 					}
 				})
 				It("should cache response and return 0 TTL if entry is expired", func() {
@@ -393,7 +393,7 @@ var _ = Describe("CachingResolver", func() {
 				BeforeEach(func() {
 					mockAnswer.Rcode = dns.RcodeNameError
 					sutConfig = config.CachingConfig{
-						CacheTimeNegative: config.Duration(time.Minute * -1),
+						CacheTimeNegative: config.NewDuration(time.Minute * -1),
 					}
 				})
 
@@ -509,7 +509,7 @@ var _ = Describe("CachingResolver", func() {
 		When("resolver is disabled", func() {
 			BeforeEach(func() {
 				sutConfig = config.CachingConfig{
-					MaxCachingTime: config.Duration(time.Minute * -1),
+					MaxCachingTime: config.NewDuration(time.Minute * -1),
 				}
 			})
 			It("should return 'disabled'", func() {
@@ -562,7 +562,7 @@ var _ = Describe("CachingResolver", func() {
 		When("cache", func() {
 			JustBeforeEach(func() {
 				sutConfig = config.CachingConfig{
-					MaxCachingTime: config.Duration(time.Second * 10),
+					MaxCachingTime: config.NewDuration(time.Second * 10),
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 1000, A, "1.1.1.1")
 

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -28,6 +28,12 @@ var _ = Describe("CachingResolver", func() {
 		mockAnswer *dns.Msg
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		sutConfig = config.CachingConfig{}
 		if err := defaults.Set(&sutConfig); err != nil {

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -120,6 +120,15 @@ var _ = Describe("CachingResolver", func() {
 							HaveTTL(BeNumerically("<=", 2))))
 				Eventually(prefetchHitDomain, "4s").Should(Receive(Equal("example.com")))
 			})
+			When("threshold is 0", func() {
+				BeforeEach(func() {
+					sutConfig.PrefetchThreshold = 0
+				})
+
+				It("should always prefetch", func() {
+					Expect(sut.shouldPrefetch("domain.tld")).Should(BeTrue())
+				})
+			})
 		})
 		When("min caching time is defined", func() {
 			BeforeEach(func() {

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/evt"
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/redis"
 	"github.com/0xERR0R/blocky/util"
@@ -40,6 +41,22 @@ var _ = Describe("CachingResolver", func() {
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 		sut.Next(m)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is false", func() {
+			Expect(sut.IsEnabled()).Should(BeFalse())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
 	})
 
 	Describe("Caching responses", func() {

--- a/resolver/client_names_resolver.go
+++ b/resolver/client_names_resolver.go
@@ -17,9 +17,8 @@ import (
 
 // ClientNamesResolver tries to determine client name by asking responsible DNS server via rDNS (reverse lookup)
 type ClientNamesResolver struct {
+	configurable[*config.ClientLookupConfig]
 	NextResolver
-
-	cfg config.ClientLookupConfig
 
 	cache            expirationcache.ExpiringCache
 	externalResolver Resolver
@@ -38,18 +37,13 @@ func NewClientNamesResolver(
 	}
 
 	cr = &ClientNamesResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 
 		cache:            expirationcache.NewCache(expirationcache.WithCleanUpInterval(time.Hour)),
 		externalResolver: r,
 	}
 
 	return
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *ClientNamesResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
 }
 
 // LogConfig implements `config.Configurable`.

--- a/resolver/client_names_resolver.go
+++ b/resolver/client_names_resolver.go
@@ -47,14 +47,14 @@ func NewClientNamesResolver(
 	return
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *ClientNamesResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *ClientNamesResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *ClientNamesResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 
 	logger.Infof("cache entries = %d", r.cache.TotalCount())
 }

--- a/resolver/client_names_resolver.go
+++ b/resolver/client_names_resolver.go
@@ -19,6 +19,7 @@ import (
 type ClientNamesResolver struct {
 	configurable[*config.ClientLookupConfig]
 	NextResolver
+	typed
 
 	cache            expirationcache.ExpiringCache
 	externalResolver Resolver
@@ -38,6 +39,7 @@ func NewClientNamesResolver(
 
 	cr = &ClientNamesResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("client_names"),
 
 		cache:            expirationcache.NewCache(expirationcache.WithCleanUpInterval(time.Hour)),
 		externalResolver: r,

--- a/resolver/client_names_resolver_test.go
+++ b/resolver/client_names_resolver_test.go
@@ -348,32 +348,4 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 			})
 		})
 	})
-
-	Describe("Configuration output", func() {
-		When("resolver is enabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.ClientLookupConfig{
-					Upstream:        config.Upstream{Net: config.NetProtocolTcpUdp, Host: "host"},
-					SingleNameOrder: []uint{1, 2},
-					ClientnameIPMapping: map[string][]net.IP{
-						"client8": {net.ParseIP("1.2.3.5")},
-					},
-				}
-			})
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
-			})
-		})
-
-		When("resolver is disabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.ClientLookupConfig{}
-			})
-			It("should return 'disabled'", func() {
-				c := sut.Configuration()
-				Expect(c).Should(ContainElement(configStatusDisabled))
-			})
-		})
-	})
 })

--- a/resolver/client_names_resolver_test.go
+++ b/resolver/client_names_resolver_test.go
@@ -23,6 +23,12 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 		m         *mockResolver
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	JustBeforeEach(func() {
 		res, err := NewClientNamesResolver(sutConfig, nil, false)
 		Expect(err).Should(Succeed())

--- a/resolver/client_names_resolver_test.go
+++ b/resolver/client_names_resolver_test.go
@@ -298,7 +298,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 				})
 			})
 			When("Upstream produces error", func() {
-				BeforeEach(func() {
+				JustBeforeEach(func() {
 					sutConfig = config.ClientLookupConfig{}
 					clientMockResolver := &mockResolver{}
 					clientMockResolver.On("Resolve", mock.Anything).Return(nil, errors.New("error"))

--- a/resolver/client_names_resolver_test.go
+++ b/resolver/client_names_resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 
 	. "github.com/0xERR0R/blocky/helpertest"
 	. "github.com/0xERR0R/blocky/model"
@@ -29,6 +30,22 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is false", func() {
+			Expect(sut.IsEnabled()).Should(BeFalse())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
 	})
 
 	Describe("Resolve client name from request clientID", func() {

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -16,6 +16,9 @@ import (
 // ConditionalUpstreamResolver delegates DNS question to other DNS resolver dependent on domain name in question
 type ConditionalUpstreamResolver struct {
 	NextResolver
+
+	cfg config.ConditionalUpstreamConfig
+
 	mapping map[string]Resolver
 }
 
@@ -26,10 +29,13 @@ func NewConditionalUpstreamResolver(
 	m := make(map[string]Resolver, len(cfg.Mapping.Upstreams))
 
 	for domain, upstream := range cfg.Mapping.Upstreams {
-		upstreams := make(map[string][]config.Upstream)
-		upstreams[upstreamDefaultCfgName] = upstream
+		pbCfg := config.UpstreamConfig{
+			ExternalResolvers: config.UpstreamMapping{
+				upstreamDefaultCfgName: upstream,
+			},
+		}
 
-		r, err := NewParallelBestResolver(upstreams, bootstrap, shouldVerifyUpstreams)
+		r, err := NewParallelBestResolver(pbCfg, bootstrap, shouldVerifyUpstreams)
 		if err != nil {
 			return nil, err
 		}

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -14,9 +14,8 @@ import (
 
 // ConditionalUpstreamResolver delegates DNS question to other DNS resolver dependent on domain name in question
 type ConditionalUpstreamResolver struct {
+	configurable[*config.ConditionalUpstreamConfig]
 	NextResolver
-
-	cfg config.ConditionalUpstreamConfig
 
 	mapping map[string]Resolver
 }
@@ -43,22 +42,12 @@ func NewConditionalUpstreamResolver(
 	}
 
 	r := ConditionalUpstreamResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 
 		mapping: m,
 	}
 
 	return &r, nil
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *ConditionalUpstreamResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
-}
-
-// LogConfig implements `config.Configurable`.
-func (r *ConditionalUpstreamResolver) LogConfig(logger *logrus.Entry) {
-	r.cfg.LogConfig(logger)
 }
 
 func (r *ConditionalUpstreamResolver) processRequest(request *model.Request) (bool, *model.Response, error) {

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -16,6 +16,7 @@ import (
 type ConditionalUpstreamResolver struct {
 	configurable[*config.ConditionalUpstreamConfig]
 	NextResolver
+	typed
 
 	mapping map[string]Resolver
 }
@@ -43,6 +44,7 @@ func NewConditionalUpstreamResolver(
 
 	r := ConditionalUpstreamResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("conditional_upstream"),
 
 		mapping: m,
 	}

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -51,14 +51,14 @@ func NewConditionalUpstreamResolver(
 	return &r, nil
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *ConditionalUpstreamResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *ConditionalUpstreamResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *ConditionalUpstreamResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 }
 
 func (r *ConditionalUpstreamResolver) processRequest(request *model.Request) (bool, *model.Response, error) {

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
@@ -43,20 +42,23 @@ func NewConditionalUpstreamResolver(
 		m[strings.ToLower(domain)] = r
 	}
 
-	return &ConditionalUpstreamResolver{mapping: m}, nil
+	r := ConditionalUpstreamResolver{
+		cfg: cfg,
+
+		mapping: m,
+	}
+
+	return &r, nil
 }
 
-// Configuration returns current configuration
-func (r *ConditionalUpstreamResolver) Configuration() (result []string) {
-	if len(r.mapping) == 0 {
-		return configDisabled
-	}
+// IsEnabled implements `config.ValueLogger`.
+func (r *ConditionalUpstreamResolver) IsEnabled() bool {
+	return r.cfg.IsEnabled()
+}
 
-	for key, val := range r.mapping {
-		result = append(result, fmt.Sprintf("%s = \"%s\"", key, val))
-	}
-
-	return
+// LogValues implements `config.ValueLogger`.
+func (r *ConditionalUpstreamResolver) LogValues(logger *logrus.Entry) {
+	r.cfg.LogValues(logger)
 }
 
 func (r *ConditionalUpstreamResolver) processRequest(request *model.Request) (bool, *model.Response, error) {

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -28,8 +28,8 @@ func NewConditionalUpstreamResolver(
 	m := make(map[string]Resolver, len(cfg.Mapping.Upstreams))
 
 	for domain, upstream := range cfg.Mapping.Upstreams {
-		pbCfg := config.UpstreamConfig{
-			ExternalResolvers: config.UpstreamMapping{
+		pbCfg := config.ParallelBestConfig{
+			ExternalResolvers: config.ParallelBestMapping{
 				upstreamDefaultCfgName: upstream,
 			},
 		}

--- a/resolver/conditional_upstream_resolver_test.go
+++ b/resolver/conditional_upstream_resolver_test.go
@@ -19,6 +19,12 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 		m   *mockResolver
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		fbTestUpstream := NewMockUDPUpstreamServer().WithAnswerFn(func(request *dns.Msg) (response *dns.Msg) {
 			response, _ = util.NewMsgWithAnswer(request.Question[0].Name, 123, A, "123.124.122.122")

--- a/resolver/conditional_upstream_resolver_test.go
+++ b/resolver/conditional_upstream_resolver_test.go
@@ -149,22 +149,4 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 			Expect(r).Should(BeNil())
 		})
 	})
-
-	Describe("Configuration output", func() {
-		When("resolver is enabled", func() {
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
-			})
-		})
-		When("resolver is disabled", func() {
-			BeforeEach(func() {
-				sut, _ = NewConditionalUpstreamResolver(config.ConditionalUpstreamConfig{}, nil, false)
-			})
-			It("should return 'disabled'", func() {
-				c := sut.Configuration()
-				Expect(c).Should(ContainElement(configStatusDisabled))
-			})
-		})
-	})
 })

--- a/resolver/conditional_upstream_resolver_test.go
+++ b/resolver/conditional_upstream_resolver_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 
@@ -52,6 +53,22 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is true", func() {
+			Expect(sut.IsEnabled()).Should(BeTrue())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
 	})
 
 	Describe("Resolve conditional DNS queries via defined DNS server", func() {

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
@@ -46,17 +45,14 @@ func NewCustomDNSResolver(cfg config.CustomDNSConfig) ChainedResolver {
 	}
 }
 
-// Configuration returns current resolver configuration
-func (r *CustomDNSResolver) Configuration() (result []string) {
-	if len(r.mapping) == 0 {
-		return configDisabled
-	}
+// IsEnabled implements `config.ValueLogger`.
+func (r *CustomDNSResolver) IsEnabled() bool {
+	return r.cfg.IsEnabled()
+}
 
-	for key, val := range r.mapping {
-		result = append(result, fmt.Sprintf("%s = \"%s\"", key, val))
-	}
-
-	return
+// LogValues implements `config.ValueLogger`.
+func (r *CustomDNSResolver) LogValues(logger *logrus.Entry) {
+	r.cfg.LogValues(logger)
 }
 
 func isSupportedType(ip net.IP, question dns.Question) bool {

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -17,6 +17,7 @@ import (
 type CustomDNSResolver struct {
 	configurable[*config.CustomDNSConfig]
 	NextResolver
+	typed
 
 	mapping          map[string][]net.IP
 	reverseAddresses map[string][]string
@@ -38,6 +39,7 @@ func NewCustomDNSResolver(cfg config.CustomDNSConfig) ChainedResolver {
 
 	return &CustomDNSResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("custom_dns"),
 
 		mapping:          m,
 		reverseAddresses: reverse,

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/log"
@@ -38,7 +37,7 @@ func NewCustomDNSResolver(cfg config.CustomDNSConfig) ChainedResolver {
 		}
 	}
 
-	ttl := uint32(time.Duration(cfg.CustomTTL).Seconds())
+	ttl := uint32(cfg.CustomTTL.Seconds())
 
 	return &CustomDNSResolver{
 		mapping:             m,

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -45,14 +45,14 @@ func NewCustomDNSResolver(cfg config.CustomDNSConfig) ChainedResolver {
 	}
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *CustomDNSResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *CustomDNSResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *CustomDNSResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 }
 
 func isSupportedType(ip net.IP, question dns.Question) bool {

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -37,7 +37,7 @@ func NewCustomDNSResolver(cfg config.CustomDNSConfig) ChainedResolver {
 		}
 	}
 
-	ttl := uint32(cfg.CustomTTL.Seconds())
+	ttl := cfg.CustomTTL.SecondsU32()
 
 	return &CustomDNSResolver{
 		mapping:             m,

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -15,9 +15,8 @@ import (
 
 // CustomDNSResolver resolves passed domain name to ip address defined in domain-IP map
 type CustomDNSResolver struct {
+	configurable[*config.CustomDNSConfig]
 	NextResolver
-
-	cfg config.CustomDNSConfig
 
 	mapping          map[string][]net.IP
 	reverseAddresses map[string][]string
@@ -38,21 +37,11 @@ func NewCustomDNSResolver(cfg config.CustomDNSConfig) ChainedResolver {
 	}
 
 	return &CustomDNSResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 
 		mapping:          m,
 		reverseAddresses: reverse,
 	}
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *CustomDNSResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
-}
-
-// LogConfig implements `config.Configurable`.
-func (r *CustomDNSResolver) LogConfig(logger *logrus.Entry) {
-	r.cfg.LogConfig(logger)
 }
 
 func isSupportedType(ip net.IP, question dns.Question) bool {

--- a/resolver/custom_dns_resolver_test.go
+++ b/resolver/custom_dns_resolver_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
 	. "github.com/onsi/ginkgo/v2"
@@ -43,6 +44,22 @@ var _ = Describe("CustomDNSResolver", func() {
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is true", func() {
+			Expect(sut.IsEnabled()).Should(BeTrue())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
 	})
 
 	Describe("Resolving custom name via CustomDNSResolver", func() {

--- a/resolver/custom_dns_resolver_test.go
+++ b/resolver/custom_dns_resolver_test.go
@@ -16,12 +16,18 @@ import (
 
 var _ = Describe("CustomDNSResolver", func() {
 	var (
+		TTL = uint32(time.Now().Second())
+
 		sut ChainedResolver
 		m   *mockResolver
 		cfg config.CustomDNSConfig
 	)
 
-	TTL := uint32(time.Now().Second())
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
 
 	BeforeEach(func() {
 		cfg = config.CustomDNSConfig{

--- a/resolver/custom_dns_resolver_test.go
+++ b/resolver/custom_dns_resolver_test.go
@@ -33,7 +33,7 @@ var _ = Describe("CustomDNSResolver", func() {
 					net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
 				},
 			}},
-			CustomTTL:           config.Duration(time.Duration(TTL) * time.Second),
+			CustomTTL:           config.NewDuration(time.Duration(TTL) * time.Second),
 			FilterUnmappedTypes: true,
 		}
 	})

--- a/resolver/custom_dns_resolver_test.go
+++ b/resolver/custom_dns_resolver_test.go
@@ -33,7 +33,7 @@ var _ = Describe("CustomDNSResolver", func() {
 					net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
 				},
 			}},
-			CustomTTL:           config.NewDuration(time.Duration(TTL) * time.Second),
+			CustomTTL:           config.Duration(time.Duration(TTL) * time.Second),
 			FilterUnmappedTypes: true,
 		}
 	})

--- a/resolver/custom_dns_resolver_test.go
+++ b/resolver/custom_dns_resolver_test.go
@@ -257,23 +257,4 @@ var _ = Describe("CustomDNSResolver", func() {
 			})
 		})
 	})
-
-	Describe("Configuration output", func() {
-		When("resolver is enabled", func() {
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
-			})
-		})
-
-		When("resolver is disabled", func() {
-			BeforeEach(func() {
-				cfg = config.CustomDNSConfig{}
-			})
-			It("should return 'disabled'", func() {
-				c := sut.Configuration()
-				Expect(c).Should(ContainElement(configStatusDisabled))
-			})
-		})
-	})
 })

--- a/resolver/ede_resolver.go
+++ b/resolver/ede_resolver.go
@@ -19,14 +19,14 @@ func NewEdeResolver(cfg config.EdeConfig) ChainedResolver {
 	}
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *EdeResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *EdeResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *EdeResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 }
 
 func (r *EdeResolver) Resolve(request *model.Request) (*model.Response, error) {

--- a/resolver/ede_resolver.go
+++ b/resolver/ede_resolver.go
@@ -9,11 +9,13 @@ import (
 type EdeResolver struct {
 	configurable[*config.EdeConfig]
 	NextResolver
+	typed
 }
 
 func NewEdeResolver(cfg config.EdeConfig) ChainedResolver {
 	return &EdeResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("extended_error_code"),
 	}
 }
 

--- a/resolver/ede_resolver.go
+++ b/resolver/ede_resolver.go
@@ -8,76 +8,53 @@ import (
 
 type EdeResolver struct {
 	NextResolver
-	config config.EdeConfig
+
+	cfg config.EdeConfig
 }
 
 func NewEdeResolver(cfg config.EdeConfig) ChainedResolver {
 	return &EdeResolver{
-		config: cfg,
+		cfg: cfg,
 	}
 }
 
 func (r *EdeResolver) Resolve(request *model.Request) (*model.Response, error) {
+	if !r.cfg.Enable {
+		return r.next.Resolve(request)
+	}
+
 	resp, err := r.next.Resolve(request)
 	if err != nil {
 		return nil, err
 	}
 
-	if r.config.Enable {
-		addExtraReasoning(resp)
-	}
+	r.addExtraReasoning(resp)
 
 	return resp, nil
 }
 
 func (r *EdeResolver) Configuration() (result []string) {
-	if !r.config.Enable {
+	if !r.cfg.Enable {
 		return configDisabled
 	}
 
 	return configEnabled
 }
 
-func addExtraReasoning(res *model.Response) {
-	// dns.ExtendedErrorCodeOther seams broken in some clients
-	infocode := convertToExtendedErrorCode(res.RType)
-	if infocode > 0 {
-		opt := new(dns.OPT)
-		opt.Hdr.Name = "."
-		opt.Hdr.Rrtype = dns.TypeOPT
-		opt.Option = append(opt.Option, convertExtendedError(res, infocode))
-		res.Res.Extra = append(res.Res.Extra, opt)
-	}
-}
+func (r *EdeResolver) addExtraReasoning(res *model.Response) {
+	infocode := res.RType.ToExtendedErrorCode()
 
-func convertExtendedError(input *model.Response, infocode uint16) *dns.EDNS0_EDE {
-	return &dns.EDNS0_EDE{
+	if infocode == dns.ExtendedErrorCodeOther {
+		// dns.ExtendedErrorCodeOther seams broken in some clients
+		return
+	}
+
+	opt := new(dns.OPT)
+	opt.Hdr.Name = "."
+	opt.Hdr.Rrtype = dns.TypeOPT
+	opt.Option = append(opt.Option, &dns.EDNS0_EDE{
 		InfoCode:  infocode,
-		ExtraText: input.Reason,
-	}
-}
-
-func convertToExtendedErrorCode(input model.ResponseType) uint16 {
-	switch input {
-	case model.ResponseTypeRESOLVED:
-		return dns.ExtendedErrorCodeOther
-	case model.ResponseTypeCACHED:
-		return dns.ExtendedErrorCodeCachedError
-	case model.ResponseTypeCONDITIONAL:
-		return dns.ExtendedErrorCodeForgedAnswer
-	case model.ResponseTypeCUSTOMDNS:
-		return dns.ExtendedErrorCodeForgedAnswer
-	case model.ResponseTypeHOSTSFILE:
-		return dns.ExtendedErrorCodeForgedAnswer
-	case model.ResponseTypeNOTFQDN:
-		return dns.ExtendedErrorCodeBlocked
-	case model.ResponseTypeBLOCKED:
-		return dns.ExtendedErrorCodeBlocked
-	case model.ResponseTypeFILTERED:
-		return dns.ExtendedErrorCodeFiltered
-	case model.ResponseTypeSPECIAL:
-		return dns.ExtendedErrorCodeFiltered
-	default:
-		return dns.ExtendedErrorCodeOther
-	}
+		ExtraText: res.Reason,
+	})
+	res.Res.Extra = append(res.Res.Extra, opt)
 }

--- a/resolver/ede_resolver.go
+++ b/resolver/ede_resolver.go
@@ -4,6 +4,7 @@ import (
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
 )
 
 type EdeResolver struct {
@@ -16,6 +17,16 @@ func NewEdeResolver(cfg config.EdeConfig) ChainedResolver {
 	return &EdeResolver{
 		cfg: cfg,
 	}
+}
+
+// IsEnabled implements `config.ValueLogger`.
+func (r *EdeResolver) IsEnabled() bool {
+	return r.cfg.IsEnabled()
+}
+
+// LogValues implements `config.ValueLogger`.
+func (r *EdeResolver) LogValues(logger *logrus.Entry) {
+	r.cfg.LogValues(logger)
 }
 
 func (r *EdeResolver) Resolve(request *model.Request) (*model.Response, error) {
@@ -31,14 +42,6 @@ func (r *EdeResolver) Resolve(request *model.Request) (*model.Response, error) {
 	r.addExtraReasoning(resp)
 
 	return resp, nil
-}
-
-func (r *EdeResolver) Configuration() (result []string) {
-	if !r.cfg.Enable {
-		return configDisabled
-	}
-
-	return configEnabled
 }
 
 func (r *EdeResolver) addExtraReasoning(res *model.Response) {

--- a/resolver/ede_resolver.go
+++ b/resolver/ede_resolver.go
@@ -4,29 +4,17 @@ import (
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
-	"github.com/sirupsen/logrus"
 )
 
 type EdeResolver struct {
+	configurable[*config.EdeConfig]
 	NextResolver
-
-	cfg config.EdeConfig
 }
 
 func NewEdeResolver(cfg config.EdeConfig) ChainedResolver {
 	return &EdeResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 	}
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *EdeResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
-}
-
-// LogConfig implements `config.Configurable`.
-func (r *EdeResolver) LogConfig(logger *logrus.Entry) {
-	r.cfg.LogConfig(logger)
 }
 
 func (r *EdeResolver) Resolve(request *model.Request) (*model.Response, error) {

--- a/resolver/ede_resolver_test.go
+++ b/resolver/ede_resolver_test.go
@@ -23,6 +23,12 @@ var _ = Describe("EdeResolver", func() {
 		mockAnswer *dns.Msg
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		mockAnswer = new(dns.Msg)
 	})

--- a/resolver/ede_resolver_test.go
+++ b/resolver/ede_resolver_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 
 	. "github.com/0xERR0R/blocky/model"
 
@@ -59,6 +60,12 @@ var _ = Describe("EdeResolver", func() {
 			// delegated to next resolver
 			Expect(m.Calls).Should(HaveLen(1))
 		})
+
+		Describe("IsEnabled", func() {
+			It("is false", func() {
+				Expect(sut.IsEnabled()).Should(BeFalse())
+			})
+		})
 	})
 
 	When("ede is enabled", func() {
@@ -106,26 +113,14 @@ var _ = Describe("EdeResolver", func() {
 				Expect(err).To(Equal(resolveErr))
 			})
 		})
-	})
 
-	Describe("Configuration output", func() {
-		When("resolver is enabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.EdeConfig{Enable: true}
-			})
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(c).Should(Equal(configEnabled))
-			})
-		})
+		Describe("LogConfig", func() {
+			It("should log something", func() {
+				logger, hook := log.NewMockEntry()
 
-		When("resolver is disabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.EdeConfig{Enable: false}
-			})
-			It("should return 'disabled'", func() {
-				c := sut.Configuration()
-				Expect(c).Should(ContainElement(configStatusDisabled))
+				sut.LogConfig(logger)
+
+				Expect(hook.Calls).ShouldNot(BeEmpty())
 			})
 		})
 	})

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -4,31 +4,19 @@ import (
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
-	"github.com/sirupsen/logrus"
 )
 
 // FilteringResolver filters DNS queries (for example can drop all AAAA query)
 // returns empty ANSWER with NOERROR
 type FilteringResolver struct {
+	configurable[*config.FilteringConfig]
 	NextResolver
-
-	cfg config.FilteringConfig
 }
 
 func NewFilteringResolver(cfg config.FilteringConfig) ChainedResolver {
 	return &FilteringResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 	}
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *FilteringResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
-}
-
-// LogConfig implements `config.Configurable`.
-func (r *FilteringResolver) LogConfig(logger *logrus.Entry) {
-	r.cfg.LogConfig(logger)
 }
 
 func (r *FilteringResolver) Resolve(request *model.Request) (*model.Response, error) {

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -14,12 +14,19 @@ import (
 // returns empty ANSWER with NOERROR
 type FilteringResolver struct {
 	NextResolver
-	queryTypes config.QTypeSet
+
+	cfg config.FilteringConfig
+}
+
+func NewFilteringResolver(cfg config.FilteringConfig) ChainedResolver {
+	return &FilteringResolver{
+		cfg: cfg,
+	}
 }
 
 func (r *FilteringResolver) Resolve(request *model.Request) (*model.Response, error) {
 	qType := request.Req.Question[0].Qtype
-	if r.queryTypes.Contains(dns.Type(qType)) {
+	if r.cfg.QueryTypes.Contains(dns.Type(qType)) {
 		response := new(dns.Msg)
 		response.SetRcode(request.Req, dns.RcodeSuccess)
 
@@ -45,10 +52,4 @@ func (r *FilteringResolver) Configuration() (result []string) {
 	result = append(result, fmt.Sprintf("filtering query Types: '%v'", strings.Join(qTypes, ", ")))
 
 	return
-}
-
-func NewFilteringResolver(cfg config.FilteringConfig) ChainedResolver {
-	return &FilteringResolver{
-		queryTypes: cfg.QueryTypes,
-	}
 }

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -11,11 +11,13 @@ import (
 type FilteringResolver struct {
 	configurable[*config.FilteringConfig]
 	NextResolver
+	typed
 }
 
 func NewFilteringResolver(cfg config.FilteringConfig) ChainedResolver {
 	return &FilteringResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("filtering"),
 	}
 }
 

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -21,14 +21,14 @@ func NewFilteringResolver(cfg config.FilteringConfig) ChainedResolver {
 	}
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *FilteringResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *FilteringResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *FilteringResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 }
 
 func (r *FilteringResolver) Resolve(request *model.Request) (*model.Response, error) {

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 
 	"github.com/miekg/dns"
@@ -28,6 +29,22 @@ var _ = Describe("FilteringResolver", func() {
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 		sut.Next(m)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is false", func() {
+			Expect(sut.IsEnabled()).Should(BeFalse())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
 	})
 
 	When("Filtering query types are defined", func() {

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -20,6 +20,12 @@ var _ = Describe("FilteringResolver", func() {
 		mockAnswer *dns.Msg
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		mockAnswer = new(dns.Msg)
 	})

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
 	. "github.com/0xERR0R/blocky/model"
+
 	"github.com/miekg/dns"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,10 +60,6 @@ var _ = Describe("FilteringResolver", func() {
 			// no call of next resolver
 			Expect(m.Calls).Should(BeZero())
 		})
-		It("Configure should output all query types", func() {
-			c := sut.Configuration()
-			Expect(c).Should(Equal([]string{"filtering query Types: 'AAAA, MX'"}))
-		})
 	})
 
 	When("No filtering query types are defined", func() {
@@ -80,10 +77,6 @@ var _ = Describe("FilteringResolver", func() {
 
 			// delegated to next resolver
 			Expect(m.Calls).Should(HaveLen(1))
-		})
-		It("Configure should output 'empty list'", func() {
-			c := sut.Configuration()
-			Expect(c).Should(ContainElement(configStatusDisabled))
 		})
 	})
 })

--- a/resolver/fqdn_only_resolver.go
+++ b/resolver/fqdn_only_resolver.go
@@ -22,14 +22,14 @@ func NewFqdnOnlyResolver(cfg config.FqdnOnlyConfig) *FqdnOnlyResolver {
 	}
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *FqdnOnlyResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *FqdnOnlyResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *FqdnOnlyResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 }
 
 func (r *FqdnOnlyResolver) Resolve(request *model.Request) (*model.Response, error) {

--- a/resolver/fqdn_only_resolver.go
+++ b/resolver/fqdn_only_resolver.go
@@ -12,11 +12,13 @@ import (
 type FqdnOnlyResolver struct {
 	configurable[*config.FqdnOnlyConfig]
 	NextResolver
+	typed
 }
 
 func NewFqdnOnlyResolver(cfg config.FqdnOnlyConfig) *FqdnOnlyResolver {
 	return &FqdnOnlyResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("fqdn_only"),
 	}
 }
 

--- a/resolver/fqdn_only_resolver.go
+++ b/resolver/fqdn_only_resolver.go
@@ -7,29 +7,17 @@ import (
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 	"github.com/miekg/dns"
-	"github.com/sirupsen/logrus"
 )
 
 type FqdnOnlyResolver struct {
+	configurable[*config.FqdnOnlyConfig]
 	NextResolver
-
-	cfg config.FqdnOnlyConfig
 }
 
 func NewFqdnOnlyResolver(cfg config.FqdnOnlyConfig) *FqdnOnlyResolver {
 	return &FqdnOnlyResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 	}
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *FqdnOnlyResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
-}
-
-// LogConfig implements `config.Configurable`.
-func (r *FqdnOnlyResolver) LogConfig(logger *logrus.Entry) {
-	r.cfg.LogConfig(logger)
 }
 
 func (r *FqdnOnlyResolver) Resolve(request *model.Request) (*model.Response, error) {

--- a/resolver/fqdn_only_resolver_test.go
+++ b/resolver/fqdn_only_resolver_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
 	. "github.com/onsi/ginkgo/v2"
@@ -13,7 +14,7 @@ import (
 var _ = Describe("FqdnOnlyResolver", func() {
 	var (
 		sut        *FqdnOnlyResolver
-		sutConfig  config.Config
+		sutConfig  config.FqdnOnlyConfig
 		m          *mockResolver
 		mockAnswer *dns.Msg
 	)
@@ -29,11 +30,25 @@ var _ = Describe("FqdnOnlyResolver", func() {
 		sut.Next(m)
 	})
 
+	Describe("IsEnabled", func() {
+		It("is false", func() {
+			Expect(sut.IsEnabled()).Should(BeFalse())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
+	})
+
 	When("Fqdn only is enabled", func() {
 		BeforeEach(func() {
-			sutConfig = config.Config{
-				FqdnOnly: true,
-			}
+			sutConfig = config.FqdnOnlyConfig{Enable: true}
 		})
 		It("Should delegate to next resolver if request query is fqdn", func() {
 			Expect(sut.Resolve(newRequest("example.com", A))).
@@ -59,17 +74,27 @@ var _ = Describe("FqdnOnlyResolver", func() {
 			// no call of next resolver
 			Expect(m.Calls).Should(BeZero())
 		})
-		It("Configure should output enabled", func() {
-			c := sut.Configuration()
-			Expect(c).Should(Equal(configEnabled))
+
+		Describe("IsEnabled", func() {
+			It("is true", func() {
+				Expect(sut.IsEnabled()).Should(BeTrue())
+			})
+		})
+
+		Describe("LogConfig", func() {
+			It("should log something", func() {
+				logger, hook := log.NewMockEntry()
+
+				sut.LogConfig(logger)
+
+				Expect(hook.Calls).ShouldNot(BeEmpty())
+			})
 		})
 	})
 
 	When("Fqdn only is disabled", func() {
 		BeforeEach(func() {
-			sutConfig = config.Config{
-				FqdnOnly: false,
-			}
+			sutConfig = config.FqdnOnlyConfig{Enable: false}
 		})
 		It("Should delegate to next resolver if request query is fqdn", func() {
 			Expect(sut.Resolve(newRequest("example.com", A))).
@@ -95,9 +120,11 @@ var _ = Describe("FqdnOnlyResolver", func() {
 			// delegated to next resolver
 			Expect(m.Calls).Should(HaveLen(1))
 		})
-		It("Configure should output disabled", func() {
-			c := sut.Configuration()
-			Expect(c).Should(ContainElement(configStatusDisabled))
+
+		Describe("IsEnabled", func() {
+			It("is false", func() {
+				Expect(sut.IsEnabled()).Should(BeFalse())
+			})
 		})
 	})
 })

--- a/resolver/fqdn_only_resolver_test.go
+++ b/resolver/fqdn_only_resolver_test.go
@@ -19,6 +19,12 @@ var _ = Describe("FqdnOnlyResolver", func() {
 		mockAnswer *dns.Msg
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		mockAnswer = new(dns.Msg)
 	})

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -26,6 +26,7 @@ const (
 type HostsFileResolver struct {
 	configurable[*config.HostsFileConfig]
 	NextResolver
+	typed
 
 	hosts splitHostsFileData
 }
@@ -35,6 +36,7 @@ type HostsFileEntry = parsers.HostsFileEntry
 func NewHostsFileResolver(cfg config.HostsFileConfig) *HostsFileResolver {
 	r := HostsFileResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("hosts_file"),
 	}
 
 	if err := r.parseHostsFile(context.Background()); err != nil {

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -203,8 +203,8 @@ func (r *HostsFileResolver) parseHostsFile(ctx context.Context) error {
 }
 
 func (r *HostsFileResolver) periodicUpdate() {
-	if r.cfg.RefreshPeriod.Cast() > 0 {
-		ticker := time.NewTicker(r.cfg.RefreshPeriod.Cast())
+	if r.cfg.RefreshPeriod.ToDuration() > 0 {
+		ticker := time.NewTicker(r.cfg.RefreshPeriod.ToDuration())
 		defer ticker.Stop()
 
 		for {

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -136,6 +136,10 @@ func (r *HostsFileResolver) Configuration() (result []string) {
 	return
 }
 
+func (r *HostsFileResolver) Cfg() config.ValueLogger {
+	return &r.cfg
+}
+
 func NewHostsFileResolver(cfg config.HostsFileConfig) *HostsFileResolver {
 	r := HostsFileResolver{
 		cfg: cfg,

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -50,14 +50,14 @@ func NewHostsFileResolver(cfg config.HostsFileConfig) *HostsFileResolver {
 	return &r
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *HostsFileResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *HostsFileResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *HostsFileResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 
 	logger.Infof("cache entries = %d", r.hosts.len())
 }

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -24,9 +24,8 @@ const (
 )
 
 type HostsFileResolver struct {
+	configurable[*config.HostsFileConfig]
 	NextResolver
-
-	cfg config.HostsFileConfig
 
 	hosts splitHostsFileData
 }
@@ -35,7 +34,7 @@ type HostsFileEntry = parsers.HostsFileEntry
 
 func NewHostsFileResolver(cfg config.HostsFileConfig) *HostsFileResolver {
 	r := HostsFileResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 	}
 
 	if err := r.parseHostsFile(context.Background()); err != nil {
@@ -48,11 +47,6 @@ func NewHostsFileResolver(cfg config.HostsFileConfig) *HostsFileResolver {
 	}
 
 	return &r
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *HostsFileResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
 }
 
 // LogConfig implements `config.Configurable`.

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -142,8 +142,8 @@ func (r *HostsFileResolver) Configuration() (result []string) {
 func NewHostsFileResolver(cfg config.HostsFileConfig) *HostsFileResolver {
 	r := HostsFileResolver{
 		HostsFilePath:  cfg.Filepath,
-		ttl:            uint32(time.Duration(cfg.HostsTTL).Seconds()),
-		refreshPeriod:  time.Duration(cfg.RefreshPeriod),
+		ttl:            uint32(cfg.HostsTTL.Seconds()),
+		refreshPeriod:  cfg.RefreshPeriod.Cast(),
 		filterLoopback: cfg.FilterLoopback,
 	}
 

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -25,7 +25,9 @@ const (
 
 type HostsFileResolver struct {
 	NextResolver
-	cfg   config.HostsFileConfig
+
+	cfg config.HostsFileConfig
+
 	hosts splitHostsFileData
 }
 

--- a/resolver/hosts_file_resolver_test.go
+++ b/resolver/hosts_file_resolver_test.go
@@ -36,8 +36,8 @@ var _ = Describe("HostsFileResolver", func() {
 
 		sutConfig = config.HostsFileConfig{
 			Filepath:       tmpFile.Path,
-			HostsTTL:       config.NewDuration(time.Duration(TTL) * time.Second),
-			RefreshPeriod:  config.NewDuration(30 * time.Minute),
+			HostsTTL:       config.Duration(time.Duration(TTL) * time.Second),
+			RefreshPeriod:  config.Duration(30 * time.Minute),
 			FilterLoopback: true,
 		}
 	})
@@ -54,7 +54,7 @@ var _ = Describe("HostsFileResolver", func() {
 			BeforeEach(func() {
 				sutConfig = config.HostsFileConfig{
 					Filepath: fmt.Sprintf("/tmp/blocky/file-%d", rand.Uint64()),
-					HostsTTL: config.NewDuration(time.Duration(TTL) * time.Second),
+					HostsTTL: config.Duration(time.Duration(TTL) * time.Second),
 				}
 			})
 			It("should not parse any hosts", func() {

--- a/resolver/hosts_file_resolver_test.go
+++ b/resolver/hosts_file_resolver_test.go
@@ -2,12 +2,11 @@ package resolver
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
 	. "github.com/onsi/ginkgo/v2"
@@ -49,11 +48,27 @@ var _ = Describe("HostsFileResolver", func() {
 		sut.Next(m)
 	})
 
+	Describe("IsEnabled", func() {
+		It("is true", func() {
+			Expect(sut.IsEnabled()).Should(BeTrue())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
+	})
+
 	Describe("Using hosts file", func() {
 		When("Hosts file cannot be located", func() {
 			BeforeEach(func() {
 				sutConfig = config.HostsFileConfig{
-					Filepath: fmt.Sprintf("/tmp/blocky/file-%d", rand.Uint64()),
+					Filepath: "/this/file/does/not/exist",
 					HostsTTL: config.Duration(time.Duration(TTL) * time.Second),
 				}
 			})

--- a/resolver/hosts_file_resolver_test.go
+++ b/resolver/hosts_file_resolver_test.go
@@ -307,25 +307,6 @@ var _ = Describe("HostsFileResolver", func() {
 		})
 	})
 
-	Describe("Configuration output", func() {
-		When("hosts file is provided", func() {
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
-			})
-		})
-
-		When("hosts file is not provided", func() {
-			BeforeEach(func() {
-				sutConfig = config.HostsFileConfig{}
-			})
-			It("should return 'disabled'", func() {
-				c := sut.Configuration()
-				Expect(c).Should(ContainElement(configStatusDisabled))
-			})
-		})
-	})
-
 	Describe("Delegating to next resolver", func() {
 		When("no hosts file is provided", func() {
 			It("should delegate to next resolver", func() {

--- a/resolver/hosts_file_resolver_test.go
+++ b/resolver/hosts_file_resolver_test.go
@@ -58,7 +58,7 @@ var _ = Describe("HostsFileResolver", func() {
 				}
 			})
 			It("should not parse any hosts", func() {
-				Expect(sut.HostsFilePath).Should(BeEmpty())
+				Expect(sut.cfg.Filepath).Should(BeEmpty())
 				Expect(sut.hosts.v4.hosts).Should(BeEmpty())
 				Expect(sut.hosts.v6.hosts).Should(BeEmpty())
 				Expect(sut.hosts.v4.aliases).Should(BeEmpty())
@@ -140,11 +140,11 @@ var _ = Describe("HostsFileResolver", func() {
 
 			It("should not be used", func() {
 				Expect(sut).ShouldNot(BeNil())
-				Expect(sut.HostsFilePath).Should(BeEmpty())
-				Expect(sut.hosts.v4.hosts).Should(HaveLen(0))
-				Expect(sut.hosts.v6.hosts).Should(HaveLen(0))
-				Expect(sut.hosts.v4.aliases).Should(HaveLen(0))
-				Expect(sut.hosts.v6.aliases).Should(HaveLen(0))
+				Expect(sut.cfg.Filepath).Should(BeEmpty())
+				Expect(sut.hosts.v4.hosts).Should(BeEmpty())
+				Expect(sut.hosts.v6.hosts).Should(BeEmpty())
+				Expect(sut.hosts.v4.aliases).Should(BeEmpty())
+				Expect(sut.hosts.v6.aliases).Should(BeEmpty())
 			})
 		})
 

--- a/resolver/hosts_file_resolver_test.go
+++ b/resolver/hosts_file_resolver_test.go
@@ -16,6 +16,8 @@ import (
 
 var _ = Describe("HostsFileResolver", func() {
 	var (
+		TTL = uint32(time.Now().Second())
+
 		sut       *HostsFileResolver
 		sutConfig config.HostsFileConfig
 		m         *mockResolver
@@ -23,7 +25,11 @@ var _ = Describe("HostsFileResolver", func() {
 		tmpFile   *TmpFile
 	)
 
-	TTL := uint32(time.Now().Second())
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
 
 	BeforeEach(func() {
 		tmpDir = NewTmpFolder("HostsFileResolver")

--- a/resolver/hosts_file_resolver_test.go
+++ b/resolver/hosts_file_resolver_test.go
@@ -36,8 +36,8 @@ var _ = Describe("HostsFileResolver", func() {
 
 		sutConfig = config.HostsFileConfig{
 			Filepath:       tmpFile.Path,
-			HostsTTL:       config.Duration(time.Duration(TTL) * time.Second),
-			RefreshPeriod:  config.Duration(30 * time.Minute),
+			HostsTTL:       config.NewDuration(time.Duration(TTL) * time.Second),
+			RefreshPeriod:  config.NewDuration(30 * time.Minute),
 			FilterLoopback: true,
 		}
 	})
@@ -54,7 +54,7 @@ var _ = Describe("HostsFileResolver", func() {
 			BeforeEach(func() {
 				sutConfig = config.HostsFileConfig{
 					Filepath: fmt.Sprintf("/tmp/blocky/file-%d", rand.Uint64()),
-					HostsTTL: config.Duration(time.Duration(TTL) * time.Second),
+					HostsTTL: config.NewDuration(time.Duration(TTL) * time.Second),
 				}
 			})
 			It("should not parse any hosts", func() {

--- a/resolver/metrics_resolver.go
+++ b/resolver/metrics_resolver.go
@@ -25,14 +25,14 @@ type MetricsResolver struct {
 	durationHistogram *prometheus.HistogramVec
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *MetricsResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *MetricsResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *MetricsResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 }
 
 // Resolve resolves the passed request

--- a/resolver/metrics_resolver.go
+++ b/resolver/metrics_resolver.go
@@ -7,7 +7,6 @@ import (
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/metrics"
 	"github.com/0xERR0R/blocky/model"
-	"github.com/sirupsen/logrus"
 
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,24 +14,13 @@ import (
 
 // MetricsResolver resolver that records metrics about requests/response
 type MetricsResolver struct {
+	configurable[*config.MetricsConfig]
 	NextResolver
-
-	cfg config.MetricsConfig
 
 	totalQueries      *prometheus.CounterVec
 	totalResponse     *prometheus.CounterVec
 	totalErrors       prometheus.Counter
 	durationHistogram *prometheus.HistogramVec
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *MetricsResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
-}
-
-// LogConfig implements `config.Configurable`.
-func (r *MetricsResolver) LogConfig(logger *logrus.Entry) {
-	r.cfg.LogConfig(logger)
 }
 
 // Resolve resolves the passed request
@@ -71,7 +59,7 @@ func (r *MetricsResolver) Resolve(request *model.Request) (*model.Response, erro
 // NewMetricsResolver creates a new intance of the MetricsResolver type
 func NewMetricsResolver(cfg config.MetricsConfig) ChainedResolver {
 	m := MetricsResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 
 		durationHistogram: durationHistogram(),
 		totalQueries:      totalQueriesMetric(),

--- a/resolver/metrics_resolver.go
+++ b/resolver/metrics_resolver.go
@@ -16,6 +16,7 @@ import (
 type MetricsResolver struct {
 	configurable[*config.MetricsConfig]
 	NextResolver
+	typed
 
 	totalQueries      *prometheus.CounterVec
 	totalResponse     *prometheus.CounterVec
@@ -60,6 +61,7 @@ func (r *MetricsResolver) Resolve(request *model.Request) (*model.Response, erro
 func NewMetricsResolver(cfg config.MetricsConfig) ChainedResolver {
 	m := MetricsResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("metrics"),
 
 		durationHistogram: durationHistogram(),
 		totalQueries:      totalQueriesMetric(),

--- a/resolver/metrics_resolver_test.go
+++ b/resolver/metrics_resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 
 	. "github.com/0xERR0R/blocky/helpertest"
 	. "github.com/0xERR0R/blocky/model"
@@ -27,6 +28,22 @@ var _ = Describe("MetricResolver", func() {
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is true", func() {
+			Expect(sut.IsEnabled()).Should(BeTrue())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
 	})
 
 	Describe("Recording prometheus metrics", func() {
@@ -60,15 +77,6 @@ var _ = Describe("MetricResolver", func() {
 
 					Expect(testutil.ToFloat64(sut.totalErrors)).Should(BeNumerically("==", 1))
 				})
-			})
-		})
-	})
-
-	Describe("Configuration output", func() {
-		When("resolver is enabled", func() {
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
 			})
 		})
 	})

--- a/resolver/metrics_resolver_test.go
+++ b/resolver/metrics_resolver_test.go
@@ -23,6 +23,12 @@ var _ = Describe("MetricResolver", func() {
 		m   *mockResolver
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		sut = NewMetricsResolver(config.MetricsConfig{Enable: true}).(*MetricsResolver)
 		m = &mockResolver{}

--- a/resolver/metrics_resolver_test.go
+++ b/resolver/metrics_resolver_test.go
@@ -23,7 +23,7 @@ var _ = Describe("MetricResolver", func() {
 	)
 
 	BeforeEach(func() {
-		sut = NewMetricsResolver(config.PrometheusConfig{Enable: true}).(*MetricsResolver)
+		sut = NewMetricsResolver(config.MetricsConfig{Enable: true}).(*MetricsResolver)
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
 		sut.Next(m)

--- a/resolver/mocks_test.go
+++ b/resolver/mocks_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/util"
+	"github.com/sirupsen/logrus"
 
 	"github.com/0xERR0R/blocky/model"
 
@@ -27,10 +28,16 @@ type mockResolver struct {
 	AnswerFn   func(qType dns.Type, qName string) (*dns.Msg, error)
 }
 
-func (r *mockResolver) Configuration() []string {
+// IsEnabled implements `config.Configurable`.
+func (r *mockResolver) IsEnabled() bool {
 	args := r.Called()
 
-	return args.Get(0).([]string)
+	return args.Get(0).(bool)
+}
+
+// LogConfig implements `config.Configurable`.
+func (r *mockResolver) LogConfig(logger *logrus.Entry) {
+	r.Called()
 }
 
 func (r *mockResolver) Resolve(req *model.Request) (*model.Response, error) {

--- a/resolver/mocks_test.go
+++ b/resolver/mocks_test.go
@@ -28,6 +28,11 @@ type mockResolver struct {
 	AnswerFn   func(qType dns.Type, qName string) (*dns.Msg, error)
 }
 
+// Type implements `Resolver`.
+func (r *mockResolver) Type() string {
+	return "mock"
+}
+
 // IsEnabled implements `config.Configurable`.
 func (r *mockResolver) IsEnabled() bool {
 	args := r.Called()

--- a/resolver/noop_resolver.go
+++ b/resolver/noop_resolver.go
@@ -14,6 +14,11 @@ func NewNoOpResolver() Resolver {
 	return NoOpResolver{}
 }
 
+// Type implements `Resolver`.
+func (NoOpResolver) Type() string {
+	return "noop"
+}
+
 // IsEnabled implements `config.Configurable`.
 func (NoOpResolver) IsEnabled() bool {
 	return true

--- a/resolver/noop_resolver.go
+++ b/resolver/noop_resolver.go
@@ -14,13 +14,13 @@ func NewNoOpResolver() Resolver {
 	return NoOpResolver{}
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (NoOpResolver) IsEnabled() bool {
 	return true
 }
 
-// LogValues implements `config.ValueLogger`.
-func (NoOpResolver) LogValues(*logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (NoOpResolver) LogConfig(*logrus.Entry) {
 }
 
 func (NoOpResolver) Resolve(*model.Request) (*model.Response, error) {

--- a/resolver/noop_resolver.go
+++ b/resolver/noop_resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"github.com/0xERR0R/blocky/model"
+	"github.com/sirupsen/logrus"
 )
 
 var NoResponse = &model.Response{} //nolint:gochecknoglobals
@@ -13,10 +14,15 @@ func NewNoOpResolver() Resolver {
 	return NoOpResolver{}
 }
 
-func (r NoOpResolver) Configuration() (result []string) {
-	return nil
+// IsEnabled implements `config.ValueLogger`.
+func (NoOpResolver) IsEnabled() bool {
+	return true
 }
 
-func (r NoOpResolver) Resolve(request *model.Request) (*model.Response, error) {
+// LogValues implements `config.ValueLogger`.
+func (NoOpResolver) LogValues(*logrus.Entry) {
+}
+
+func (NoOpResolver) Resolve(*model.Request) (*model.Response, error) {
 	return NoResponse, nil
 }

--- a/resolver/noop_resolver_test.go
+++ b/resolver/noop_resolver_test.go
@@ -10,6 +10,12 @@ import (
 var _ = Describe("NoOpResolver", func() {
 	var sut NoOpResolver
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		sut = NewNoOpResolver().(NoOpResolver)
 	})

--- a/resolver/noop_resolver_test.go
+++ b/resolver/noop_resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -21,10 +22,19 @@ var _ = Describe("NoOpResolver", func() {
 		})
 	})
 
-	Describe("Configuration output", func() {
-		It("returns nothing", func() {
-			c := sut.Configuration()
-			Expect(c).Should(BeNil())
+	Describe("IsEnabled", func() {
+		It("is true", func() {
+			Expect(sut.IsEnabled()).Should(BeTrue())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should not log anything", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).Should(BeEmpty())
 		})
 	})
 })

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -27,7 +27,7 @@ const (
 
 // ParallelBestResolver delegates the DNS message to 2 upstream resolvers and returns the fastest answer
 type ParallelBestResolver struct {
-	cfg config.UpstreamConfig
+	cfg config.ParallelBestConfig
 
 	resolversPerClient map[string][]*upstreamResolverStatus
 }
@@ -79,7 +79,7 @@ func testResolver(r *UpstreamResolver) error {
 
 // NewParallelBestResolver creates new resolver instance
 func NewParallelBestResolver(
-	cfg config.UpstreamConfig, bootstrap *Bootstrap, shouldVerifyUpstreams bool,
+	cfg config.ParallelBestConfig, bootstrap *Bootstrap, shouldVerifyUpstreams bool,
 ) (Resolver, error) {
 	logger := log.PrefixedLog(parallelResolverLogger)
 
@@ -120,7 +120,9 @@ func NewParallelBestResolver(
 	return newParallelBestResolver(cfg, resolverGroups)
 }
 
-func newParallelBestResolver(cfg config.UpstreamConfig, resolverGroups map[string][]Resolver) (Resolver, error) {
+func newParallelBestResolver(
+	cfg config.ParallelBestConfig, resolverGroups map[string][]Resolver,
+) (Resolver, error) {
 	resolversPerClient := make(map[string][]*upstreamResolverStatus, len(resolverGroups))
 
 	for groupName, resolvers := range resolverGroups {

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -28,6 +28,7 @@ const (
 // ParallelBestResolver delegates the DNS message to 2 upstream resolvers and returns the fastest answer
 type ParallelBestResolver struct {
 	configurable[*config.ParallelBestConfig]
+	typed
 
 	resolversPerClient map[string][]*upstreamResolverStatus
 }
@@ -142,6 +143,7 @@ func newParallelBestResolver(
 
 	r := ParallelBestResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("parallel_best"),
 
 		resolversPerClient: resolversPerClient,
 	}

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -27,7 +27,7 @@ const (
 
 // ParallelBestResolver delegates the DNS message to 2 upstream resolvers and returns the fastest answer
 type ParallelBestResolver struct {
-	cfg config.ParallelBestConfig
+	configurable[*config.ParallelBestConfig]
 
 	resolversPerClient map[string][]*upstreamResolverStatus
 }
@@ -141,22 +141,12 @@ func newParallelBestResolver(
 	}
 
 	r := ParallelBestResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 
 		resolversPerClient: resolversPerClient,
 	}
 
 	return &r, nil
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *ParallelBestResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
-}
-
-// LogConfig implements `config.Configurable`.
-func (r *ParallelBestResolver) LogConfig(logger *logrus.Entry) {
-	r.cfg.LogConfig(logger)
 }
 
 func (r ParallelBestResolver) String() string {

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	upstreamDefaultCfgName = config.UpstreamDefaultCfgName
-	parallelResolverLogger = "parallel_best_resolver"
+	parallelResolverType   = "parallel_best"
 	resolverCount          = 2
 )
 
@@ -82,7 +82,7 @@ func testResolver(r *UpstreamResolver) error {
 func NewParallelBestResolver(
 	cfg config.ParallelBestConfig, bootstrap *Bootstrap, shouldVerifyUpstreams bool,
 ) (*ParallelBestResolver, error) {
-	logger := log.PrefixedLog(parallelResolverLogger)
+	logger := log.PrefixedLog(parallelResolverType)
 
 	upstreamResolvers := cfg.ExternalResolvers
 	resolverGroups := make(map[string][]Resolver, len(upstreamResolvers))
@@ -143,7 +143,7 @@ func newParallelBestResolver(
 
 	r := ParallelBestResolver{
 		configurable: withConfig(&cfg),
-		typed:        withType("parallel_best"),
+		typed:        withType(parallelResolverType),
 
 		resolversPerClient: resolversPerClient,
 	}
@@ -206,7 +206,7 @@ func (r *ParallelBestResolver) resolversForClient(request *model.Request) (resul
 
 // Resolve sends the query request to multiple upstream resolvers and returns the fastest result
 func (r *ParallelBestResolver) Resolve(request *model.Request) (*model.Response, error) {
-	logger := log.WithPrefix(request.Log, parallelResolverLogger)
+	logger := log.WithPrefix(request.Log, parallelResolverType)
 
 	resolvers := r.resolversForClient(request)
 

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -149,8 +149,12 @@ func newParallelBestResolver(
 	return &r, nil
 }
 
-func (r ParallelBestResolver) String() string {
-	result := make([]string, 0)
+func (r *ParallelBestResolver) Name() string {
+	return r.String()
+}
+
+func (r *ParallelBestResolver) String() string {
+	result := make([]string, 0, len(r.resolversPerClient))
 
 	for name, res := range r.resolversPerClient {
 		tmp := make([]string, len(res))

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	upstreamDefaultCfgName = "default"
+	upstreamDefaultCfgName = config.UpstreamDefaultCfgName
 	parallelResolverLogger = "parallel_best_resolver"
 	resolverCount          = 2
 )
@@ -147,17 +147,14 @@ func newParallelBestResolver(cfg config.UpstreamConfig, resolverGroups map[strin
 	return &r, nil
 }
 
-// Configuration returns current resolver configuration
-func (r *ParallelBestResolver) Configuration() (result []string) {
-	result = append(result, "upstream resolvers:")
-	for name, res := range r.resolversPerClient {
-		result = append(result, fmt.Sprintf("- %s", name))
-		for _, r := range res {
-			result = append(result, fmt.Sprintf("  - %s", r.resolver))
-		}
-	}
+// IsEnabled implements `config.ValueLogger`.
+func (r *ParallelBestResolver) IsEnabled() bool {
+	return r.cfg.IsEnabled()
+}
 
-	return
+// LogValues implements `config.ValueLogger`.
+func (r *ParallelBestResolver) LogValues(logger *logrus.Entry) {
+	r.cfg.LogValues(logger)
 }
 
 func (r ParallelBestResolver) String() string {

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -80,7 +80,7 @@ func testResolver(r *UpstreamResolver) error {
 // NewParallelBestResolver creates new resolver instance
 func NewParallelBestResolver(
 	cfg config.ParallelBestConfig, bootstrap *Bootstrap, shouldVerifyUpstreams bool,
-) (Resolver, error) {
+) (*ParallelBestResolver, error) {
 	logger := log.PrefixedLog(parallelResolverLogger)
 
 	upstreamResolvers := cfg.ExternalResolvers
@@ -122,7 +122,7 @@ func NewParallelBestResolver(
 
 func newParallelBestResolver(
 	cfg config.ParallelBestConfig, resolverGroups map[string][]Resolver,
-) (Resolver, error) {
+) (*ParallelBestResolver, error) {
 	resolversPerClient := make(map[string][]*upstreamResolverStatus, len(resolverGroups))
 
 	for groupName, resolvers := range resolverGroups {

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -147,14 +147,14 @@ func newParallelBestResolver(cfg config.UpstreamConfig, resolverGroups map[strin
 	return &r, nil
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *ParallelBestResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *ParallelBestResolver) LogValues(logger *logrus.Entry) {
-	r.cfg.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *ParallelBestResolver) LogConfig(logger *logrus.Entry) {
+	r.cfg.LogConfig(logger)
 }
 
 func (r ParallelBestResolver) String() string {

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -71,6 +71,12 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 		})
 	})
 
+	Describe("Name", func() {
+		It("should not be empty", func() {
+			Expect(sut.Name()).ShouldNot(BeEmpty())
+		})
+	})
+
 	When("default upstream resolvers are not defined", func() {
 		It("should fail on startup", func() {
 			_, err := NewParallelBestResolver(config.ParallelBestConfig{

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -21,7 +21,7 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 
 	systemResolverBootstrap := &Bootstrap{}
 
-	config.GetConfig().UpstreamTimeout = config.Duration(1000 * time.Millisecond)
+	config.GetConfig().UpstreamTimeout = config.NewDuration(1000 * time.Millisecond)
 
 	When("default upstream resolvers are not defined", func() {
 		It("should fail on startup", func() {

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -30,6 +30,12 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 		bootstrap *Bootstrap
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		sutMapping = config.ParallelBestMapping{
 			upstreamDefaultCfgName: {

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -21,7 +21,7 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 
 	systemResolverBootstrap := &Bootstrap{}
 
-	config.GetConfig().UpstreamTimeout = config.NewDuration(1000 * time.Millisecond)
+	config.GetConfig().UpstreamTimeout = config.Duration(1000 * time.Millisecond)
 
 	When("default upstream resolvers are not defined", func() {
 		It("should fail on startup", func() {

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -61,7 +61,7 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 		},
 		retry.Attempts(uint(cfg.CreationAttempts)),
 		retry.DelayType(retry.FixedDelay),
-		retry.Delay(time.Duration(cfg.CreationCooldown)),
+		retry.Delay(cfg.CreationCooldown.Cast()),
 		retry.OnRetry(func(n uint, err error) {
 			logger.Warnf(
 				"Error occurred on query writer creation, retry attempt %d/%d: %v", n+1, cfg.CreationAttempts, err,

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -61,7 +61,7 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 		},
 		retry.Attempts(uint(cfg.CreationAttempts)),
 		retry.DelayType(retry.FixedDelay),
-		retry.Delay(cfg.CreationCooldown.Cast()),
+		retry.Delay(cfg.CreationCooldown.ToDuration()),
 		retry.OnRetry(func(n uint, err error) {
 			logger.Warnf(
 				"Error occurred on query writer creation, retry attempt %d/%d: %v", n+1, cfg.CreationAttempts, err,

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -89,7 +89,7 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 	return &resolver
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *QueryLoggingResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -23,6 +23,7 @@ const (
 type QueryLoggingResolver struct {
 	configurable[*config.QueryLogConfig]
 	NextResolver
+	typed
 
 	logChan chan *querylog.LogEntry
 	writer  querylog.Writer
@@ -73,6 +74,7 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 
 	resolver := QueryLoggingResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("query_logging"),
 
 		logChan: logChan,
 		writer:  writer,

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	cleanUpRunPeriod           = 12 * time.Hour
-	queryLoggingResolverPrefix = "query_logging_resolver"
-	logChanCap                 = 1000
-	defaultFlushPeriod         = 30 * time.Second
+	cleanUpRunPeriod         = 12 * time.Hour
+	queryLoggingResolverType = "query_logging"
+	logChanCap               = 1000
+	defaultFlushPeriod       = 30 * time.Second
 )
 
 // QueryLoggingResolver writes query information (question, answer, duration, ...)
@@ -31,7 +31,7 @@ type QueryLoggingResolver struct {
 
 // NewQueryLoggingResolver returns a new resolver instance
 func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
-	logger := log.PrefixedLog(queryLoggingResolverPrefix)
+	logger := log.PrefixedLog(queryLoggingResolverType)
 
 	var writer querylog.Writer
 
@@ -74,7 +74,7 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 
 	resolver := QueryLoggingResolver{
 		configurable: withConfig(&cfg),
-		typed:        withType("query_logging"),
+		typed:        withType(queryLoggingResolverType),
 
 		logChan: logChan,
 		writer:  writer,
@@ -106,7 +106,7 @@ func (r *QueryLoggingResolver) doCleanUp() {
 
 // Resolve logs the query, duration and the result
 func (r *QueryLoggingResolver) Resolve(request *model.Request) (*model.Response, error) {
-	logger := log.WithPrefix(request.Log, queryLoggingResolverPrefix)
+	logger := log.WithPrefix(request.Log, queryLoggingResolverType)
 
 	start := time.Now()
 
@@ -173,7 +173,7 @@ func (r *QueryLoggingResolver) writeLog() {
 
 		// if log channel is > 50% full, this could be a problem with slow writer (external storage over network etc.)
 		if len(r.logChan) > halfCap {
-			log.PrefixedLog(queryLoggingResolverPrefix).WithField("channel_len",
+			r.log().WithField("channel_len",
 				len(r.logChan)).Warnf("query log writer is too slow, write duration: %d ms", time.Since(start).Milliseconds())
 		}
 	}

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -10,7 +10,6 @@ import (
 	"github.com/0xERR0R/blocky/util"
 	"github.com/avast/retry-go/v4"
 	"github.com/miekg/dns"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -22,9 +21,8 @@ const (
 
 // QueryLoggingResolver writes query information (question, answer, duration, ...)
 type QueryLoggingResolver struct {
+	configurable[*config.QueryLogConfig]
 	NextResolver
-
-	cfg config.QueryLogConfig
 
 	logChan chan *querylog.LogEntry
 	writer  querylog.Writer
@@ -74,7 +72,7 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 	logChan := make(chan *querylog.LogEntry, logChanCap)
 
 	resolver := QueryLoggingResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 
 		logChan: logChan,
 		writer:  writer,
@@ -87,16 +85,6 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) ChainedResolver {
 	}
 
 	return &resolver
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *QueryLoggingResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
-}
-
-// LogConfig implements `config.Configurable`.
-func (r *QueryLoggingResolver) LogConfig(logger *logrus.Entry) {
-	r.cfg.LogConfig(logger)
 }
 
 // triggers periodically cleanup of old log files

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/0xERR0R/blocky/config"
@@ -11,6 +10,7 @@ import (
 	"github.com/0xERR0R/blocky/util"
 	"github.com/avast/retry-go/v4"
 	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -107,6 +107,18 @@ func resolveQueryLogFields(cfg config.QueryLogConfig) []config.QueryLogField {
 	return fields
 }
 
+// IsEnabled implements `config.ValueLogger`.
+func (r *QueryLoggingResolver) IsEnabled() bool {
+	return r.cfg.IsEnabled()
+}
+
+// LogValues implements `config.ValueLogger`.
+func (r *QueryLoggingResolver) LogValues(logger *logrus.Entry) {
+	r.cfg.LogValues(logger)
+
+	logger.Infof("fields: %s", r.fields)
+}
+
 // triggers periodically cleanup of old log files
 func (r *QueryLoggingResolver) periodicCleanUp() {
 	ticker := time.NewTicker(cleanUpRunPeriod)
@@ -195,14 +207,4 @@ func (r *QueryLoggingResolver) writeLog() {
 				len(r.logChan)).Warnf("query log writer is too slow, write duration: %d ms", time.Since(start).Milliseconds())
 		}
 	}
-}
-
-// Configuration returns the current resolver configuration
-func (r *QueryLoggingResolver) Configuration() (result []string) {
-	result = append(result, fmt.Sprintf("type: %q", r.cfg.Type))
-	result = append(result, fmt.Sprintf("target: %q", r.cfg.Target))
-	result = append(result, fmt.Sprintf("logRetentionDays: %d", r.cfg.LogRetentionDays))
-	result = append(result, fmt.Sprintf("fields: %s", r.fields))
-
-	return
 }

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -280,24 +280,6 @@ var _ = Describe("QueryLoggingResolver", func() {
 		})
 	})
 
-	Describe("Configuration output", func() {
-		When("resolver is enabled", func() {
-			BeforeEach(func() {
-				sutConfig = config.QueryLogConfig{
-					Target:           tmpDir.Path,
-					Type:             config.QueryLogTypeCsvClient,
-					LogRetentionDays: 0,
-					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
-				}
-			})
-			It("should return configuration", func() {
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", 1))
-			})
-		})
-	})
-
 	Describe("Clean up of query log directory", func() {
 		When("fallback logger is enabled, log retention is enabled", func() {
 			BeforeEach(func() {

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -52,6 +52,10 @@ var _ = Describe("QueryLoggingResolver", func() {
 	})
 
 	JustBeforeEach(func() {
+		if len(sutConfig.Fields) == 0 {
+			sutConfig.SetDefaults() // not called when using a struct literal
+		}
+
 		sut = NewQueryLoggingResolver(sutConfig).(*QueryLoggingResolver)
 		DeferCleanup(func() { close(sut.logChan) })
 		m = &mockResolver{}

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -64,7 +64,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 			BeforeEach(func() {
 				sutConfig = config.QueryLogConfig{
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 			})
 			It("should process request without query logging", func() {
@@ -84,7 +84,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           tmpDir.Path,
 					Type:             config.QueryLogTypeCsvClient,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 300, A, "123.122.121.120")
 			})
@@ -152,7 +152,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           tmpDir.Path,
 					Type:             config.QueryLogTypeCsv,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 300, A, "123.122.121.120")
 			})
@@ -212,7 +212,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           tmpDir.Path,
 					Type:             config.QueryLogTypeCsv,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 					Fields:           []config.QueryLogField{config.QueryLogFieldClientIP},
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 300, A, "123.122.121.120")
@@ -259,7 +259,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 				sutConfig = config.QueryLogConfig{
 					Type:             config.QueryLogTypeNone,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 			})
 			It("should drop messages", func() {
@@ -284,7 +284,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Type:             config.QueryLogTypeCsvClient,
 					LogRetentionDays: 0,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 			})
 			It("should return configuration", func() {
@@ -301,7 +301,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					LogRetentionDays: 7,
 					Type:             config.QueryLogTypeConsole,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 			})
 			It("should do nothing", func() {
@@ -315,7 +315,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Type:             config.QueryLogTypeCsv,
 					LogRetentionDays: 7,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 			})
 			It("should remove files older than defined log retention", func() {
@@ -351,7 +351,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           "dummy",
 					Type:             config.QueryLogTypeMysql,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 			})
 			It("should use fallback", func() {
@@ -365,7 +365,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           "dummy",
 					Type:             config.QueryLogTypePostgresql,
 					CreationAttempts: 1,
-					CreationCooldown: config.NewDuration(time.Millisecond),
+					CreationCooldown: config.Duration(time.Millisecond),
 				}
 			})
 			It("should use fallback", func() {

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -355,7 +355,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 				}
 			})
 			It("should use fallback", func() {
-				Expect(sut.logType).Should(Equal(config.QueryLogTypeConsole))
+				Expect(sut.cfg.Type).Should(Equal(config.QueryLogTypeConsole))
 			})
 		})
 
@@ -369,7 +369,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 				}
 			})
 			It("should use fallback", func() {
-				Expect(sut.logType).Should(Equal(config.QueryLogTypeConsole))
+				Expect(sut.cfg.Type).Should(Equal(config.QueryLogTypeConsole))
 			})
 		})
 	})

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -45,6 +45,12 @@ var _ = Describe("QueryLoggingResolver", func() {
 		mockAnswer *dns.Msg
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		mockAnswer = new(dns.Msg)
 		tmpDir = NewTmpFolder("queryLoggingResolver")

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -64,7 +64,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 			BeforeEach(func() {
 				sutConfig = config.QueryLogConfig{
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 			})
 			It("should process request without query logging", func() {
@@ -84,7 +84,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           tmpDir.Path,
 					Type:             config.QueryLogTypeCsvClient,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 300, A, "123.122.121.120")
 			})
@@ -152,7 +152,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           tmpDir.Path,
 					Type:             config.QueryLogTypeCsv,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 300, A, "123.122.121.120")
 			})
@@ -212,7 +212,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           tmpDir.Path,
 					Type:             config.QueryLogTypeCsv,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 					Fields:           []config.QueryLogField{config.QueryLogFieldClientIP},
 				}
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 300, A, "123.122.121.120")
@@ -259,7 +259,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 				sutConfig = config.QueryLogConfig{
 					Type:             config.QueryLogTypeNone,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 			})
 			It("should drop messages", func() {
@@ -284,7 +284,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Type:             config.QueryLogTypeCsvClient,
 					LogRetentionDays: 0,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 			})
 			It("should return configuration", func() {
@@ -301,7 +301,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					LogRetentionDays: 7,
 					Type:             config.QueryLogTypeConsole,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 			})
 			It("should do nothing", func() {
@@ -315,7 +315,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Type:             config.QueryLogTypeCsv,
 					LogRetentionDays: 7,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 			})
 			It("should remove files older than defined log retention", func() {
@@ -351,7 +351,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           "dummy",
 					Type:             config.QueryLogTypeMysql,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 			})
 			It("should use fallback", func() {
@@ -365,7 +365,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Target:           "dummy",
 					Type:             config.QueryLogTypePostgresql,
 					CreationAttempts: 1,
-					CreationCooldown: config.Duration(time.Millisecond),
+					CreationCooldown: config.NewDuration(time.Millisecond),
 				}
 			})
 			It("should use fallback", func() {

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/querylog"
 
 	"github.com/0xERR0R/blocky/config"
@@ -61,6 +62,22 @@ var _ = Describe("QueryLoggingResolver", func() {
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer, Reason: "reason"}, nil)
 		sut.Next(m)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is true", func() {
+			Expect(sut.IsEnabled()).Should(BeTrue())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
 	})
 
 	Describe("Process request", func() {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -163,6 +163,11 @@ func withType(t string) typed {
 func (t *typed) Type() string {
 	return t.typeName
 }
+
+func (t *typed) log() *logrus.Entry {
+	return log.PrefixedLog(t.Type())
+}
+
 // Should be embedded in a Resolver to auto-implement `config.Configurable`.
 type configurable[T config.Configurable] struct {
 	cfg T

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -150,6 +150,7 @@ func ForEach(resolver Resolver, callback func(Resolver)) {
 	}
 }
 
+// LogResolverConfig logs the resolver's type and config.
 func LogResolverConfig(res Resolver, logger *logrus.Entry) {
 	// Use the type, not the full typeName, to avoid redundant information with the config
 	typeName := res.Type()

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -71,7 +71,7 @@ func newRequestWithClientID(question string, rType dns.Type, ip, requestClientID
 
 // Resolver generic interface for all resolvers
 type Resolver interface {
-	config.ValueLogger
+	config.Configurable
 
 	// Resolve performs resolution of a DNS request
 	Resolve(req *model.Request) (*model.Response, error)

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -150,6 +150,20 @@ func ForEach(resolver Resolver, callback func(Resolver)) {
 	}
 }
 
+func LogResolverConfig(res Resolver, logger *logrus.Entry) {
+	// Use the type, not the full typeName, to avoid redundant information with the config
+	typeName := res.Type()
+
+	if !res.IsEnabled() {
+		logger.Debugf("-> %s: disabled", typeName)
+
+		return
+	}
+
+	logger.Infof("-> %s:", typeName)
+	log.WithIndent(logger, "     ", res.LogConfig)
+}
+
 // Should be embedded in a Resolver to auto-implement `Resolver.Type`.
 type typed struct {
 	typeName string

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -151,3 +151,22 @@ func ForEach(resolver Resolver, callback func(Resolver)) {
 		}
 	}
 }
+
+// Should be embedded in a Resolver to auto-implement `config.Configurable`.
+type configurable[T config.Configurable] struct {
+	cfg T
+}
+
+func withConfig[T config.Configurable](cfg T) configurable[T] {
+	return configurable[T]{cfg: cfg}
+}
+
+// IsEnabled implements `config.Configurable`.
+func (c *configurable[T]) IsEnabled() bool {
+	return c.cfg.IsEnabled()
+}
+
+// LogConfig implements `config.Configurable`.
+func (c *configurable[T]) LogConfig(logger *logrus.Entry) {
+	c.cfg.LogConfig(logger)
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
@@ -89,6 +90,11 @@ type Resolver interface {
 
 	// Configuration returns current resolver configuration
 	Configuration() []string
+}
+
+type ConfigGetter interface {
+	// Configuration returns current resolver configuration
+	Cfg() config.ValueLogger
 }
 
 // ChainedResolver represents a resolver, which can delegate result to the next one

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"strings"
+
 	"github.com/0xERR0R/blocky/config"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -66,19 +68,31 @@ var _ = Describe("Resolver", func() {
 			It("should return resolver name", func() {
 				br, _ := NewBlockingResolver(config.BlockingConfig{BlockType: "zeroIP"}, nil, systemResolverBootstrap)
 				name := Name(br)
-				Expect(name).Should(Equal("BlockingResolver"))
+				Expect(name).Should(Equal("blocking"))
 			})
 		})
 		When("'Name' is called on a NamedResolver", func() {
-			It("should return it's custom name", func() {
+			It("should return its custom name", func() {
 				br, _ := NewBlockingResolver(config.BlockingConfig{BlockType: "zeroIP"}, nil, systemResolverBootstrap)
 
 				cfg := config.RewriterConfig{Rewrite: map[string]string{"not": "empty"}}
 				r := NewRewriterResolver(cfg, br)
 
 				name := Name(r)
-				Expect(name).Should(Equal("BlockingResolver w/ RewriterResolver"))
+				Expect(name).Should(Equal("blocking w/ rewrite"))
 			})
 		})
 	})
 })
+
+func expectValidResolverType(sut Resolver) {
+	By("it must not contain spaces", func() {
+		Expect(sut.Type()).ShouldNot(ContainSubstring(" "))
+	})
+	By("it must be lower case", func() {
+		Expect(sut.Type()).Should(Equal(strings.ToLower(sut.Type())))
+	})
+	By("it must not contain 'resolver'", func() {
+		Expect(sut.Type()).ShouldNot(ContainSubstring("resolver"))
+	})
+}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -7,9 +7,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Resolver", func() {
-	systemResolverBootstrap := &Bootstrap{}
+var systemResolverBootstrap = &Bootstrap{}
 
+var _ = Describe("Resolver", func() {
 	Describe("Creating resolver chain", func() {
 		When("A chain of resolvers will be created", func() {
 			It("should be iterable by calling 'GetNext'", func() {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
+	"github.com/sirupsen/logrus"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,6 +61,33 @@ var _ = Describe("Resolver", func() {
 
 				Expect(itResult).ShouldNot(BeEmpty())
 				Expect(itResult).Should(Equal([]Resolver{r1, r2, r3, r4}))
+			})
+		})
+
+		Describe("LogResolverConfig", func() {
+			It("should call the resolver's `LogConfig`", func() {
+				logger := logrus.NewEntry(log.Log())
+
+				m := &mockResolver{}
+				m.On("IsEnabled").Return(true)
+				m.On("LogConfig")
+
+				LogResolverConfig(m, logger)
+
+				m.AssertExpectations(GinkgoT())
+			})
+
+			When("the resolver is disabled", func() {
+				It("should not call the resolver's `LogConfig`", func() {
+					logger := logrus.NewEntry(log.Log())
+
+					m := &mockResolver{}
+					m.On("IsEnabled").Return(false)
+
+					LogResolverConfig(m, logger)
+
+					m.AssertExpectations(GinkgoT())
+				})
 			})
 		})
 	})

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Resolver", func() {
 			It("should return it's custom name", func() {
 				br, _ := NewBlockingResolver(config.BlockingConfig{BlockType: "zeroIP"}, nil, systemResolverBootstrap)
 
-				cfg := config.RewriteConfig{Rewrite: map[string]string{"not": "empty"}}
+				cfg := config.RewriterConfig{Rewrite: map[string]string{"not": "empty"}}
 				r := NewRewriterResolver(cfg, br)
 
 				name := Name(r)

--- a/resolver/rewriter_resolver.go
+++ b/resolver/rewriter_resolver.go
@@ -18,9 +18,8 @@ import (
 // The branch is where the rewrite is active. If the branch doesn't
 // yield a result, the normal resolving is continued.
 type RewriterResolver struct {
+	configurable[*config.RewriterConfig]
 	NextResolver
-
-	cfg config.RewriterConfig
 
 	inner Resolver
 }
@@ -37,7 +36,7 @@ func NewRewriterResolver(cfg config.RewriterConfig, inner ChainedResolver) Chain
 	inner.Next(NewNoOpResolver())
 
 	return &RewriterResolver{
-		cfg: cfg,
+		configurable: withConfig(&cfg),
 
 		inner: inner,
 	}
@@ -45,11 +44,6 @@ func NewRewriterResolver(cfg config.RewriterConfig, inner ChainedResolver) Chain
 
 func (r *RewriterResolver) Name() string {
 	return fmt.Sprintf("%s w/ %s", Name(r.inner), defaultName(r))
-}
-
-// IsEnabled implements `config.Configurable`.
-func (r *RewriterResolver) IsEnabled() bool {
-	return r.cfg.IsEnabled()
 }
 
 // LogConfig implements `config.Configurable`.

--- a/resolver/rewriter_resolver.go
+++ b/resolver/rewriter_resolver.go
@@ -20,6 +20,7 @@ import (
 type RewriterResolver struct {
 	configurable[*config.RewriterConfig]
 	NextResolver
+	typed
 
 	inner Resolver
 }
@@ -37,13 +38,14 @@ func NewRewriterResolver(cfg config.RewriterConfig, inner ChainedResolver) Chain
 
 	return &RewriterResolver{
 		configurable: withConfig(&cfg),
+		typed:        withType("rewrite"),
 
 		inner: inner,
 	}
 }
 
 func (r *RewriterResolver) Name() string {
-	return fmt.Sprintf("%s w/ %s", Name(r.inner), defaultName(r))
+	return fmt.Sprintf("%s w/ %s", Name(r.inner), r.Type())
 }
 
 // LogConfig implements `config.Configurable`.

--- a/resolver/rewriter_resolver.go
+++ b/resolver/rewriter_resolver.go
@@ -20,12 +20,12 @@ import (
 type RewriterResolver struct {
 	NextResolver
 
-	cfg config.RewriteConfig
+	cfg config.RewriterConfig
 
 	inner Resolver
 }
 
-func NewRewriterResolver(cfg config.RewriteConfig, inner ChainedResolver) ChainedResolver {
+func NewRewriterResolver(cfg config.RewriterConfig, inner ChainedResolver) ChainedResolver {
 	if len(cfg.Rewrite) == 0 {
 		return inner
 	}

--- a/resolver/rewriter_resolver.go
+++ b/resolver/rewriter_resolver.go
@@ -50,7 +50,7 @@ func (r *RewriterResolver) Name() string {
 
 // LogConfig implements `config.Configurable`.
 func (r *RewriterResolver) LogConfig(logger *logrus.Entry) {
-	r.inner.LogConfig(logger)
+	LogResolverConfig(r.inner, logger)
 
 	r.cfg.LogConfig(logger)
 }

--- a/resolver/rewriter_resolver.go
+++ b/resolver/rewriter_resolver.go
@@ -47,16 +47,16 @@ func (r *RewriterResolver) Name() string {
 	return fmt.Sprintf("%s w/ %s", Name(r.inner), defaultName(r))
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *RewriterResolver) IsEnabled() bool {
 	return r.cfg.IsEnabled()
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *RewriterResolver) LogValues(logger *logrus.Entry) {
-	r.inner.LogValues(logger)
+// LogConfig implements `config.Configurable`.
+func (r *RewriterResolver) LogConfig(logger *logrus.Entry) {
+	r.inner.LogConfig(logger)
 
-	r.cfg.LogValues(logger)
+	r.cfg.LogConfig(logger)
 }
 
 // Resolve uses the inner resolver to resolve the rewritten query

--- a/resolver/rewriter_resolver.go
+++ b/resolver/rewriter_resolver.go
@@ -47,17 +47,16 @@ func (r *RewriterResolver) Name() string {
 	return fmt.Sprintf("%s w/ %s", Name(r.inner), defaultName(r))
 }
 
-// Configuration returns current resolver configuration
-func (r *RewriterResolver) Configuration() (result []string) {
-	result = append(result, "rewrite:")
-	for key, val := range r.cfg.Rewrite {
-		result = append(result, fmt.Sprintf("  %s = \"%s\"", key, val))
-	}
+// IsEnabled implements `config.ValueLogger`.
+func (r *RewriterResolver) IsEnabled() bool {
+	return r.cfg.IsEnabled()
+}
 
-	innerCfg := r.inner.Configuration()
-	result = append(result, innerCfg...)
+// LogValues implements `config.ValueLogger`.
+func (r *RewriterResolver) LogValues(logger *logrus.Entry) {
+	r.inner.LogValues(logger)
 
-	return result
+	r.cfg.LogValues(logger)
 }
 
 // Resolve uses the inner resolver to resolve the rewritten query

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -31,6 +31,12 @@ var _ = Describe("RewriterResolver", func() {
 		mNextResponse *model.Response
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		mInner = &mockResolver{}
 		mNext = &mockResolver{}

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -2,8 +2,10 @@ package resolver
 
 import (
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
+	"github.com/sirupsen/logrus"
 
 	"github.com/miekg/dns"
 	. "github.com/onsi/ginkgo/v2"
@@ -194,11 +196,11 @@ var _ = Describe("RewriterResolver", func() {
 	Describe("Configuration output", func() {
 		When("resolver is enabled", func() {
 			It("should return configuration", func() {
-				innerOutput := []string{"inner:", "config-output"}
-				mInner.On("Configuration").Return(innerOutput)
+				mInner.On("LogConfig")
 
-				c := sut.Configuration()
-				Expect(len(c)).Should(BeNumerically(">", len(innerOutput)))
+				sut.LogConfig(logrus.NewEntry(log.Log()))
+
+				Expect(mInner.Calls).Should(HaveLen(1))
 			})
 		})
 	})

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -19,7 +19,7 @@ const (
 var _ = Describe("RewriterResolver", func() {
 	var (
 		sut       ChainedResolver
-		sutConfig config.RewriteConfig
+		sutConfig config.RewriterConfig
 		mInner    *mockResolver
 		mNext     *mockResolver
 
@@ -33,7 +33,7 @@ var _ = Describe("RewriterResolver", func() {
 		mInner = &mockResolver{}
 		mNext = &mockResolver{}
 
-		sutConfig = config.RewriteConfig{Rewrite: map[string]string{"original": "rewritten"}}
+		sutConfig = config.RewriterConfig{Rewrite: map[string]string{"original": "rewritten"}}
 	})
 
 	JustBeforeEach(func() {
@@ -48,7 +48,7 @@ var _ = Describe("RewriterResolver", func() {
 
 	When("has no configuration", func() {
 		BeforeEach(func() {
-			sutConfig = config.RewriteConfig{}
+			sutConfig = config.RewriterConfig{}
 		})
 
 		It("should return the inner resolver", func() {

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -203,10 +203,9 @@ var _ = Describe("RewriterResolver", func() {
 		When("resolver is enabled", func() {
 			It("should return configuration", func() {
 				mInner.On("LogConfig")
+				mInner.On("IsEnabled").Return(true)
 
 				sut.LogConfig(logrus.NewEntry(log.Log()))
-
-				Expect(mInner.Calls).Should(HaveLen(1))
 			})
 		})
 	})

--- a/resolver/sudn_resolver.go
+++ b/resolver/sudn_resolver.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -58,6 +59,16 @@ func NewSpecialUseDomainNamesResolver() ChainedResolver {
 	}
 }
 
+// IsEnabled implements `config.ValueLogger`.
+func (r *SpecialUseDomainNamesResolver) IsEnabled() bool {
+	// RFC 6761 & 6762 are always active
+	return true
+}
+
+// LogValues implements `config.ValueLogger`.
+func (r *SpecialUseDomainNamesResolver) LogValues(logger *logrus.Entry) {
+}
+
 func (r *SpecialUseDomainNamesResolver) Resolve(request *model.Request) (*model.Response, error) {
 	// RFC 6761 - negative
 	if r.isSpecial(request, sudnArpaSlice()...) ||
@@ -76,11 +87,6 @@ func (r *SpecialUseDomainNamesResolver) Resolve(request *model.Request) (*model.
 	}
 
 	return r.next.Resolve(request)
-}
-
-// RFC 6761 & 6762 are always active
-func (r *SpecialUseDomainNamesResolver) Configuration() []string {
-	return configEnabled
 }
 
 func (r *SpecialUseDomainNamesResolver) isSpecial(request *model.Request, names ...string) bool {

--- a/resolver/sudn_resolver.go
+++ b/resolver/sudn_resolver.go
@@ -47,11 +47,15 @@ type defaultIPs struct {
 
 type SpecialUseDomainNamesResolver struct {
 	NextResolver
+	typed
+
 	defaults *defaultIPs
 }
 
 func NewSpecialUseDomainNamesResolver() ChainedResolver {
 	return &SpecialUseDomainNamesResolver{
+		typed: withType("special_use_domains"),
+
 		defaults: &defaultIPs{
 			loopbackV4: net.ParseIP("127.0.0.1"),
 			loopbackV6: net.IPv6loopback,

--- a/resolver/sudn_resolver.go
+++ b/resolver/sudn_resolver.go
@@ -71,6 +71,7 @@ func (r *SpecialUseDomainNamesResolver) IsEnabled() bool {
 
 // LogConfig implements `config.Configurable`.
 func (r *SpecialUseDomainNamesResolver) LogConfig(logger *logrus.Entry) {
+	logger.Info("enabled")
 }
 
 func (r *SpecialUseDomainNamesResolver) Resolve(request *model.Request) (*model.Response, error) {

--- a/resolver/sudn_resolver.go
+++ b/resolver/sudn_resolver.go
@@ -59,14 +59,14 @@ func NewSpecialUseDomainNamesResolver() ChainedResolver {
 	}
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *SpecialUseDomainNamesResolver) IsEnabled() bool {
 	// RFC 6761 & 6762 are always active
 	return true
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *SpecialUseDomainNamesResolver) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (r *SpecialUseDomainNamesResolver) LogConfig(logger *logrus.Entry) {
 }
 
 func (r *SpecialUseDomainNamesResolver) Resolve(request *model.Request) (*model.Response, error) {

--- a/resolver/sudn_resolver_test.go
+++ b/resolver/sudn_resolver_test.go
@@ -17,6 +17,12 @@ var _ = Describe("SudnResolver", Label("sudnResolver"), func() {
 		m   *mockResolver
 	)
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	BeforeEach(func() {
 		mockAnswer, err := util.NewMsgWithAnswer("example.com.", 300, A, "123.145.123.145")
 		Expect(err).Should(Succeed())

--- a/resolver/sudn_resolver_test.go
+++ b/resolver/sudn_resolver_test.go
@@ -28,6 +28,22 @@ var _ = Describe("SudnResolver", Label("sudnResolver"), func() {
 		sut.Next(m)
 	})
 
+	Describe("IsEnabled", func() {
+		It("is true", func() {
+			Expect(sut.IsEnabled()).Should(BeTrue())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should not log anything", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).Should(BeEmpty())
+		})
+	})
+
 	Describe("Blocking special names", func() {
 		It("should block arpa", func() {
 			for _, arpa := range sudnArpaSlice() {
@@ -132,16 +148,6 @@ var _ = Describe("SudnResolver", Label("sudnResolver"), func() {
 						HaveResponseType(ResponseTypeRESOLVED),
 						HaveReturnCode(dns.RcodeSuccess),
 					))
-		})
-	})
-
-	Describe("LogConfig", func() {
-		It("should not log anything", func() {
-			logger, hook := log.NewMockEntry()
-
-			sut.LogConfig(logger)
-
-			Expect(hook.Calls).Should(BeEmpty())
 		})
 	})
 })

--- a/resolver/sudn_resolver_test.go
+++ b/resolver/sudn_resolver_test.go
@@ -46,7 +46,7 @@ var _ = Describe("SudnResolver", Label("sudnResolver"), func() {
 
 			sut.LogConfig(logger)
 
-			Expect(hook.Calls).Should(BeEmpty())
+			Expect(hook.Calls).ShouldNot(BeEmpty())
 		})
 	})
 

--- a/resolver/sudn_resolver_test.go
+++ b/resolver/sudn_resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 	"github.com/miekg/dns"
@@ -134,11 +135,13 @@ var _ = Describe("SudnResolver", Label("sudnResolver"), func() {
 		})
 	})
 
-	Describe("Configuration pseudo test", func() {
-		It("should always be empty", func() {
-			c := sut.Configuration()
+	Describe("LogConfig", func() {
+		It("should not log anything", func() {
+			logger, hook := log.NewMockEntry()
 
-			Expect(len(c)).Should(BeNumerically(">=", 1))
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).Should(BeEmpty())
 		})
 	})
 })

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -51,7 +51,7 @@ type httpUpstreamClient struct {
 }
 
 func createUpstreamClient(cfg config.Upstream) upstreamClient {
-	timeout := config.GetConfig().UpstreamTimeout.Cast()
+	timeout := config.GetConfig().UpstreamTimeout.ToDuration()
 
 	tlsConfig := tls.Config{
 		ServerName: cfg.Host,

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -30,6 +30,8 @@ const (
 
 // UpstreamResolver sends request to external DNS server
 type UpstreamResolver struct {
+	typed
+
 	upstream       config.Upstream
 	upstreamClient upstreamClient
 	bootstrap      *Bootstrap
@@ -209,6 +211,8 @@ func newUpstreamResolverUnchecked(upstream config.Upstream, bootstrap *Bootstrap
 	upstreamClient := createUpstreamClient(upstream)
 
 	return &UpstreamResolver{
+		typed: withType("upstream"),
+
 		upstream:       upstream,
 		upstreamClient: upstreamClient,
 		bootstrap:      bootstrap,
@@ -226,7 +230,7 @@ func (r *UpstreamResolver) LogConfig(logger *logrus.Entry) {
 }
 
 func (r UpstreamResolver) String() string {
-	return fmt.Sprintf("upstream '%s'", r.upstream)
+	return fmt.Sprintf("%s '%s'", r.Type(), r.upstream)
 }
 
 // Resolve calls external resolver

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -51,7 +51,7 @@ type httpUpstreamClient struct {
 }
 
 func createUpstreamClient(cfg config.Upstream) upstreamClient {
-	timeout := time.Duration(config.GetConfig().UpstreamTimeout)
+	timeout := config.GetConfig().UpstreamTimeout.Cast()
 
 	tlsConfig := tls.Config{
 		ServerName: cfg.Host,

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -215,9 +215,14 @@ func newUpstreamResolverUnchecked(upstream config.Upstream, bootstrap *Bootstrap
 	}
 }
 
-// Configuration return current resolver configuration
-func (r *UpstreamResolver) Configuration() (result []string) {
-	return []string{r.String()}
+// IsEnabled implements `config.ValueLogger`.
+func (r *UpstreamResolver) IsEnabled() bool {
+	return true
+}
+
+// LogValues implements `config.ValueLogger`.
+func (r *UpstreamResolver) LogValues(logger *logrus.Entry) {
+	logger.Info(r.upstream)
 }
 
 func (r UpstreamResolver) String() string {

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -215,13 +215,13 @@ func newUpstreamResolverUnchecked(upstream config.Upstream, bootstrap *Bootstrap
 	}
 }
 
-// IsEnabled implements `config.ValueLogger`.
+// IsEnabled implements `config.Configurable`.
 func (r *UpstreamResolver) IsEnabled() bool {
 	return true
 }
 
-// LogValues implements `config.ValueLogger`.
-func (r *UpstreamResolver) LogValues(logger *logrus.Entry) {
+// LogConfig implements `config.Configurable`.
+func (r *UpstreamResolver) LogConfig(logger *logrus.Entry) {
 	logger.Info(r.upstream)
 }
 

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -235,8 +235,6 @@ func (r UpstreamResolver) String() string {
 
 // Resolve calls external resolver
 func (r *UpstreamResolver) Resolve(request *model.Request) (response *model.Response, err error) {
-	logger := log.WithPrefix(request.Log, "upstream_resolver")
-
 	ips, err := r.bootstrap.UpstreamIPs(r)
 	if err != nil {
 		return nil, err
@@ -256,7 +254,7 @@ func (r *UpstreamResolver) Resolve(request *model.Request) (response *model.Resp
 			var err error
 			resp, rtt, err = r.upstreamClient.callExternal(request.Req, upstreamURL, request.Protocol)
 			if err == nil {
-				logger.WithFields(logrus.Fields{
+				r.log().WithFields(logrus.Fields{
 					"answer":           util.AnswerToString(resp.Answer),
 					"return_code":      dns.RcodeToString[resp.Rcode],
 					"upstream":         r.upstream.String(),
@@ -281,7 +279,7 @@ func (r *UpstreamResolver) Resolve(request *model.Request) (response *model.Resp
 			return errors.As(err, &netErr) && netErr.Timeout()
 		}),
 		retry.OnRetry(func(n uint, err error) {
-			logger.WithFields(logrus.Fields{
+			r.log().WithFields(logrus.Fields{
 				"upstream":    r.upstream.String(),
 				"upstream_ip": ip.String(),
 				"question":    util.QuestionToString(request.Req.Question),

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -221,7 +221,7 @@ func (r *UpstreamResolver) Configuration() (result []string) {
 }
 
 func (r UpstreamResolver) String() string {
-	return fmt.Sprintf("upstream '%s'", r.upstream.String())
+	return fmt.Sprintf("upstream '%s'", r.upstream)
 }
 
 // Resolve calls external resolver

--- a/resolver/upstream_resolver_test.go
+++ b/resolver/upstream_resolver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
 	"github.com/miekg/dns"
@@ -17,7 +18,34 @@ import (
 )
 
 var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
-	systemResolverBootstrap := &Bootstrap{}
+	var (
+		sut       *UpstreamResolver
+		sutConfig config.Upstream
+	)
+
+	BeforeEach(func() {
+		sutConfig = config.Upstream{Host: "localhost"}
+	})
+
+	JustBeforeEach(func() {
+		sut = newUpstreamResolverUnchecked(sutConfig, systemResolverBootstrap)
+	})
+
+	Describe("IsEnabled", func() {
+		It("is true", func() {
+			Expect(sut.IsEnabled()).Should(BeTrue())
+		})
+	})
+
+	Describe("LogConfig", func() {
+		It("should log something", func() {
+			logger, hook := log.NewMockEntry()
+
+			sut.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+		})
+	})
 
 	Describe("Using DNS upstream", func() {
 		When("Configured DNS resolver can resolve query", func() {
@@ -35,7 +63,7 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 							HaveResponseType(ResponseTypeRESOLVED),
 							HaveReturnCode(dns.RcodeSuccess),
 							HaveTTL(BeNumerically("==", 123)),
-							HaveReason(fmt.Sprintf("RESOLVED (%s)", upstream.String()))),
+							HaveReason(fmt.Sprintf("RESOLVED (%s)", upstream))),
 					)
 			})
 		})
@@ -53,7 +81,7 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 							HaveNoAnswer(),
 							HaveResponseType(ResponseTypeRESOLVED),
 							HaveReturnCode(dns.RcodeNameError),
-							HaveReason(fmt.Sprintf("RESOLVED (%s)", upstream.String()))),
+							HaveReason(fmt.Sprintf("RESOLVED (%s)", upstream))),
 					)
 			})
 		})
@@ -213,17 +241,6 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 					ContainSubstring("no such host"),
 					ContainSubstring("i/o timeout"),
 					ContainSubstring("Temporary failure in name resolution")))
-			})
-		})
-	})
-	Describe("Configuration", func() {
-		When("Configuration is called", func() {
-			It("should return configuration", func() {
-				sut := newUpstreamResolverUnchecked(config.Upstream{}, nil)
-
-				c := sut.Configuration()
-
-				Expect(len(c)).Should(BeNumerically(">=", 1))
 			})
 		})
 	})

--- a/resolver/upstream_resolver_test.go
+++ b/resolver/upstream_resolver_test.go
@@ -31,6 +31,12 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 		sut = newUpstreamResolverUnchecked(sutConfig, systemResolverBootstrap)
 	})
 
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
 	Describe("IsEnabled", func() {
 		It("is true", func() {
 			Expect(sut.IsEnabled()).Should(BeTrue())

--- a/server/server.go
+++ b/server/server.go
@@ -440,13 +440,16 @@ func (s *Server) printConfiguration() {
 	logger().Info("current configuration:")
 
 	resolver.ForEach(s.queryResolver, func(res resolver.Resolver) {
+		// Use the type, not the full name, to avoid redundant information with the config
+		name := res.Type()
+
 		if !res.IsEnabled() {
-			logger().Debugf("-> %s: disabled", resolver.Name(res))
+			logger().Debugf("-> %s: disabled", name)
 
 			return
 		}
 
-		logger().Infof("-> %s", resolver.Name(res))
+		logger().Infof("-> %s:", name)
 		log.WithIndent(logger(), "     ", res.LogConfig)
 	})
 

--- a/server/server.go
+++ b/server/server.go
@@ -416,11 +416,11 @@ func createQueryResolver(
 		resolver.NewEdeResolver(cfg.Ede),
 		resolver.NewQueryLoggingResolver(cfg.QueryLog),
 		resolver.NewMetricsResolver(cfg.Prometheus),
-		resolver.NewRewriterResolver(cfg.CustomDNS.RewriteConfig, resolver.NewCustomDNSResolver(cfg.CustomDNS)),
+		resolver.NewRewriterResolver(cfg.CustomDNS.RewriterConfig, resolver.NewCustomDNSResolver(cfg.CustomDNS)),
 		resolver.NewHostsFileResolver(cfg.HostsFile),
 		blocking,
 		resolver.NewCachingResolver(cfg.Caching, redisClient),
-		resolver.NewRewriterResolver(cfg.Conditional.RewriteConfig, condUpstream),
+		resolver.NewRewriterResolver(cfg.Conditional.RewriterConfig, condUpstream),
 		resolver.NewSpecialUseDomainNamesResolver(),
 		parallel,
 	)

--- a/server/server.go
+++ b/server/server.go
@@ -395,7 +395,7 @@ func createQueryResolver(
 	redisClient *redis.Client,
 ) (r resolver.Resolver, err error) {
 	blocking, blErr := resolver.NewBlockingResolver(cfg.Blocking, redisClient, bootstrap)
-	parallel, pErr := resolver.NewParallelBestResolver(cfg.Upstream.ExternalResolvers, bootstrap, cfg.StartVerifyUpstream)
+	parallel, pErr := resolver.NewParallelBestResolver(cfg.Upstream, bootstrap, cfg.StartVerifyUpstream)
 	clientNames, cnErr := resolver.NewClientNamesResolver(cfg.ClientLookup, bootstrap, cfg.StartVerifyUpstream)
 	condUpstream, cuErr := resolver.NewConditionalUpstreamResolver(cfg.Conditional, bootstrap, cfg.StartVerifyUpstream)
 

--- a/server/server.go
+++ b/server/server.go
@@ -440,23 +440,11 @@ func (s *Server) printConfiguration() {
 	logger().Info("current configuration:")
 
 	resolver.ForEach(s.queryResolver, func(res resolver.Resolver) {
-		// Use the type, not the full name, to avoid redundant information with the config
-		name := res.Type()
-
-		if !res.IsEnabled() {
-			logger().Debugf("-> %s: disabled", name)
-
-			return
-		}
-
-		logger().Infof("-> %s:", name)
-		log.WithIndent(logger(), "     ", res.LogConfig)
+		resolver.LogResolverConfig(res, logger())
 	})
 
-	logger().Infof("- DNS listening on addrs/ports: %v", s.cfg.Ports.DNS)
-	logger().Infof("- TLS listening on addrs/ports: %v", s.cfg.Ports.TLS)
-	logger().Infof("- HTTP listening on addrs/ports: %v", s.cfg.Ports.HTTP)
-	logger().Infof("- HTTPS listening on addrs/ports: %v", s.cfg.Ports.HTTPS)
+	logger().Info("listeners:")
+	log.WithIndent(logger(), "  ", s.cfg.Ports.LogConfig)
 
 	logger().Info("runtime information:")
 

--- a/server/server.go
+++ b/server/server.go
@@ -447,7 +447,7 @@ func (s *Server) printConfiguration() {
 		}
 
 		logger().Infof("-> %s", resolver.Name(res))
-		log.WithIndent(logger(), "     ", res.LogValues)
+		log.WithIndent(logger(), "     ", res.LogConfig)
 	})
 
 	logger().Infof("- DNS listening on addrs/ports: %v", s.cfg.Ports.DNS)

--- a/server/server.go
+++ b/server/server.go
@@ -443,8 +443,17 @@ func (s *Server) printConfiguration() {
 	for res != nil {
 		logger().Infof("-> resolver: '%s'", resolver.Name(res))
 
-		for _, c := range res.Configuration() {
-			logger().Infof("     %s", c)
+		if resCfg, ok := res.(resolver.ConfigGetter); ok {
+			func() {
+				undo := log.PrefixMessages("     ", logger().Logger)
+				defer undo()
+
+				resCfg.Cfg().LogValues(logger())
+			}()
+		} else {
+			for _, c := range res.Configuration() {
+				logger().Infof("     %s", c)
+			}
 		}
 
 		if c, ok := res.(resolver.ChainedResolver); ok {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -105,7 +105,7 @@ var _ = BeforeSuite(func() {
 	// create server
 	sut, err = NewServer(&config.Config{
 		CustomDNS: config.CustomDNSConfig{
-			CustomTTL: config.NewDuration(3600 * time.Second),
+			CustomTTL: config.Duration(3600 * time.Second),
 			Mapping: config.CustomDNSMapping{
 				HostIPs: map[string][]net.IP{
 					"custom.lan": {net.ParseIP("192.168.178.55")},
@@ -141,7 +141,7 @@ var _ = BeforeSuite(func() {
 				"clYoutubeOnly":   {"youtube"},
 			},
 			BlockType: "zeroIp",
-			BlockTTL:  config.NewDuration(6 * time.Hour),
+			BlockTTL:  config.Duration(6 * time.Hour),
 		},
 		Upstream: config.UpstreamConfig{
 			ExternalResolvers: map[string][]config.Upstream{"default": {upstreamGoogle}},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -158,7 +158,7 @@ var _ = BeforeSuite(func() {
 		},
 		CertFile: certPem.Path,
 		KeyFile:  keyPem.Path,
-		Prometheus: config.PrometheusConfig{
+		Prometheus: config.MetricsConfig{
 			Enable: true,
 			Path:   "/metrics",
 		},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -105,7 +105,7 @@ var _ = BeforeSuite(func() {
 	// create server
 	sut, err = NewServer(&config.Config{
 		CustomDNS: config.CustomDNSConfig{
-			CustomTTL: config.Duration(time.Duration(3600) * time.Second),
+			CustomTTL: config.NewDuration(3600 * time.Second),
 			Mapping: config.CustomDNSMapping{
 				HostIPs: map[string][]net.IP{
 					"custom.lan": {net.ParseIP("192.168.178.55")},
@@ -141,7 +141,7 @@ var _ = BeforeSuite(func() {
 				"clYoutubeOnly":   {"youtube"},
 			},
 			BlockType: "zeroIp",
-			BlockTTL:  config.Duration(6 * time.Hour),
+			BlockTTL:  config.NewDuration(6 * time.Hour),
 		},
 		Upstream: config.UpstreamConfig{
 			ExternalResolvers: map[string][]config.Upstream{"default": {upstreamGoogle}},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -143,7 +143,7 @@ var _ = BeforeSuite(func() {
 			BlockType: "zeroIp",
 			BlockTTL:  config.Duration(6 * time.Hour),
 		},
-		Upstream: config.UpstreamConfig{
+		Upstream: config.ParallelBestConfig{
 			ExternalResolvers: map[string][]config.Upstream{"default": {upstreamGoogle}},
 		},
 		ClientLookup: config.ClientLookupConfig{
@@ -643,7 +643,7 @@ var _ = Describe("Running DNS server", func() {
 			It("start was called 2 times, start should fail", func() {
 				// create server
 				server, err := NewServer(&config.Config{
-					Upstream: config.UpstreamConfig{
+					Upstream: config.ParallelBestConfig{
 						ExternalResolvers: map[string][]config.Upstream{
 							"default": {config.Upstream{Net: config.NetProtocolTcpUdp, Host: "4.4.4.4", Port: 53}},
 						},
@@ -685,7 +685,7 @@ var _ = Describe("Running DNS server", func() {
 			It("stop was called 2 times, start should fail", func() {
 				// create server
 				server, err := NewServer(&config.Config{
-					Upstream: config.UpstreamConfig{
+					Upstream: config.ParallelBestConfig{
 						ExternalResolvers: map[string][]config.Upstream{
 							"default": {config.Upstream{Net: config.NetProtocolTcpUdp, Host: "4.4.4.4", Port: 53}},
 						},

--- a/util/common.go
+++ b/util/common.go
@@ -109,7 +109,7 @@ func NewMsgWithQuestion(question string, qType dns.Type) *dns.Msg {
 
 // NewMsgWithAnswer creates new DNS message with answer
 func NewMsgWithAnswer(domain string, ttl uint, dnsType dns.Type, address string) (*dns.Msg, error) {
-	rr, err := dns.NewRR(fmt.Sprintf("%s\t%d\tIN\t%s\t%s", domain, ttl, dnsType.String(), address))
+	rr, err := dns.NewRR(fmt.Sprintf("%s\t%d\tIN\t%s\t%s", domain, ttl, dnsType, address))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I started these changes while working the hosts file resolver, and wanted to make a PR before I do the same to other resolvers, if there's interest.

The `config.Duration` change is to try and make using the type easier: with an embed all original methods are available.  
The tradeoffs are:
- defaults need to be parsed from a JSON string, which has to be escaped: ```struct { x Duration `default:"\"1h\""` }```
- converting to `time.Duration` is a bit less explicit: `x.Cast()` vs `time.Duration(x)`. That could be `x.Duration`, but I thought that was awkward to read (ex: `cfg.ConnectionCooldown.Duration`).

That first change allowed me to not copy the values out of the `config.HostsFileConfig` into the `HostsFileResolver` since using the `config.Duration` directly is easy.  
I think this is nice because it makes adding config options faster. And finding all references to an option/renaming it is instant. Depending on how we end up doing config reloading, it could help too: update a single field and trigger a refresh.

The config printing I moved to the config struct itself, instead of the resolver. And changed it to print via a logger instead of returning an array.  
I think that's valuable so we can make what's shown more or less verbose depending on the log level.

Let me know if what's of interest, if any, and I can adapt the PR.
The first change can be merged as is. The other two, I'd apply the idea to more resolvers.  
I also didn't take the time to fix the tests for the third change.