### PR TITLE
Add homebrew link to the installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -180,4 +180,8 @@ See [https://github.com/m0zgen/blocky-installer](https://github.com/m0zgen/block
 
 See [https://www.freebsd.org/cgi/ports.cgi?query=blocky&stype=all](https://www.freebsd.org/cgi/ports.cgi?query=blocky&stype=all)
 
+### Homebrew package for MacOS
+
+See [https://formulae.brew.sh/formula/blocky](https://formulae.brew.sh/formula/blocky)
+
 --8<-- "docs/includes/abbreviations.md"


### PR DESCRIPTION
Blocky is now available in Homebrew.

https://formulae.brew.sh/formula/blocky
https://github.com/Homebrew/homebrew-core/pull/127041
https://github.com/Homebrew/homebrew-core/pull/120963
https://github.com/0xERR0R/blocky/issues/839