### PR TITLE
chore(test): fix freezing test

### DIFF
--- a/resolver/bootstrap_test.go
+++ b/resolver/bootstrap_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 			})
 
 			It("should use the system resolver", func() {
-				usedSystemResolver := make(chan bool, 10)
+				usedSystemResolver := make(chan bool, 100)
 
 				sut.systemResolver = &net.Resolver{
 					PreferGo: true,


### PR DESCRIPTION
On my local machine and on a code server instance the execution of resolver tests was frozen. After some debugging, I found that the "system resolver" in the test was invoked > 15 times and the channel has only capacity of 10.