### PR TITLE
feat: reduce DNS response cache memory consumption

### DIFF
--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -204,20 +204,20 @@ func (r *CachingResolver) Resolve(request *model.Request) (response *model.Respo
 
 func (r *CachingResolver) getFromCache(key string) (*dns.Msg, time.Duration) {
 	val, ttl := r.resultCache.Get(key)
-	if val != nil {
-		res := new(dns.Msg)
-
-		err := res.Unpack(*val)
-		if err != nil {
-			log.Log().Error("can't unpack cached entry. Cache malformed?", err)
-
-			return nil, 0
-		}
-
-		return res, ttl
+	if val == nil {
+		return nil, 0
 	}
 
-	return nil, 0
+	res := new(dns.Msg)
+
+	err := res.Unpack(*val)
+	if err != nil {
+		r.log().Error("can't unpack cached entry. Cache malformed?", err)
+
+		return nil, 0
+	}
+
+	return res, ttl
 }
 
 func setTTLInCachedResponse(resp *dns.Msg, ttl time.Duration) {


### PR DESCRIPTION
currently, we store dns.Msg struct in the DNS response cache. In my tests, a typical response for example "A google.com" needs approx. 270 bytes. If we cache the binary representation (wire format), we'll need only 70 bytes.

This PR changes the result cache struct from dns.Msg to []byte. This avoids also copying of dns struct on one place.