### PR TITLE
Adding a switch on/off for active disable OpenDNS by ip groups

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -38,6 +38,10 @@ type QueryRequest struct {
 	Query string `json:"query"`
 	// request type (A, AAAA, ...)
 	Type string `json:"type"`
+	// optional : Use remote address : default false
+	UseRemoteAddress bool
+	// optional : Remote address override
+	RemoteAddress string
 }
 
 // QueryResult is a data structure for the DNS result

--- a/api/api.go
+++ b/api/api.go
@@ -22,6 +22,15 @@ const (
 	// PathBlockingDisablePath defines the REST endpoint for blocking disable
 	PathBlockingDisablePath = "/api/blocking/disable"
 
+	// PathClientDNSResolverStatusPath defines the REST endpoint for client dns resolver status
+	PathClientDNSResolverStatusPath = "/api/dns/status"
+
+	// PathClientDNSResolverEnablePath defines the REST endpoint for client dns resolver enable
+	PathClientDNSResolverEnablePath = "/api/dns/enable"
+
+	// PathClientDNSResolverDisablePath defines the REST endpoint for client dns resolver disable
+	PathClientDNSResolverDisablePath = "/api/dns/disable"
+
 	// PathListsRefresh defines the REST endpoint for blocking refresh
 	PathListsRefresh = "/api/lists/refresh"
 
@@ -39,9 +48,11 @@ type QueryRequest struct {
 	// request type (A, AAAA, ...)
 	Type string `json:"type"`
 	// optional : Use remote address : default false
-	UseRemoteAddress bool
+	UseRemoteAddress bool `json:"useRemoteAddress"`
 	// optional : Remote address override
-	RemoteAddress string
+	RemoteAddress string `json:"remoteAddress"`
+	// optional : refresh cache : default false
+	RefreshCache bool `json:"refreshCache"`
 }
 
 // QueryResult is a data structure for the DNS result

--- a/api/api_endpoints.go
+++ b/api/api_endpoints.go
@@ -24,6 +24,13 @@ type BlockingControl interface {
 	BlockingStatus() BlockingStatus
 }
 
+// ClientDNSResolverControl interface to control the blocking status
+type ClientDNSResolverControl interface {
+	EnableClientDNSResolver()
+	DisableClientDNSResolver(duration time.Duration, disableGroups []string) error
+	ClientDNSResolverStatus() BlockingStatus
+}
+
 // ListRefresher interface to control the list refresh
 type ListRefresher interface {
 	RefreshLists()
@@ -32,6 +39,11 @@ type ListRefresher interface {
 // BlockingEndpoint endpoint for the blocking status control
 type BlockingEndpoint struct {
 	control BlockingControl
+}
+
+// BlockingEndpoint endpoint for the blocking status control
+type ClientDNSResolverEndpoint struct {
+	control ClientDNSResolverControl
 }
 
 // ListRefreshEndpoint endpoint for list refresh
@@ -43,6 +55,10 @@ type ListRefreshEndpoint struct {
 func RegisterEndpoint(router chi.Router, t interface{}) {
 	if a, ok := t.(BlockingControl); ok {
 		registerBlockingEndpoints(router, a)
+	}
+
+	if a, ok := t.(ClientDNSResolverControl); ok {
+		registerClientDNSResolverEndpoints(router, a)
 	}
 
 	if a, ok := t.(ListRefresher); ok {
@@ -75,6 +91,14 @@ func registerBlockingEndpoints(router chi.Router, control BlockingControl) {
 	router.Get(PathBlockingStatusPath, s.apiBlockingStatus)
 }
 
+func registerClientDNSResolverEndpoints(router chi.Router, control ClientDNSResolverControl) {
+	s := &ClientDNSResolverEndpoint{control}
+	// register API endpoints
+	router.Get(PathClientDNSResolverEnablePath, s.apiClientDNSResolverEnable)
+	router.Get(PathClientDNSResolverDisablePath, s.apiClientDNSResolverDisable)
+	router.Get(PathClientDNSResolverStatusPath, s.apiClientDNSResolverStatus)
+}
+
 // apiBlockingEnable is the http endpoint to enable the blocking status
 // @Summary Enable blocking
 // @Description enable the blocking status
@@ -85,8 +109,82 @@ func (s *BlockingEndpoint) apiBlockingEnable(rw http.ResponseWriter, _ *http.Req
 	log.Log().Info("enabling blocking...")
 
 	s.control.EnableBlocking()
+	rw.Header().Set(contentTypeHeader, jsonContentType)
+	_, err := rw.Write([]byte("{}"))
+
+	if err != nil {
+		log.Log().Error("Can't send an empty answer: ", log.EscapeInput(err.Error()))
+	}
+}
+
+// apiClientDNSResolverEnable is the http endpoint to enable the client dns resolver status
+// @Summary Enable client dns resolver
+// @Description enable the client dns resolver status
+// @Tags blocking
+// @Success 200   "Blocking is enabled"
+// @Router /blocking/enable [get]
+func (s *ClientDNSResolverEndpoint) apiClientDNSResolverEnable(rw http.ResponseWriter, _ *http.Request) {
+	log.Log().Info("enabling blocking...")
+
+	s.control.EnableClientDNSResolver()
 
 	rw.Header().Set(contentTypeHeader, jsonContentType)
+	_, err := rw.Write([]byte("{}"))
+
+	if err != nil {
+		log.Log().Error("Can't send an empty answer: ", log.EscapeInput(err.Error()))
+	}
+}
+
+// apiDisableClientDNSResolver is the http endpoint to disable the blocking status
+// @Summary Disable client dns resolver
+// @Description disable the client dns resolver for client
+// @Tags blocking
+// @Param duration query string false "duration of blocking (Example: 300s, 5m, 1h, 5m30s)" Format(duration)
+// @Param groups query string false "groups to disable (comma separated). If empty, disable all groups" Format(string)
+// @Success 200   "Blocking is disabled"
+// @Failure 400   "Wrong duration format"
+// @Failure 400   "Unknown group"
+// @Router /blocking/disable [get]
+func (s *ClientDNSResolverEndpoint) apiClientDNSResolverDisable(rw http.ResponseWriter, req *http.Request) {
+	var (
+		duration time.Duration
+		groups   []string
+		err      error
+	)
+
+	rw.Header().Set(contentTypeHeader, jsonContentType)
+
+	// parse duration from query parameter
+	durationParam := req.URL.Query().Get("duration")
+	if len(durationParam) > 0 {
+		duration, err = time.ParseDuration(durationParam)
+		if err != nil {
+			log.Log().Errorf("wrong duration format '%s'", log.EscapeInput(durationParam))
+			rw.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+	}
+
+	groupsParam := req.URL.Query().Get("groups")
+	if len(groupsParam) > 0 {
+		groups = strings.Split(groupsParam, ",")
+	}
+
+	err = s.control.DisableClientDNSResolver(duration, groups)
+	if err != nil {
+		log.Log().Error("can't dns disable the blocking: ", log.EscapeInput(err.Error()))
+		rw.WriteHeader(http.StatusBadRequest)
+	} else {
+		log.Log().Warn("Blocking request acknowledged but not sent to redis: ")
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte("{}"))
+
+		if err != nil {
+			log.Log().Error("Can't send an empty answer: ", log.EscapeInput(err.Error()))
+		}
+	}
 }
 
 // apiBlockingDisable is the http endpoint to disable the blocking status
@@ -129,7 +227,33 @@ func (s *BlockingEndpoint) apiBlockingDisable(rw http.ResponseWriter, req *http.
 	if err != nil {
 		log.Log().Error("can't disable the blocking: ", log.EscapeInput(err.Error()))
 		rw.WriteHeader(http.StatusBadRequest)
+	} else {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte("{}"))
+
+		if err != nil {
+			log.Log().Error("Can't send an empty answer: ", log.EscapeInput(err.Error()))
+		}
 	}
+}
+
+// apiClientDNSResolverStatus is the http endpoint to get current client dns resolver status
+// @Summary client dns resolver status
+// @Description get current client dns resolver status
+// @Tags client dns resolver
+// @Produce  json
+// @Success 200 {object} api.BlockingStatus "Returns current blocking status"
+// @Router /blocking/status [get]
+func (s *ClientDNSResolverEndpoint) apiClientDNSResolverStatus(rw http.ResponseWriter, _ *http.Request) {
+	status := s.control.ClientDNSResolverStatus()
+
+	rw.Header().Set(contentTypeHeader, jsonContentType)
+
+	response, err := json.Marshal(status)
+	util.LogOnError("unable to marshal response ", err)
+
+	_, err = rw.Write(response)
+	util.LogOnError("unable to write response ", err)
 }
 
 // apiBlockingStatus is the http endpoint to get current blocking status

--- a/model/models.go
+++ b/model/models.go
@@ -69,4 +69,5 @@ type Request struct {
 	Req             *dns.Msg
 	Log             *logrus.Entry
 	RequestTS       time.Time
+	RefreshCache    bool
 }

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -157,7 +157,9 @@ func (r *CachingResolver) Resolve(request *model.Request) (response *model.Respo
 
 		val, ttl := r.resultCache.Get(cacheKey)
 
-		if val != nil {
+		if request.RefreshCache {
+			logger.Debug("Forcing refresh from cache")
+		} else if val != nil {
 			logger.Debug("domain is cached")
 
 			r.publishMetricsIfEnabled(evt.CachingResultCacheHit, domain)

--- a/server/server_endpoints.go
+++ b/server/server_endpoints.go
@@ -33,6 +33,21 @@ const (
 	corsMaxAge        = 5 * time.Minute
 )
 
+type ApiResponseWriter struct {
+	ip string
+}
+
+func (r *ApiResponseWriter) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP(r.ip)}
+}
+func (r *ApiResponseWriter) LocalAddr() net.Addr       { return nil }
+func (r *ApiResponseWriter) WriteMsg(m *dns.Msg) error { return nil }
+func (r *ApiResponseWriter) Write([]byte) (int, error) { return 0, nil }
+func (r *ApiResponseWriter) Close() error              { return nil }
+func (r *ApiResponseWriter) TsigStatus() error         { return nil }
+func (r *ApiResponseWriter) TsigTimersOnly(bool)       {}
+func (r *ApiResponseWriter) Hijack()                   {}
+
 func secureHeader(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("strict-transport-security", "max-age=63072000")
@@ -174,6 +189,7 @@ func extractIP(r *http.Request) string {
 // @Router /query [post]
 func (s *Server) apiQuery(rw http.ResponseWriter, req *http.Request) {
 	var queryRequest api.QueryRequest
+	var apirw ApiResponseWriter
 
 	rw.Header().Set(contentTypeHeader, jsonContentType)
 
@@ -200,9 +216,21 @@ func (s *Server) apiQuery(rw http.ResponseWriter, req *http.Request) {
 		query += "."
 	}
 
-	dnsRequest := util.NewMsgWithQuestion(query, qType)
+	useRemoteAdress := queryRequest.UseRemoteAddress
+	if useRemoteAdress {
+		remoteAddr, _, err := net.SplitHostPort(req.RemoteAddr)
+		if err != nil {
+			logAndResponseWithError(err, "Cannot find remote url on "+req.RemoteAddr+" : ", rw)
+			return
+		} else {
+			apirw = ApiResponseWriter{ip: remoteAddr}
+		}
+	} else if queryRequest.RemoteAddress != "" {
+		apirw = ApiResponseWriter{ip: queryRequest.RemoteAddress}
+	}
 
-	r := newRequest(net.ParseIP(extractIP(req)), model.RequestProtocolTCP, "", dnsRequest)
+	dnsRequest := util.NewMsgWithQuestion(query, qType)
+	r := createResolverRequest(&apirw, dnsRequest)
 
 	response, err := s.queryResolver.Resolve(r)
 	if err != nil {


### PR DESCRIPTION
Adding two endpoint : 
```
GET /api/dns/disable?groups=<client-group-id>&duration=120m
GET /api/dns/enable
GET /api/dns/status
```
to switch on or off specific DNS applied for a client group id
A way to activate desactivate parental control or adguard temporary