### PR TITLE
fix: use different TTL of multiple records in answer

### DIFF
--- a/helpertest/helper.go
+++ b/helpertest/helper.go
@@ -19,6 +19,7 @@ import (
 const (
 	A     = dns.Type(dns.TypeA)
 	AAAA  = dns.Type(dns.TypeAAAA)
+	CNAME = dns.Type(dns.TypeCNAME)
 	HTTPS = dns.Type(dns.TypeHTTPS)
 	MX    = dns.Type(dns.TypeMX)
 	PTR   = dns.Type(dns.TypePTR)

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -315,11 +316,9 @@ func convertMessage(message *redisMessage, ttl time.Duration) (*CacheMessage, er
 
 // getTTL of dns message or return defaultCacheTime if 0
 func (c *Client) getTTL(dns *dns.Msg) time.Duration {
-	ttl := uint32(0)
+	ttl := uint32(math.MaxInt32)
 	for _, a := range dns.Answer {
-		if a.Header().Ttl > ttl {
-			ttl = a.Header().Ttl
-		}
+		ttl = min(ttl, a.Header().Ttl)
 	}
 
 	if ttl == 0 {


### PR DESCRIPTION
If query result contains multiple records in the answer section (with different TTL):
- use the smallest TTL for entire cache entry
- cached entry should still have different TTLs (TTL distance of cached item should be the same as origin)

fixes #1091