### PR TITLE
fix: use correct resolver in "using response from resolver" debug log

### DIFF
--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -56,12 +56,14 @@ func (r *upstreamResolverStatus) resolve(req *model.Request, ch chan<- requestRe
 	}
 
 	ch <- requestResponse{
+		resolver: &r.resolver,
 		response: resp,
 		err:      err,
 	}
 }
 
 type requestResponse struct {
+	resolver *Resolver
 	response *model.Response
 	err      error
 }
@@ -240,7 +242,7 @@ func (r *ParallelBestResolver) Resolve(request *model.Request) (*model.Response,
 				collectedErrors = append(collectedErrors, result.err)
 			} else {
 				logger.WithFields(logrus.Fields{
-					"resolver": r1.resolver,
+					"resolver": *result.resolver,
 					"answer":   util.AnswerToString(result.response.Res.Answer),
 				}).Debug("using response from resolver")
 


### PR DESCRIPTION
This PR fixes a very minor bug in the "using response from resolver" debug log which I've found while playing around.

<details>

<summary>Before and after (check line 5)</summary>

Before:
```
DEBUG parallel_best: using upstream 'tcp-tls:[2a01:3a0:53:53::]' and upstream 'tcp-tls:dns3.digitalcourage.de' as resolver client_ip=<IP> question=A (ccc.de.)
DEBUG parallel_best: delegating to resolver client_ip=<IP> question=A (ccc.de.) resolver=upstream 'tcp-tls:[2a01:3a0:53:53::]'
DEBUG parallel_best: delegating to resolver client_ip=<IP> question=A (ccc.de.) resolver=upstream 'tcp-tls:dns3.digitalcourage.de'
DEBUG upstream: received response from upstream answer=A (195.54.164.39) net=tcp-tls protocol=UDP response_time_ms=72 return_code=NOERROR upstream=tcp-tls:dns3.digitalcourage.de
DEBUG parallel_best: using response from resolver answer=A (195.54.164.39) client_ip=<IP> question=A (ccc.de.) resolver=upstream 'tcp-tls:[2a01:3a0:53:53::]'
 INFO queryLog: query resolved answer=A (195.54.164.39) client_ip=<IP> duration_ms=137 question_name=ccc.de. question_type=A response_code=NOERROR response_reason=RESOLVED (tcp-tls:dns3.digitalcourage.de) response_type=RESOLVED
DEBUG upstream: received response from upstream answer=A (195.54.164.39) net=tcp-tls protocol=UDP response_time_ms=61 return_code=NOERROR upstream=tcp-tls:[2a01:3a0:53:53::]
```
After:
```
DEBUG parallel_best: using upstream 'tcp-tls:[2a01:3a0:53:53::]' and upstream 'tcp-tls:dns3.digitalcourage.de' as resolver client_ip=<IP> question=A (ccc.de.)
DEBUG parallel_best: delegating to resolver client_ip=<IP> question=A (ccc.de.) resolver=upstream 'tcp-tls:[2a01:3a0:53:53::]'
DEBUG parallel_best: delegating to resolver client_ip=<IP> question=A (ccc.de.) resolver=upstream 'tcp-tls:dns3.digitalcourage.de'
DEBUG upstream: received response from upstream answer=A (195.54.164.39) net=tcp-tls protocol=UDP response_time_ms=85 return_code=NOERROR upstream=tcp-tls:dns3.digitalcourage.de
DEBUG parallel_best: using response from resolver answer=A (195.54.164.39) client_ip=<IP> question=A (ccc.de.) resolver=upstream 'tcp-tls:dns3.digitalcourage.de'
 INFO queryLog: query resolved answer=A (195.54.164.39) client_ip=<IP> duration_ms=136 question_name=ccc.de. question_type=A response_code=NOERROR response_reason=RESOLVED (tcp-tls:dns3.digitalcourage.de) response_type=RESOLVED
DEBUG upstream: received response from upstream answer=A (195.54.164.39) net=tcp-tls protocol=UDP response_time_ms=48 return_code=NOERROR upstream=tcp-tls:[2a01:3a0:53:53::]
```

</details>

Thanks for building blocky. I really love it! :)