### PR TITLE
fix: ANSI color codes being printed on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v1.0.2
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.13
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/miekg/dns v1.1.56
 	github.com/mroth/weightedrand/v2 v2.1.0

--- a/log/logger.go
+++ b/log/logger.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/mattn/go-colorable"
 	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 	"golang.org/x/exp/maps"
@@ -110,6 +111,9 @@ func ConfigureLogger(cfg *Config) {
 		})
 
 		logger.SetFormatter(logFormatter)
+
+		// Windows does not support ANSI colors
+		logger.SetOutput(colorable.NewColorableStdout())
 
 	case FormatTypeJson:
 		logger.SetFormatter(&logrus.JSONFormatter{})

--- a/server/server_config_trigger_windows.go
+++ b/server/server_config_trigger_windows.go
@@ -1,4 +1,6 @@
 package server
 
-func registerPrintConfigurationTrigger(s *Server) {
+import "context"
+
+func registerPrintConfigurationTrigger(ctx context.Context, s *Server) {
 }


### PR DESCRIPTION
Set logger output to `colorable.NewColorableStdout` for `FormatTypeText` to fix missing colors in Windows.

Closes: #1204 

