### PR TITLE
feat(cache): change regex cache to use a single regex to save memory

### DIFF
--- a/cache/stringcache/in_memory_grouped_cache.go
+++ b/cache/stringcache/in_memory_grouped_cache.go
@@ -57,8 +57,13 @@ func (c *InMemoryGroupedCache) Refresh(group string) GroupFactory {
 		factory: c.factoryFn(),
 		finishFn: func(sc stringCache) {
 			c.lock.Lock()
-			c.caches[group] = sc
-			c.lock.Unlock()
+			defer c.lock.Unlock()
+
+			if sc != nil {
+				c.caches[group] = sc
+			} else {
+				delete(c.caches, group)
+			}
 		},
 	}
 }


### PR DESCRIPTION
A quick test w/ https://big.oisd.nl/regex shows memory goes down from 436 MB to 303 MB, which seems stable across runs.

Progress for #1222