### PR TITLE
Improve query log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ e2e-test: ## run e2e tests
 		-o type=docker \
 		-t blocky-e2e \
 		.
-	go run github.com/onsi/ginkgo/v2/ginkgo --label-filter="e2e" ./...
+	go run github.com/onsi/ginkgo/v2/ginkgo --label-filter="e2e" e2e
 
 race: ## run tests with race detector
 	go run github.com/onsi/ginkgo/v2/ginkgo --label-filter="!e2e" --race ./...

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -12,6 +12,7 @@ type QueryLogConfig struct {
 	CreationAttempts int             `yaml:"creationAttempts" default:"3"`
 	CreationCooldown Duration        `yaml:"creationCooldown" default:"2s"`
 	Fields           []QueryLogField `yaml:"fields"`
+	FlushInterval    Duration        `yaml:"flushInterval" default:"30s"`
 }
 
 // SetDefaults implements `defaults.Setter`.
@@ -37,5 +38,6 @@ func (c *QueryLogConfig) LogConfig(logger *logrus.Entry) {
 	logger.Infof("logRetentionDays: %d", c.LogRetentionDays)
 	logger.Debugf("creationAttempts: %d", c.CreationAttempts)
 	logger.Debugf("creationCooldown: %s", c.CreationCooldown)
+	logger.Infof("flushInterval: %s", c.FlushInterval)
 	logger.Infof("fields: %s", c.Fields)
 }

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -203,6 +203,8 @@ queryLog:
   fields:
     - clientIP
     - duration
+  # optional: Interval to write data in bulk to the external database, default: 30s
+  flushInterval: 30s
 
 # optional: Blocky can synchronize its cache and blocking state between multiple instances through redis.
 redis:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -628,8 +628,9 @@ Configuration parameters:
 | queryLog.target           | string                                                                               | no        |               | directory for writing the logs (for csv) or database url (for mysql or postgresql) |
 | queryLog.logRetentionDays | int                                                                                  | no        | 0             | if > 0, deletes log files/database entries which are older than ... days           |
 | queryLog.creationAttempts | int                                                                                  | no        | 3             | Max attempts to create specific query log writer                                   |
-| queryLog.CreationCooldown | duration format                                                                      | no        | 2             | Time between the creation attempts                                                 |
+| queryLog.CreationCooldown | duration format                                                                      | no        | 2s            | Time between the creation attempts                                                 |
 | queryLog.fields           | list enum (clientIP, clientName, responseReason, responseAnswer, question, duration) | no        | all           | which information should be logged                                                 |
+| queryLog.flushInterval    | duration format                                                                      | no        | 30s           | Interval to write data in bulk to the external database                            |
 
 !!! hint
 
@@ -647,6 +648,7 @@ example for CSV format with limited logging information
       fields:
       - clientIP
       - duration
+      flushInterval: 30s
     ```
 
 example for Database

--- a/e2e/querylog_test.go
+++ b/e2e/querylog_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Query logs functional tests", func() {
 				"queryLog:",
 				"  type: mysql",
 				"  target: user:user@tcp(mariaDB:3306)/user?charset=utf8mb4&parseTime=True&loc=Local",
+				"  flushInterval: 1s",
 			)
 
 			Expect(err).Should(Succeed())
@@ -119,6 +120,7 @@ var _ = Describe("Query logs functional tests", func() {
 				"queryLog:",
 				"  type: postgresql",
 				"  target: postgres://user:user@postgres:5432/user",
+				"  flushInterval: 1s",
 			)
 
 			Expect(err).Should(Succeed())

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -16,7 +16,6 @@ const (
 	cleanUpRunPeriod         = 12 * time.Hour
 	queryLoggingResolverType = "query_logging"
 	logChanCap               = 1000
-	defaultFlushPeriod       = 30 * time.Second
 )
 
 // QueryLoggingResolver writes query information (question, answer, duration, ...)
@@ -44,9 +43,9 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) *QueryLoggingResolver {
 			case config.QueryLogTypeCsvClient:
 				writer, err = querylog.NewCSVWriter(cfg.Target, true, cfg.LogRetentionDays)
 			case config.QueryLogTypeMysql:
-				writer, err = querylog.NewDatabaseWriter("mysql", cfg.Target, cfg.LogRetentionDays, defaultFlushPeriod)
+				writer, err = querylog.NewDatabaseWriter("mysql", cfg.Target, cfg.LogRetentionDays, cfg.FlushInterval.ToDuration())
 			case config.QueryLogTypePostgresql:
-				writer, err = querylog.NewDatabaseWriter("postgresql", cfg.Target, cfg.LogRetentionDays, defaultFlushPeriod)
+				writer, err = querylog.NewDatabaseWriter("postgresql", cfg.Target, cfg.LogRetentionDays, cfg.FlushInterval.ToDuration())
 			case config.QueryLogTypeConsole:
 				writer = querylog.NewLoggerWriter()
 			case config.QueryLogTypeNone:

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -43,9 +43,11 @@ func NewQueryLoggingResolver(cfg config.QueryLogConfig) *QueryLoggingResolver {
 			case config.QueryLogTypeCsvClient:
 				writer, err = querylog.NewCSVWriter(cfg.Target, true, cfg.LogRetentionDays)
 			case config.QueryLogTypeMysql:
-				writer, err = querylog.NewDatabaseWriter("mysql", cfg.Target, cfg.LogRetentionDays, cfg.FlushInterval.ToDuration())
+				writer, err = querylog.NewDatabaseWriter("mysql", cfg.Target, cfg.LogRetentionDays,
+					cfg.FlushInterval.ToDuration())
 			case config.QueryLogTypePostgresql:
-				writer, err = querylog.NewDatabaseWriter("postgresql", cfg.Target, cfg.LogRetentionDays, cfg.FlushInterval.ToDuration())
+				writer, err = querylog.NewDatabaseWriter("postgresql", cfg.Target, cfg.LogRetentionDays,
+					cfg.FlushInterval.ToDuration())
 			case config.QueryLogTypeConsole:
 				writer = querylog.NewLoggerWriter()
 			case config.QueryLogTypeNone:


### PR DESCRIPTION
* Externalize parameter for the database flush interval
* Use 1s in e2e-tests -> this improves e2e job execution (2 tests run now 30s faster each)
* Small improvement for Healthcheck e2e-test, improves also the execution time