### PR TITLE
fix: truncated responses should not be cached

### DIFF
--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -213,7 +213,7 @@ func (r *CachingResolver) trackQueryDomainNameCount(domain, cacheKey string, log
 }
 
 func (r *CachingResolver) putInCache(cacheKey string, response *model.Response, prefetch, publish bool) {
-	if response.Res.Rcode == dns.RcodeSuccess {
+	if response.Res.Rcode == dns.RcodeSuccess && !response.Res.Truncated {
 		// put value into cache
 		r.resultCache.Put(cacheKey, &cacheValue{response.Res, prefetch}, r.adjustTTLs(response.Res.Answer))
 	} else if response.Res.Rcode == dns.RcodeNameError {


### PR DESCRIPTION
In some cases if UDP is used and EDNS is not enabled, the responses > 512 are truncated and blocky caches them. That means, if client requests a query per UDP and receives truncated response, it will do a retry with TCP and return the truncated response from the cache.

I think, it doesn't make sense to cache truncated responses.