### PR TITLE
Update deprecated port specification in example config

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,8 +27,9 @@ blocking:
   clientGroupsBlock:
     default:
       - ads
-port: 53
-httpPort: 4000
+ports:
+  dns: 53
+  http: 4000
 ```
 
 ## Run as standalone binary


### PR DESCRIPTION
Got a deprecation warning whilst setting up blocky with the simple example config. This should fix it and align the example config with https://0xerr0r.github.io/blocky/configuration/#ports-configuration. 

Thanks for your work, quick and easy to setup and I really enjoy the minimal approach!