### PR TITLE
test: temporarily downgrade golang version

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -50,7 +50,9 @@ jobs:
         uses: actions/setup-go@v4
         if: matrix.go == true
         with:
-          go-version-file: go.mod
+          #pinning to 1.20.5 until https://github.com/testcontainers/testcontainers-go/issues/1359 is resolved
+          go-version: "1.20.5"
+          #go-version-file: go.mod
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
pinning to 1.20.5 until https://github.com/testcontainers/testcontainers-go/issues/1359 is resolved