### PR TITLE
feat: add ginkgolinter to golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,7 @@ linters:
     - wastedassign
     - whitespace
     - wsl
+    - ginkgolinter
   disable:
     - noctx
     - contextcheck
@@ -72,7 +73,24 @@ linters:
 linters-settings:
   gomnd:
     ignored-numbers:
-      - '0666'
+      - "0666"
+  ginkgolinter:
+    # Suppress the wrong length assertion warning.
+    suppress-len-assertion: true
+    # Suppress the wrong nil assertion warning.
+    suppress-nil-assertion: true
+    # Suppress the wrong error assertion warning.
+    suppress-err-assertion: true
+    # Suppress the wrong comparison assertion warning.
+    suppress-compare-assertion: true
+    # Suppress the function all in async assertion warning.
+    suppress-async-assertion: true
+    # Suppress warning for comparing values from different types, like int32 and uint32
+    suppress-type-compare-assertion: true
+    # Trigger warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt
+    forbid-focus-container: true
+    # Don't trigger warnings for HaveLen(0)
+    allow-havelen-zero: true
 
 issues:
   exclude-rules:

--- a/api/api_interface_impl_test.go
+++ b/api/api_interface_impl_test.go
@@ -217,7 +217,7 @@ var _ = Describe("API implementation tests", func() {
 				var resp200 BlockingStatus200JSONResponse
 				Expect(resp).Should(BeAssignableToTypeOf(resp200))
 				resp200 = resp.(BlockingStatus200JSONResponse)
-				Expect(resp200.Enabled).Should(Equal(false))
+				Expect(resp200.Enabled).Should(BeFalse())
 				Expect(resp200.DisabledGroups).Should(HaveValue(Equal([]string{"gr1", "gr2"})))
 				Expect(resp200.AutoEnableInSec).Should(HaveValue(BeNumerically("==", 47)))
 			})

--- a/lists/downloader_test.go
+++ b/lists/downloader_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Downloader", func() {
 		}
 		Expect(Bus().Subscribe(CachingFailedDownloadChanged, fn)).Should(Succeed())
 		DeferCleanup(func() {
-			Expect(Bus().Unsubscribe(CachingFailedDownloadChanged, fn))
+			Expect(Bus().Unsubscribe(CachingFailedDownloadChanged, fn)).Should(Succeed())
 		})
 
 		loggerHook = test.NewGlobal()


### PR DESCRIPTION
Added ginkgolinter to golangci config to disable some rules automatically in tests if ginkgo is imported.