### PR TITLE
fix: log `startStrategy` instead of deprecated `failStartOnListError`

### DIFF
--- a/config/blocking.go
+++ b/config/blocking.go
@@ -9,19 +9,18 @@ import (
 
 // BlockingConfig configuration for query blocking
 type BlockingConfig struct {
-	BlackLists        map[string][]string `yaml:"blackLists"`
-	WhiteLists        map[string][]string `yaml:"whiteLists"`
-	ClientGroupsBlock map[string][]string `yaml:"clientGroupsBlock"`
-	BlockType         string              `yaml:"blockType" default:"ZEROIP"`
-	BlockTTL          Duration            `yaml:"blockTTL" default:"6h"`
-	DownloadTimeout   Duration            `yaml:"downloadTimeout" default:"60s"`
-	DownloadAttempts  uint                `yaml:"downloadAttempts" default:"3"`
-	DownloadCooldown  Duration            `yaml:"downloadCooldown" default:"1s"`
-	RefreshPeriod     Duration            `yaml:"refreshPeriod" default:"4h"`
-	// Deprecated
-	FailStartOnListError  bool              `yaml:"failStartOnListError" default:"false"`
-	ProcessingConcurrency uint              `yaml:"processingConcurrency" default:"4"`
-	StartStrategy         StartStrategyType `yaml:"startStrategy" default:"blocking"`
+	BlackLists            map[string][]string `yaml:"blackLists"`
+	WhiteLists            map[string][]string `yaml:"whiteLists"`
+	ClientGroupsBlock     map[string][]string `yaml:"clientGroupsBlock"`
+	BlockType             string              `yaml:"blockType" default:"ZEROIP"`
+	BlockTTL              Duration            `yaml:"blockTTL" default:"6h"`
+	DownloadTimeout       Duration            `yaml:"downloadTimeout" default:"60s"`
+	DownloadAttempts      uint                `yaml:"downloadAttempts" default:"3"`
+	DownloadCooldown      Duration            `yaml:"downloadCooldown" default:"1s"`
+	RefreshPeriod         Duration            `yaml:"refreshPeriod" default:"4h"`
+	FailStartOnListError  bool                `yaml:"failStartOnListError" default:"false"` // Deprecated
+	ProcessingConcurrency uint                `yaml:"processingConcurrency" default:"4"`
+	StartStrategy         StartStrategyType   `yaml:"startStrategy" default:"blocking"`
 }
 
 // IsEnabled implements `config.Configurable`.
@@ -45,7 +44,7 @@ func (c *BlockingConfig) LogConfig(logger *logrus.Entry) {
 
 	logger.Infof("downloadTimeout = %s", c.DownloadTimeout)
 
-	logger.Infof("failStartOnListError = %t", c.FailStartOnListError)
+	logger.Infof("startStrategy = %s", c.StartStrategy)
 
 	if c.RefreshPeriod > 0 {
 		logger.Infof("refresh = every %s", c.RefreshPeriod)


### PR DESCRIPTION
Fixes #956.