### PR TITLE
chore: make test non-blocking

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -711,7 +711,7 @@ bootstrapDns:
 			}
 
 			panicMsg := "panic value"
-			calls := make(chan int32)
+			calls := make(chan int32, 3)
 
 			var call atomic.Int32
 


### PR DESCRIPTION
I accidentally broke the implementation. This caused the test to hang. Using buffered chan in test now, this should avoid this situation in the future.