### PR TITLE
docs: make config option names lower-case

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -628,7 +628,7 @@ Configuration parameters:
 | queryLog.target           | string                                                                               | no        |               | directory for writing the logs (for csv) or database url (for mysql or postgresql) |
 | queryLog.logRetentionDays | int                                                                                  | no        | 0             | if > 0, deletes log files/database entries which are older than ... days           |
 | queryLog.creationAttempts | int                                                                                  | no        | 3             | Max attempts to create specific query log writer                                   |
-| queryLog.CreationCooldown | duration format                                                                      | no        | 2s            | Time between the creation attempts                                                 |
+| queryLog.creationCooldown | duration format                                                                      | no        | 2s            | Time between the creation attempts                                                 |
 | queryLog.fields           | list enum (clientIP, clientName, responseReason, responseAnswer, question, duration) | no        | all           | which information should be logged                                                 |
 | queryLog.flushInterval    | duration format                                                                      | no        | 30s           | Interval to write data in bulk to the external database                            |
 


### PR DESCRIPTION
Originally made a suggestion in https://github.com/0xERR0R/blocky/pull/1138#discussion_r1325921811 but since I also approved the PR, it was auto merged before the suggestion could be applied.