### PR TITLE
fix(tests): properly silence log output

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,5 +105,6 @@ issues:
       linters:
         - dupl
         - funlen
+        - gochecknoinits
         - gochecknoglobals
         - gosec

--- a/api/api_suite_test.go
+++ b/api/api_suite_test.go
@@ -8,8 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestResolver(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestResolver(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "API Suite")
 }

--- a/cache/expirationcache/expiration_cache_suite_test.go
+++ b/cache/expirationcache/expiration_cache_suite_test.go
@@ -9,8 +9,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCache(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestCache(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Expiration cache suite")
 }

--- a/cache/stringcache/string_cache_suite_test.go
+++ b/cache/stringcache/string_cache_suite_test.go
@@ -9,8 +9,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCache(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestCache(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "String cache suite")
 }

--- a/cache/stringcache/string_caches_benchmark_test.go
+++ b/cache/stringcache/string_caches_benchmark_test.go
@@ -33,7 +33,7 @@ var (
 	baseMemStats runtime.MemStats
 )
 
-func init() { //nolint:gochecknoinits
+func init() {
 	// If you update either list, make sure both are the list version (see file header).
 	stringTestData = loadTestdata("../../helpertest/data/oisd-big-plain.txt")
 

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -9,8 +9,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCmd(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestCmd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Command Suite")
 }

--- a/config/config_suite_test.go
+++ b/config/config_suite_test.go
@@ -14,8 +14,11 @@ var (
 	hook   *log.MockLoggerHook
 )
 
-func TestConfig(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
 }

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -14,8 +14,11 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 )
 
-func TestLists(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestLists(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "e2e Suite", Label("e2e"))
 }

--- a/lists/list_suite_test.go
+++ b/lists/list_suite_test.go
@@ -9,8 +9,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestLists(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestLists(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Lists Suite")
 }

--- a/lists/parsers/parsers_suite_test.go
+++ b/lists/parsers/parsers_suite_test.go
@@ -9,8 +9,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestLists(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestLists(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Parsers Suite")
 }

--- a/log/mock_entry.go
+++ b/log/mock_entry.go
@@ -1,15 +1,13 @@
 package log
 
 import (
-	"io"
-
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 )
 
 func NewMockEntry() (*logrus.Entry, *MockLoggerHook) {
-	logger := logrus.New()
-	logger.Out = io.Discard
+	logger, _ := test.NewNullLogger()
 	logger.Level = logrus.TraceLevel
 
 	entry := logrus.Entry{Logger: logger}

--- a/querylog/querylog_suite_test.go
+++ b/querylog/querylog_suite_test.go
@@ -9,8 +9,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestResolver(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestResolver(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Querylog Suite")
 }

--- a/redis/redis_suite_test.go
+++ b/redis/redis_suite_test.go
@@ -10,9 +10,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestRedisClient(t *testing.T) {
+func init() {
 	log.Silence()
 	redis.SetLogger(NoLogs{})
+}
+
+func TestRedisClient(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Redis Suite")
 }

--- a/resolver/resolver_suite_test.go
+++ b/resolver/resolver_suite_test.go
@@ -12,9 +12,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestResolver(t *testing.T) {
+func init() {
 	log.Silence()
 	redis.SetLogger(NoLogs{})
+}
+
+func TestResolver(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Resolver Suite")
 }

--- a/resolver/upstream_tree_resolver.go
+++ b/resolver/upstream_tree_resolver.go
@@ -104,7 +104,7 @@ func (r *UpstreamTreeResolver) upstreamGroupByClient(request *model.Request) str
 
 	if len(groups) > 0 {
 		if len(groups) > 1 {
-			r.log().WithFields(logrus.Fields{
+			request.Log.WithFields(logrus.Fields{
 				"clientNames": request.ClientNames,
 				"clientIP":    clientIP,
 				"groups":      groups,

--- a/server/server.go
+++ b/server/server.go
@@ -115,8 +115,6 @@ func retrieveCertificate(cfg *config.Config) (cert tls.Certificate, err error) {
 //
 //nolint:funlen
 func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err error) {
-	log.ConfigureLogger(&cfg.Log)
-
 	var cert tls.Certificate
 
 	if len(cfg.Ports.HTTPS) > 0 || len(cfg.Ports.TLS) > 0 {

--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -8,8 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDNSServer(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestDNSServer(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Server Suite")
 }

--- a/trie/trie_suite_test.go
+++ b/trie/trie_suite_test.go
@@ -9,8 +9,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestTrie(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestTrie(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Trie Suite")
 }

--- a/util/util_suite_test.go
+++ b/util/util_suite_test.go
@@ -8,8 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestLists(t *testing.T) {
+func init() {
 	log.Silence()
+}
+
+func TestLists(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Util Suite")
 }


### PR DESCRIPTION
Using `init` allows it to also work for benchmarks.  
And `log.Silence` was sometimes getting overridden by `log.init`.