### PR TITLE
refactor: make use of contexts in more places

### DIFF
--- a/cache/expirationcache/expiration_cache.go
+++ b/cache/expirationcache/expiration_cache.go
@@ -37,7 +37,7 @@ type Options struct {
 // OnExpirationCallback will be called just before an element gets expired and will
 // be removed from cache. This function can return new value and TTL to leave the
 // element in the cache or nil to remove it
-type OnExpirationCallback[T any] func(key string) (val *T, ttl time.Duration)
+type OnExpirationCallback[T any] func(ctx context.Context, key string) (val *T, ttl time.Duration)
 
 // OnCacheHitCallback will be called on cache get if entry was found
 type OnCacheHitCallback func(key string)
@@ -58,7 +58,7 @@ func NewCacheWithOnExpired[T any](ctx context.Context, options Options,
 	l, _ := lru.New(defaultSize)
 	c := &ExpiringLRUCache[T]{
 		cleanUpInterval: defaultCleanUpInterval,
-		preExpirationFn: func(key string) (val *T, ttl time.Duration) {
+		preExpirationFn: func(ctx context.Context, key string) (val *T, ttl time.Duration) {
 			return nil, 0
 		},
 		onCacheHit:  func(key string) {},
@@ -126,7 +126,7 @@ func (e *ExpiringLRUCache[T]) cleanUp() {
 		var keysToDelete []string
 
 		for _, key := range expiredKeys {
-			newVal, newTTL := e.preExpirationFn(key)
+			newVal, newTTL := e.preExpirationFn(context.Background(), key)
 			if newVal != nil {
 				e.Put(key, newVal, newTTL)
 			} else {

--- a/cache/expirationcache/expiration_cache_test.go
+++ b/cache/expirationcache/expiration_cache_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Expiration cache", func() {
 	Describe("preExpiration function", func() {
 		When("function is defined", func() {
 			It("should update the value and TTL if function returns values", func() {
-				fn := func(key string) (val *string, ttl time.Duration) {
+				fn := func(ctx context.Context, key string) (val *string, ttl time.Duration) {
 					v2 := "v2"
 
 					return &v2, time.Second
@@ -169,7 +169,7 @@ var _ = Describe("Expiration cache", func() {
 			})
 
 			It("should update the value and TTL if function returns values on cleanup if element is expired", func() {
-				fn := func(key string) (val *string, ttl time.Duration) {
+				fn := func(ctx context.Context, key string) (val *string, ttl time.Duration) {
 					v2 := "val2"
 
 					return &v2, time.Second
@@ -192,7 +192,7 @@ var _ = Describe("Expiration cache", func() {
 			})
 
 			It("should delete the key if function returns nil", func() {
-				fn := func(key string) (val *string, ttl time.Duration) {
+				fn := func(ctx context.Context, key string) (val *string, ttl time.Duration) {
 					return nil, 0
 				}
 				cache := NewCacheWithOnExpired[string](ctx, Options{CleanupInterval: 100 * time.Microsecond}, fn)

--- a/cache/expirationcache/prefetching_cache_test.go
+++ b/cache/expirationcache/prefetching_cache_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Prefetching expiration cache", func() {
 					},
 					PrefetchThreshold: 2,
 					PrefetchExpires:   100 * time.Millisecond,
-					ReloadFn: func(cacheKey string) (*string, time.Duration) {
+					ReloadFn: func(ctx context.Context, cacheKey string) (*string, time.Duration) {
 						v := "v2"
 
 						return &v, 50 * time.Millisecond
@@ -86,7 +86,7 @@ var _ = Describe("Prefetching expiration cache", func() {
 					},
 					PrefetchThreshold: 2,
 					PrefetchExpires:   100 * time.Millisecond,
-					ReloadFn: func(cacheKey string) (*string, time.Duration) {
+					ReloadFn: func(ctx context.Context, cacheKey string) (*string, time.Duration) {
 						v := "v2"
 
 						return &v, 50 * time.Millisecond
@@ -113,7 +113,7 @@ var _ = Describe("Prefetching expiration cache", func() {
 					Options: Options{
 						CleanupInterval: 100 * time.Millisecond,
 					},
-					ReloadFn: func(cacheKey string) (*string, time.Duration) {
+					ReloadFn: func(ctx context.Context, cacheKey string) (*string, time.Duration) {
 						v := "v2"
 
 						return &v, 50 * time.Millisecond
@@ -143,7 +143,7 @@ var _ = Describe("Prefetching expiration cache", func() {
 					},
 					PrefetchThreshold: 2,
 					PrefetchExpires:   100 * time.Millisecond,
-					ReloadFn: func(cacheKey string) (*string, time.Duration) {
+					ReloadFn: func(ctx context.Context, cacheKey string) (*string, time.Duration) {
 						v := "v2"
 
 						return &v, 50 * time.Millisecond

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -155,7 +155,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				}
 				Bus().Publish(ApplicationStarted, "")
 				Eventually(func(g Gomega) {
-					g.Expect(sut.Resolve(newRequestWithClient("blocked2.com.", A, "192.168.178.39", "client1"))).
+					g.Expect(sut.Resolve(ctx, newRequestWithClient("blocked2.com.", A, "192.168.178.39", "client1"))).
 						Should(And(
 							BeDNSRecord("blocked2.com.", A, "0.0.0.0"),
 							HaveTTL(BeNumerically("==", 60)),
@@ -185,6 +185,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("Domain is on the black list", func() {
 			It("should block request", func() {
 				Eventually(sut.Resolve).
+					WithContext(ctx).
 					WithArguments(newRequestWithClient("regex.com.", dns.Type(dns.TypeA), "1.2.1.2", "client1")).
 					Should(
 						SatisfyAll(
@@ -222,7 +223,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 		When("client name is defined in client groups block", func() {
 			It("should block the A query if domain is on the black list (single)", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "client1"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "client1"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -233,7 +234,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						))
 			})
 			It("should block the A query if domain is on the black list (multipart 1)", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "client2"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "client2"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -244,7 +245,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						))
 			})
 			It("should block the A query if domain is on the black list (multipart 2)", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "client3"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "client3"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -255,7 +256,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						))
 			})
 			It("should block the A query if domain is on the black list (merged)", func() {
-				Expect(sut.Resolve(newRequestWithClient("blocked2.com.", A, "1.2.1.2", "client3"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked2.com.", A, "1.2.1.2", "client3"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("blocked2.com.", A, "0.0.0.0"),
@@ -266,7 +267,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						))
 			})
 			It("should block the AAAA query if domain is on the black list", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", AAAA, "1.2.1.2", "client1"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", AAAA, "1.2.1.2", "client1"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", AAAA, "::"),
@@ -277,18 +278,18 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						))
 			})
 			It("should block the HTTPS query if domain is on the black list", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", HTTPS, "1.2.1.2", "client1"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", HTTPS, "1.2.1.2", "client1"))).
 					Should(HaveReturnCode(dns.RcodeNameError))
 			})
 			It("should block the MX query if domain is on the black list", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", MX, "1.2.1.2", "client1"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", MX, "1.2.1.2", "client1"))).
 					Should(HaveReturnCode(dns.RcodeNameError))
 			})
 		})
 
 		When("Client ip is defined in client groups block", func() {
 			It("should block the query if domain is on the black list", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "192.168.178.55", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "192.168.178.55", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -301,7 +302,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("Client CIDR (10.43.8.64 - 10.43.8.79) is defined in client groups block", func() {
 			It("should not block the query for 10.43.8.63 if domain is on the black list", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "10.43.8.63", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "10.43.8.63", "unknown"))).
 					Should(
 						SatisfyAll(
 							HaveNoAnswer(),
@@ -313,7 +314,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				m.AssertExpectations(GinkgoT())
 			})
 			It("should not block the query for 10.43.8.80 if domain is on the black list", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "10.43.8.80", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "10.43.8.80", "unknown"))).
 					Should(
 						SatisfyAll(
 							HaveNoAnswer(),
@@ -328,7 +329,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 		When("Client CIDR (10.43.8.64 - 10.43.8.79) is defined in client groups block", func() {
 			It("should block the query for 10.43.8.64 if domain is on the black list", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "10.43.8.64", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "10.43.8.64", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -339,7 +340,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						))
 			})
 			It("should block the query for 10.43.8.79 if domain is on the black list", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "10.43.8.79", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "10.43.8.79", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -353,7 +354,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 		When("Client has multiple names and for each name a client group block definition exists", func() {
 			It("should block query if domain is in one group", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "client1", "altname"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "client1", "altname"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -364,7 +365,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						))
 			})
 			It("should block query if domain is in another group too", func() {
-				Expect(sut.Resolve(newRequestWithClient("blocked2.com.", A, "1.2.1.2", "client1", "altName"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked2.com.", A, "1.2.1.2", "client1", "altName"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("blocked2.com.", A, "0.0.0.0"),
@@ -377,7 +378,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("Client name matches wildcard", func() {
 			It("should block query if domain is in one group", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "wildcard1name"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "wildcard1name"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -391,7 +392,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 		When("Default group is defined", func() {
 			It("should block domains from default group for each client", func() {
-				Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("blocked3.com.", A, "0.0.0.0"),
@@ -418,7 +419,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			})
 
 			It("should return NXDOMAIN if query is blocked", func() {
-				Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							HaveNoAnswer(),
@@ -444,7 +445,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			})
 
 			It("should return answer with specified TTL", func() {
-				Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("blocked3.com.", A, "0.0.0.0"),
@@ -461,7 +462,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				It("should return custom IP with specified TTL", func() {
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("blocked3.com.", A, "12.12.12.12"),
@@ -489,7 +490,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			})
 
 			It("should return ipv4 address for A query if query is blocked", func() {
-				Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("blocked3.com.", A, "12.12.12.12"),
@@ -501,7 +502,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			})
 
 			It("should return ipv6 address for AAAA query if query is blocked", func() {
-				Expect(sut.Resolve(newRequestWithClient("blocked3.com.", AAAA, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", AAAA, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("blocked3.com.", AAAA, "2001:db8:85a3::8a2e:370:7334"),
@@ -528,7 +529,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			})
 
 			It("should use fallback for ipv6 and return zero ip", func() {
-				Expect(sut.Resolve(newRequestWithClient("blocked3.com.", AAAA, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", AAAA, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("blocked3.com.", AAAA, "::"),
@@ -547,7 +548,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 					mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 300, A, "123.145.123.145")
 				})
 				It("should block query, if lookup result contains blacklisted IP", func() {
-					Expect(sut.Resolve(newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("example.com.", A, "0.0.0.0"),
@@ -567,7 +568,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 					)
 				})
 				It("should block query, if lookup result contains blacklisted IP", func() {
-					Expect(sut.Resolve(newRequestWithClient("example.com.", AAAA, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("example.com.", AAAA, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("example.com.", AAAA, "::"),
@@ -590,7 +591,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				mockAnswer.Answer = []dns.RR{rr1, rr2, rr3}
 			})
 			It("should block the query, if response contains a CNAME with domain on a blacklist", func() {
-				Expect(sut.Resolve(newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("example.com.", A, "0.0.0.0"),
@@ -617,7 +618,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				}
 			})
 			It("Should not be blocked", func() {
-				Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							HaveNoAnswer(),
@@ -649,7 +650,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			})
 			It("should block everything else except domains on the white list with default group", func() {
 				By("querying domain on the whitelist", func() {
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -662,7 +663,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				By("querying another domain, which is not on the whitelist", func() {
-					Expect(sut.Resolve(newRequestWithClient("google.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("google.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("google.com.", A, "0.0.0.0"),
@@ -678,7 +679,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			It("should block everything else except domains on the white list "+
 				"if multiple white list only groups are defined", func() {
 				By("querying domain on the whitelist", func() {
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "one-client"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "one-client"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -691,7 +692,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				By("querying another domain, which is not on the whitelist", func() {
-					Expect(sut.Resolve(newRequestWithClient("blocked2.com.", A, "1.2.1.2", "one-client"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked2.com.", A, "1.2.1.2", "one-client"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("blocked2.com.", A, "0.0.0.0"),
@@ -706,7 +707,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			It("should block everything else except domains on the white list "+
 				"if multiple white list only groups are defined", func() {
 				By("querying domain on the whitelist group 1", func() {
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "all-client"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "all-client"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -719,7 +720,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				By("querying another domain, which is in the whitelist group 1", func() {
-					Expect(sut.Resolve(newRequestWithClient("blocked2.com.", A, "1.2.1.2", "all-client"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked2.com.", A, "1.2.1.2", "all-client"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -745,7 +746,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 300, A, "123.145.123.145")
 			})
 			It("should not block if DNS answer contains IP from the white list", func() {
-				Expect(sut.Resolve(newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							BeDNSRecord("example.com.", A, "123.145.123.145"),
@@ -775,7 +776,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("domain is not on the black list", func() {
 			It("should delegate to next resolver", func() {
-				Expect(sut.Resolve(newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							HaveNoAnswer(),
@@ -792,7 +793,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				}
 			})
 			It("should delegate to next resolver", func() {
-				Expect(sut.Resolve(newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
+				Expect(sut.Resolve(ctx, newRequestWithClient("example.com.", A, "1.2.1.2", "unknown"))).
 					Should(
 						SatisfyAll(
 							HaveNoAnswer(),
@@ -819,7 +820,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("Disable blocking is called", func() {
 			It("no query should be blocked", func() {
 				By("Perform query to ensure that the blocking status is active (defaultGroup)", func() {
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("blocked3.com.", A, "0.0.0.0"),
@@ -830,7 +831,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				By("Perform query to ensure that the blocking status is active (group1)", func() {
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -847,7 +848,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("perform the same query again (defaultGroup)", func() {
 					// now is blocking disabled, query the url again
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -861,7 +862,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("perform the same query again (group1)", func() {
 					// now is blocking disabled, query the url again
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -880,7 +881,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("perform the same query again (defaultGroup)", func() {
 					// now is blocking disabled, query the url again
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -893,7 +894,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				By("Perform query to ensure that the blocking status is active (group1)", func() {
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -908,7 +909,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("Disable blocking for all groups is called with a duration parameter", func() {
 			It("No query should be blocked only for passed amount of time", func() {
 				By("Perform query to ensure that the blocking status is active (defaultGroup)", func() {
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("blocked3.com.", A, "0.0.0.0"),
@@ -918,7 +919,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 							))
 				})
 				By("Perform query to ensure that the blocking status is active (group1)", func() {
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -941,7 +942,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("perform the same query again to ensure that this query will not be blocked (defaultGroup)", func() {
 					// now is blocking disabled, query the url again
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -954,7 +955,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 				By("perform the same query again to ensure that this query will not be blocked (group1)", func() {
 					// now is blocking disabled, query the url again
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -974,7 +975,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 					// wait 1 sec
 					Eventually(enabled, "1s").Should(Receive(BeTrue()))
 
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("blocked3.com.", A, "0.0.0.0"),
@@ -983,7 +984,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 								HaveReturnCode(dns.RcodeSuccess),
 							))
 
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -998,7 +999,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("Disable blocking for one group is called with a duration parameter", func() {
 			It("No query should be blocked only for passed amount of time", func() {
 				By("Perform query to ensure that the blocking status is active (defaultGroup)", func() {
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("blocked3.com.", A, "0.0.0.0"),
@@ -1008,7 +1009,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 							))
 				})
 				By("Perform query to ensure that the blocking status is active (group1)", func() {
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("domain1.com.", A, "0.0.0.0"),
@@ -1031,7 +1032,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("perform the same query again to ensure that this query will not be blocked (defaultGroup)", func() {
 					// now is blocking disabled, query the url again
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("blocked3.com.", A, "0.0.0.0"),
@@ -1042,7 +1043,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 				By("perform the same query again to ensure that this query will not be blocked (group1)", func() {
 					// now is blocking disabled, query the url again
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
@@ -1062,7 +1063,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 					// wait 1 sec
 					Eventually(enabled, "1s").Should(Receive(BeTrue()))
 
-					Expect(sut.Resolve(newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("blocked3.com.", A, "0.0.0.0"),
@@ -1071,7 +1072,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 								HaveReturnCode(dns.RcodeSuccess),
 							))
 
-					Expect(sut.Resolve(newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
+					Expect(sut.Resolve(ctx, newRequestWithClient("domain1.com.", A, "1.2.1.2", "unknown"))).
 						Should(
 							SatisfyAll(
 								BeDNSRecord("domain1.com.", A, "0.0.0.0"),

--- a/resolver/bootstrap_test.go
+++ b/resolver/bootstrap_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 					},
 				}
 
-				_, err := sut.resolveUpstream(nil, "example.com")
+				_, err := sut.resolveUpstream(ctx, nil, "example.com")
 				Expect(err).ShouldNot(Succeed())
 				Expect(usedSystemResolver).Should(Receive(BeTrue()))
 			})
@@ -244,7 +244,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 		When("called from bootstrap.upstream", func() {
 			It("uses hardcoded IPs", func() {
-				ips, err := sut.resolveUpstream(bootstrapUpstream, "host")
+				ips, err := sut.resolveUpstream(ctx, bootstrapUpstream, "host")
 
 				Expect(err).Should(Succeed())
 				Expect(ips).Should(Equal(sutConfig.BootstrapDNS[0].IPs))
@@ -253,7 +253,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 		When("hostname is an IP", func() {
 			It("returns immediately", func() {
-				ips, err := sut.resolve("0.0.0.0", config.IPVersionDual.QTypes())
+				ips, err := sut.resolve(ctx, "0.0.0.0", config.IPVersionDual.QTypes())
 
 				Expect(err).Should(Succeed())
 				Expect(ips).Should(ContainElement(net.IPv4zero))
@@ -269,7 +269,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				bootstrapUpstream.On("Resolve", mock.Anything).Return(&model.Response{Res: bootstrapResponse}, nil)
 
-				ips, err := sut.resolve("localhost", []dns.Type{AAAA})
+				ips, err := sut.resolve(ctx, "localhost", []dns.Type{AAAA})
 
 				Expect(err).Should(Succeed())
 				Expect(ips).Should(HaveLen(1))
@@ -283,7 +283,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				bootstrapUpstream.On("Resolve", mock.Anything).Return(nil, resolveErr)
 
-				ips, err := sut.resolve("localhost", []dns.Type{A})
+				ips, err := sut.resolve(ctx, "localhost", []dns.Type{A})
 
 				Expect(err).ShouldNot(Succeed())
 				Expect(err.Error()).Should(ContainSubstring(resolveErr.Error()))
@@ -297,7 +297,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				bootstrapUpstream.On("Resolve", mock.Anything).Return(&model.Response{Res: bootstrapResponse}, nil)
 
-				ips, err := sut.resolve("unknownhost.invalid", []dns.Type{A})
+				ips, err := sut.resolve(ctx, "unknownhost.invalid", []dns.Type{A})
 
 				Expect(err).ShouldNot(Succeed())
 				Expect(err.Error()).Should(ContainSubstring("no such host"))
@@ -329,7 +329,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				r := newUpstreamResolverUnchecked(upstream, sut)
 
-				rsp, err := r.Resolve(mainReq)
+				rsp, err := r.Resolve(ctx, mainReq)
 				Expect(err).Should(Succeed())
 				Expect(mockUpstreamServer.GetCallCount()).Should(Equal(1))
 				Expect(rsp.Res.Question[0].Name).Should(Equal("example.com."))
@@ -373,7 +373,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				// implicit expectation of 0 bootstrapUpstream.Resolve calls
 
-				_, err = t.DialContext(context.Background(), "ip", "!bad-addr!")
+				_, err = t.DialContext(ctx, "ip", "!bad-addr!")
 				Expect(err).ShouldNot(Succeed())
 			})
 
@@ -384,7 +384,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				t := sut.NewHTTPTransport()
 
-				_, err = t.DialContext(context.Background(), "ip", "abc:123")
+				_, err = t.DialContext(ctx, "ip", "abc:123")
 
 				Expect(err).ShouldNot(Succeed())
 				Expect(err.Error()).Should(ContainSubstring(resolveErr.Error()))
@@ -397,7 +397,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				t := sut.NewHTTPTransport()
 
-				_, err = t.DialContext(context.Background(), "ip", "abc:123")
+				_, err = t.DialContext(ctx, "ip", "abc:123")
 
 				Expect(err).ShouldNot(Succeed())
 				Expect(err.Error()).Should(ContainSubstring("no such host"))
@@ -437,7 +437,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 		Describe("resolve", func() {
 			AfterEach(func() {
-				_, err := sut.resolveUpstream(nil, "example.com")
+				_, err := sut.resolveUpstream(ctx, nil, "example.com")
 				Expect(err).Should(Succeed())
 
 				m.AssertExpectations(GinkgoT())
@@ -501,7 +501,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 			AfterEach(func() {
 				t := sut.NewHTTPTransport()
 
-				conn, err := t.DialContext(context.Background(), dialIPVersion.Net(), "localhost:0")
+				conn, err := t.DialContext(ctx, dialIPVersion.Net(), "localhost:0")
 				Expect(err).Should(Succeed())
 				Expect(conn).Should(Equal(aMockConn))
 
@@ -583,7 +583,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 		})
 
 		It("uses both", func() {
-			_, err := sut.resolve("example.com.", []dns.Type{dns.Type(dns.TypeA)})
+			_, err := sut.resolve(ctx, "example.com.", []dns.Type{dns.Type(dns.TypeA)})
 
 			Expect(err).To(Succeed())
 

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -114,7 +114,7 @@ var _ = Describe("CachingResolver", func() {
 				})).Should(Succeed())
 
 				// first request
-				_, _ = sut.Resolve(newRequest("example.com.", A))
+				_, _ = sut.Resolve(ctx, newRequest("example.com.", A))
 
 				// Domain is not prefetched
 				Expect(domainPrefetched).ShouldNot(Receive())
@@ -124,7 +124,7 @@ var _ = Describe("CachingResolver", func() {
 
 				// now query again > threshold
 				for i := 0; i < prefetchThreshold+1; i++ {
-					_, err := sut.Resolve(newRequest("example.com.", A))
+					_, err := sut.Resolve(ctx, newRequest("example.com.", A))
 					Expect(err).Should(Succeed())
 				}
 
@@ -132,7 +132,7 @@ var _ = Describe("CachingResolver", func() {
 				Eventually(domainPrefetched, "10s").Should(Receive(Equal(true)))
 
 				// and it should hit from prefetch cache
-				Expect(sut.Resolve(newRequest("example.com.", A))).
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 					Should(
 						SatisfyAll(
 							HaveResponseType(ResponseTypeCACHED),
@@ -156,7 +156,7 @@ var _ = Describe("CachingResolver", func() {
 			})
 			It("should cache response and use response's TTL for multiple records", func() {
 				By("first request", func() {
-					result, err := sut.Resolve(newRequest("example.com.", A))
+					result, err := sut.Resolve(ctx, newRequest("example.com.", A))
 					Expect(err).Should(Succeed())
 					Expect(result).
 						Should(
@@ -176,7 +176,7 @@ var _ = Describe("CachingResolver", func() {
 
 				By("second request", func() {
 					Eventually(func(g Gomega) {
-						result, err := sut.Resolve(newRequest("example.com.", A))
+						result, err := sut.Resolve(ctx, newRequest("example.com.", A))
 						g.Expect(err).Should(Succeed())
 						g.Expect(result).
 							Should(
@@ -218,7 +218,7 @@ var _ = Describe("CachingResolver", func() {
 						_ = Bus().SubscribeOnce(CachingResultCacheChanged, func(d int) {
 							totalCacheCount <- d
 						})
-						Expect(sut.Resolve(newRequest("example.com.", A))).
+						Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeRESOLVED),
@@ -239,7 +239,7 @@ var _ = Describe("CachingResolver", func() {
 								domain <- true
 							})
 
-							g.Expect(sut.Resolve(newRequest("example.com.", A))).
+							g.Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 								Should(
 									SatisfyAll(
 										HaveResponseType(ResponseTypeCACHED),
@@ -264,7 +264,7 @@ var _ = Describe("CachingResolver", func() {
 
 					It("should cache response and use min caching time as TTL", func() {
 						By("first request", func() {
-							Expect(sut.Resolve(newRequest("example.com.", A))).
+							Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 								Should(
 									SatisfyAll(
 										HaveResponseType(ResponseTypeRESOLVED),
@@ -276,7 +276,9 @@ var _ = Describe("CachingResolver", func() {
 						})
 
 						By("second request", func() {
-							Eventually(sut.Resolve).WithArguments(newRequest("example.com.", A)).
+							Eventually(sut.Resolve).
+								WithContext(ctx).
+								WithArguments(newRequest("example.com.", A)).
 								Should(
 									SatisfyAll(
 										HaveResponseType(ResponseTypeCACHED),
@@ -299,7 +301,7 @@ var _ = Describe("CachingResolver", func() {
 
 					It("should cache response and use min caching time as TTL", func() {
 						By("first request", func() {
-							Expect(sut.Resolve(newRequest("example.com.", AAAA))).
+							Expect(sut.Resolve(ctx, newRequest("example.com.", AAAA))).
 								Should(
 									SatisfyAll(
 										HaveResponseType(ResponseTypeRESOLVED),
@@ -310,7 +312,9 @@ var _ = Describe("CachingResolver", func() {
 						})
 
 						By("second request", func() {
-							Eventually(sut.Resolve).WithArguments(newRequest("example.com.", AAAA)).
+							Eventually(sut.Resolve).
+								WithContext(ctx).
+								WithArguments(newRequest("example.com.", AAAA)).
 								Should(
 									SatisfyAll(
 										HaveResponseType(ResponseTypeCACHED),
@@ -344,7 +348,7 @@ var _ = Describe("CachingResolver", func() {
 
 				It("Shouldn't cache any responses", func() {
 					By("first request", func() {
-						Expect(sut.Resolve(newRequest("example.com.", AAAA))).
+						Expect(sut.Resolve(ctx, newRequest("example.com.", AAAA))).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeRESOLVED),
@@ -355,7 +359,9 @@ var _ = Describe("CachingResolver", func() {
 					})
 
 					By("second request", func() {
-						Eventually(sut.Resolve).WithArguments(newRequest("example.com.", AAAA)).
+						Eventually(sut.Resolve).
+							WithContext(ctx).
+							WithArguments(newRequest("example.com.", AAAA)).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeRESOLVED),
@@ -378,7 +384,7 @@ var _ = Describe("CachingResolver", func() {
 				})
 				It("should cache response and use max caching time as TTL if response TTL is bigger", func() {
 					By("first request", func() {
-						Expect(sut.Resolve(newRequest("example.com.", AAAA))).
+						Expect(sut.Resolve(ctx, newRequest("example.com.", AAAA))).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeRESOLVED),
@@ -389,7 +395,9 @@ var _ = Describe("CachingResolver", func() {
 					})
 
 					By("second request", func() {
-						Eventually(sut.Resolve).WithArguments(newRequest("example.com.", AAAA)).
+						Eventually(sut.Resolve).
+							WithContext(ctx).
+							WithArguments(newRequest("example.com.", AAAA)).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeCACHED),
@@ -417,7 +425,7 @@ var _ = Describe("CachingResolver", func() {
 				})
 				It("should cache response and return 0 TTL if entry is expired", func() {
 					By("first request", func() {
-						Expect(sut.Resolve(newRequest("example.com.", A))).
+						Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeRESOLVED),
@@ -430,7 +438,9 @@ var _ = Describe("CachingResolver", func() {
 					})
 
 					By("second request", func() {
-						Eventually(sut.Resolve, "2s").WithArguments(newRequest("example.com.", A)).
+						Eventually(sut.Resolve, "2s").
+							WithContext(ctx).
+							WithArguments(newRequest("example.com.", A)).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeCACHED),
@@ -461,7 +471,7 @@ var _ = Describe("CachingResolver", func() {
 					})
 
 					By("first request", func() {
-						Expect(sut.Resolve(newRequest("example.com.", AAAA))).
+						Expect(sut.Resolve(ctx, newRequest("example.com.", AAAA))).
 							Should(SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
 								HaveReturnCode(dns.RcodeNameError),
@@ -472,7 +482,9 @@ var _ = Describe("CachingResolver", func() {
 					})
 
 					By("second request", func() {
-						Eventually(sut.Resolve).WithArguments(newRequest("example.com.", AAAA)).
+						Eventually(sut.Resolve).
+							WithContext(ctx).
+							WithArguments(newRequest("example.com.", AAAA)).
 							Should(SatisfyAll(
 								HaveResponseType(ResponseTypeCACHED),
 								HaveReason("CACHED NEGATIVE"),
@@ -495,7 +507,7 @@ var _ = Describe("CachingResolver", func() {
 
 				It("response shouldn't be cached", func() {
 					By("first request", func() {
-						Expect(sut.Resolve(newRequest("example.com.", AAAA))).
+						Expect(sut.Resolve(ctx, newRequest("example.com.", AAAA))).
 							Should(SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
 								HaveReturnCode(dns.RcodeNameError),
@@ -506,7 +518,9 @@ var _ = Describe("CachingResolver", func() {
 					})
 
 					By("second request", func() {
-						Eventually(sut.Resolve).WithArguments(newRequest("example.com.", AAAA)).
+						Eventually(sut.Resolve).
+							WithContext(ctx).
+							WithArguments(newRequest("example.com.", AAAA)).
 							Should(SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
 								HaveReason(""),
@@ -529,7 +543,7 @@ var _ = Describe("CachingResolver", func() {
 
 				It("response should be cached", func() {
 					By("first request", func() {
-						Expect(sut.Resolve(newRequest("example.com.", AAAA))).
+						Expect(sut.Resolve(ctx, newRequest("example.com.", AAAA))).
 							Should(SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
 								HaveReturnCode(dns.RcodeSuccess),
@@ -540,7 +554,9 @@ var _ = Describe("CachingResolver", func() {
 					})
 
 					By("second request", func() {
-						Eventually(sut.Resolve).WithArguments(newRequest("example.com.", AAAA)).
+						Eventually(sut.Resolve).
+							WithContext(ctx).
+							WithArguments(newRequest("example.com.", AAAA)).
 							Should(SatisfyAll(
 								HaveResponseType(ResponseTypeCACHED),
 								HaveReason("CACHED"),
@@ -563,7 +579,7 @@ var _ = Describe("CachingResolver", func() {
 			})
 			It("Should be cached", func() {
 				By("first request", func() {
-					Expect(sut.Resolve(newRequest("google.de.", MX))).
+					Expect(sut.Resolve(ctx, newRequest("google.de.", MX))).
 						Should(SatisfyAll(
 							HaveResponseType(ResponseTypeRESOLVED),
 							HaveReturnCode(dns.RcodeSuccess),
@@ -575,7 +591,9 @@ var _ = Describe("CachingResolver", func() {
 				})
 
 				By("second request", func() {
-					Eventually(sut.Resolve).WithArguments(newRequest("google.de.", MX)).
+					Eventually(sut.Resolve).
+						WithContext(ctx).
+						WithArguments(newRequest("google.de.", MX)).
 						Should(SatisfyAll(
 							HaveResponseType(ResponseTypeCACHED),
 							HaveReason("CACHED"),
@@ -599,7 +617,7 @@ var _ = Describe("CachingResolver", func() {
 			})
 			It("Should not be cached", func() {
 				By("first request", func() {
-					Expect(sut.Resolve(newRequest("google.de.", A))).
+					Expect(sut.Resolve(ctx, newRequest("google.de.", A))).
 						Should(SatisfyAll(
 							HaveResponseType(ResponseTypeRESOLVED),
 							HaveReturnCode(dns.RcodeSuccess),
@@ -611,7 +629,7 @@ var _ = Describe("CachingResolver", func() {
 				})
 
 				By("second request", func() {
-					Expect(sut.Resolve(newRequest("google.de.", A))).
+					Expect(sut.Resolve(ctx, newRequest("google.de.", A))).
 						Should(SatisfyAll(
 							HaveResponseType(ResponseTypeRESOLVED),
 							HaveReturnCode(dns.RcodeSuccess),
@@ -633,7 +651,7 @@ var _ = Describe("CachingResolver", func() {
 			})
 			It("Should not be cached", func() {
 				By("first request", func() {
-					Expect(sut.Resolve(newRequest("google.de.", A))).
+					Expect(sut.Resolve(ctx, newRequest("google.de.", A))).
 						Should(SatisfyAll(
 							HaveResponseType(ResponseTypeRESOLVED),
 							HaveReturnCode(dns.RcodeSuccess),
@@ -645,7 +663,7 @@ var _ = Describe("CachingResolver", func() {
 				})
 
 				By("second request", func() {
-					Expect(sut.Resolve(newRequest("google.de.", A))).
+					Expect(sut.Resolve(ctx, newRequest("google.de.", A))).
 						Should(SatisfyAll(
 							HaveResponseType(ResponseTypeRESOLVED),
 							HaveReturnCode(dns.RcodeSuccess),
@@ -671,7 +689,7 @@ var _ = Describe("CachingResolver", func() {
 			})
 			It("Should not be cached", func() {
 				By("first request", func() {
-					Expect(sut.Resolve(newRequest("google.de.", A))).
+					Expect(sut.Resolve(ctx, newRequest("google.de.", A))).
 						Should(SatisfyAll(
 							HaveResponseType(ResponseTypeRESOLVED),
 							HaveReturnCode(dns.RcodeSuccess),
@@ -688,7 +706,9 @@ var _ = Describe("CachingResolver", func() {
 				})
 
 				By("second request", func() {
-					Eventually(sut.Resolve).WithArguments(newRequest("google.de.", A)).
+					Eventually(sut.Resolve).
+						WithContext(ctx).
+						WithArguments(newRequest("google.de.", A)).
 						Should(SatisfyAll(
 							HaveResponseType(ResponseTypeCACHED),
 							HaveReason("CACHED"),
@@ -750,7 +770,7 @@ var _ = Describe("CachingResolver", func() {
 			})
 
 			It("put in redis", func() {
-				Expect(sut.Resolve(newRequest("example.com.", A))).
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 					Should(HaveResponseType(ResponseTypeRESOLVED))
 
 				Eventually(func() []string {
@@ -772,7 +792,9 @@ var _ = Describe("CachingResolver", func() {
 				}
 				redisClient.CacheChannel <- redisMockMsg
 
-				Eventually(sut.Resolve).WithArguments(request).
+				Eventually(sut.Resolve).
+					WithContext(ctx).
+					WithArguments(request).
 					Should(
 						SatisfyAll(
 							HaveResponseType(ResponseTypeCACHED),

--- a/resolver/client_names_resolver.go
+++ b/resolver/client_names_resolver.go
@@ -32,7 +32,7 @@ func NewClientNamesResolver(ctx context.Context,
 ) (cr *ClientNamesResolver, err error) {
 	var r Resolver
 	if !cfg.Upstream.IsDefault() {
-		r, err = NewUpstreamResolver(cfg.Upstream, bootstrap, shouldVerifyUpstreams)
+		r, err = NewUpstreamResolver(ctx, cfg.Upstream, bootstrap, shouldVerifyUpstreams)
 		if err != nil {
 			return nil, err
 		}
@@ -59,17 +59,17 @@ func (r *ClientNamesResolver) LogConfig(logger *logrus.Entry) {
 }
 
 // Resolve tries to resolve the client name from the ip address
-func (r *ClientNamesResolver) Resolve(request *model.Request) (*model.Response, error) {
-	clientNames := r.getClientNames(request)
+func (r *ClientNamesResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
+	clientNames := r.getClientNames(ctx, request)
 
 	request.ClientNames = clientNames
 	request.Log = request.Log.WithField("client_names", strings.Join(clientNames, "; "))
 
-	return r.next.Resolve(request)
+	return r.next.Resolve(ctx, request)
 }
 
 // returns names of client
-func (r *ClientNamesResolver) getClientNames(request *model.Request) []string {
+func (r *ClientNamesResolver) getClientNames(ctx context.Context, request *model.Request) []string {
 	if request.RequestClientID != "" {
 		return []string{request.RequestClientID}
 	}
@@ -88,7 +88,7 @@ func (r *ClientNamesResolver) getClientNames(request *model.Request) []string {
 		return cpy
 	}
 
-	names := r.resolveClientNames(ip, log.WithPrefix(request.Log, "client_names_resolver"))
+	names := r.resolveClientNames(ctx, ip, log.WithPrefix(request.Log, "client_names_resolver"))
 
 	r.cache.Put(ip.String(), &names, time.Hour)
 
@@ -111,7 +111,9 @@ func extractClientNamesFromAnswer(answer []dns.RR, fallbackIP net.IP) (clientNam
 }
 
 // tries to resolve client name from mapping, performs reverse DNS lookup otherwise
-func (r *ClientNamesResolver) resolveClientNames(ip net.IP, logger *logrus.Entry) (result []string) {
+func (r *ClientNamesResolver) resolveClientNames(
+	ctx context.Context, ip net.IP, logger *logrus.Entry,
+) (result []string) {
 	// try client mapping first
 	result = r.getNameFromIPMapping(ip, result)
 	if len(result) > 0 {
@@ -124,7 +126,7 @@ func (r *ClientNamesResolver) resolveClientNames(ip net.IP, logger *logrus.Entry
 
 	reverse, _ := dns.ReverseAddr(ip.String())
 
-	resp, err := r.externalResolver.Resolve(&model.Request{
+	resp, err := r.externalResolver.Resolve(ctx, &model.Request{
 		Req: util.NewMsgWithQuestion(reverse, dns.Type(dns.TypePTR)),
 		Log: logger,
 	})

--- a/resolver/client_names_resolver_test.go
+++ b/resolver/client_names_resolver_test.go
@@ -22,8 +22,9 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 		sut       *ClientNamesResolver
 		sutConfig config.ClientLookupConfig
 		m         *mockResolver
-		ctx       context.Context
-		cancelFn  context.CancelFunc
+
+		ctx      context.Context
+		cancelFn context.CancelFunc
 	)
 
 	Describe("Type", func() {
@@ -34,6 +35,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 	JustBeforeEach(func() {
 		var err error
+
 		ctx, cancelFn = context.WithCancel(context.Background())
 		DeferCleanup(cancelFn)
 
@@ -71,7 +73,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 		It("should use clientID if set", func() {
 			request := newRequestWithClientID("google1.de.", dns.Type(dns.TypeA), "1.2.3.4", "client123")
-			Expect(sut.Resolve(request)).
+			Expect(sut.Resolve(ctx, request)).
 				Should(
 					SatisfyAll(
 						HaveResponseType(ResponseTypeRESOLVED),
@@ -82,7 +84,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 		})
 		It("should use IP as fallback if clientID not set", func() {
 			request := newRequestWithClientID("google2.de.", dns.Type(dns.TypeA), "1.2.3.4", "")
-			Expect(sut.Resolve(request)).
+			Expect(sut.Resolve(ctx, request)).
 				Should(
 					SatisfyAll(
 						HaveResponseType(ResponseTypeRESOLVED),
@@ -112,7 +114,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 		It("should resolve defined name with ipv4 address", func() {
 			request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "1.2.3.4")
-			Expect(sut.Resolve(request)).
+			Expect(sut.Resolve(ctx, request)).
 				Should(
 					SatisfyAll(
 						HaveResponseType(ResponseTypeRESOLVED),
@@ -124,7 +126,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 		It("should resolve defined name with ipv6 address", func() {
 			request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "2a02:590:505:4700:2e4f:1503:ce74:df78")
-			Expect(sut.Resolve(request)).
+			Expect(sut.Resolve(ctx, request)).
 				Should(
 					SatisfyAll(
 						HaveResponseType(ResponseTypeRESOLVED),
@@ -135,7 +137,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 		})
 		It("should resolve multiple names defined names", func() {
 			request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "1.2.3.5")
-			Expect(sut.Resolve(request)).
+			Expect(sut.Resolve(ctx, request)).
 				Should(
 					SatisfyAll(
 						HaveResponseType(ResponseTypeRESOLVED),
@@ -168,7 +170,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 				It("should resolve client name", func() {
 					By("first request", func() {
 						request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-						Expect(sut.Resolve(request)).
+						Expect(sut.Resolve(ctx, request)).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeRESOLVED),
@@ -180,7 +182,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 					By("second request", func() {
 						request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-						Expect(sut.Resolve(request)).
+						Expect(sut.Resolve(ctx, request)).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeRESOLVED),
@@ -198,7 +200,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 					By("third request", func() {
 						request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-						Expect(sut.Resolve(request)).
+						Expect(sut.Resolve(ctx, request)).
 							Should(
 								SatisfyAll(
 									HaveResponseType(ResponseTypeRESOLVED),
@@ -223,7 +225,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 				It("should resolve all client names", func() {
 					request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-					Expect(sut.Resolve(request)).
+					Expect(sut.Resolve(ctx, request)).
 						Should(
 							SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
@@ -251,7 +253,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 				It("should resolve client name", func() {
 					request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-					Expect(sut.Resolve(request)).
+					Expect(sut.Resolve(ctx, request)).
 						Should(
 							SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
@@ -272,7 +274,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 				It("should resolve the client name depending to defined order", func() {
 					request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-					Expect(sut.Resolve(request)).
+					Expect(sut.Resolve(ctx, request)).
 						Should(
 							SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
@@ -298,7 +300,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 
 				It("should use fallback for client name", func() {
 					request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-					Expect(sut.Resolve(request)).
+					Expect(sut.Resolve(ctx, request)).
 						Should(
 							SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
@@ -318,7 +320,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 				})
 				It("should use fallback for client name", func() {
 					request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-					Expect(sut.Resolve(request)).
+					Expect(sut.Resolve(ctx, request)).
 						Should(
 							SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
@@ -335,7 +337,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 				})
 				It("should resolve no names", func() {
 					request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "")
-					Expect(sut.Resolve(request)).
+					Expect(sut.Resolve(ctx, request)).
 						Should(
 							SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),
@@ -351,7 +353,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 				})
 				It("should use fallback for client name", func() {
 					request := newRequestWithClient("google.de.", dns.Type(dns.TypeA), "192.168.178.25")
-					Expect(sut.Resolve(request)).
+					Expect(sut.Resolve(ctx, request)).
 						Should(
 							SatisfyAll(
 								HaveResponseType(ResponseTypeRESOLVED),

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"net"
 	"strings"
 
@@ -123,7 +124,7 @@ func (r *CustomDNSResolver) processRequest(request *model.Request) *model.Respon
 }
 
 // Resolve uses internal mapping to resolve the query
-func (r *CustomDNSResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *CustomDNSResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	logger := log.WithPrefix(request.Log, "custom_dns_resolver")
 
 	reverseResp := r.handleReverseDNS(request)
@@ -140,5 +141,5 @@ func (r *CustomDNSResolver) Resolve(request *model.Request) (*model.Response, er
 
 	logger.WithField("next_resolver", Name(r.next)).Trace("go to next resolver")
 
-	return r.next.Resolve(request)
+	return r.next.Resolve(ctx, request)
 }

--- a/resolver/ecs_resolver.go
+++ b/resolver/ecs_resolver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -46,7 +47,7 @@ func NewECSResolver(cfg config.ECS) ChainedResolver {
 
 // Resolve adds the subnet information as EDNS0 option to the request of the next resolver
 // and sets the client IP from the EDNS0 option to the request if this option is enabled
-func (r *ECSResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *ECSResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	if r.cfg.IsEnabled() {
 		so := util.GetEdns0Option[*dns.EDNS0_SUBNET](request.Req)
 		// Set the client IP from the Edns0 subnet option if the option is enabled and the correct subnet mask is set
@@ -67,7 +68,7 @@ func (r *ECSResolver) Resolve(request *model.Request) (*model.Response, error) {
 		}
 	}
 
-	return r.next.Resolve(request)
+	return r.next.Resolve(ctx, request)
 }
 
 // setSubnet appends the subnet information to the request as EDNS0 option

--- a/resolver/ede_resolver.go
+++ b/resolver/ede_resolver.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
@@ -25,12 +27,12 @@ func NewEDEResolver(cfg config.EDE) *EDEResolver {
 
 // Resolve adds the reason as EDNS0 option to the response of the next resolver
 // if it is enabled in the configuration
-func (r *EDEResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *EDEResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	if !r.cfg.Enable {
-		return r.next.Resolve(request)
+		return r.next.Resolve(ctx, request)
 	}
 
-	resp, err := r.next.Resolve(request)
+	resp, err := r.next.Resolve(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/resolver/ede_resolver_test.go
+++ b/resolver/ede_resolver_test.go
@@ -2,6 +2,7 @@
 package resolver
 
 import (
+	"context"
 	"errors"
 	"math"
 
@@ -24,6 +25,9 @@ var _ = Describe("EdeResolver", func() {
 		sutConfig  config.EDE
 		m          *mockResolver
 		mockAnswer *dns.Msg
+
+		ctx      context.Context
+		cancelFn context.CancelFunc
 	)
 
 	Describe("Type", func() {
@@ -33,6 +37,9 @@ var _ = Describe("EdeResolver", func() {
 	})
 
 	BeforeEach(func() {
+		ctx, cancelFn = context.WithCancel(context.Background())
+		DeferCleanup(cancelFn)
+
 		mockAnswer = new(dns.Msg)
 	})
 
@@ -57,7 +64,7 @@ var _ = Describe("EdeResolver", func() {
 			}
 		})
 		It("shouldn't add EDE information", func() {
-			Expect(sut.Resolve(newRequest("example.com.", A))).
+			Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 				Should(
 					SatisfyAll(
 						HaveNoAnswer(),
@@ -89,7 +96,7 @@ var _ = Describe("EdeResolver", func() {
 		}
 
 		It("should add EDE information", func() {
-			Expect(sut.Resolve(newRequest("example.com.", A))).
+			Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 				Should(
 					SatisfyAll(
 						HaveNoAnswer(),
@@ -115,7 +122,7 @@ var _ = Describe("EdeResolver", func() {
 			})
 
 			It("shouldn't add EDE information", func() {
-				Expect(sut.Resolve(newRequest("example.com.", A))).
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 					Should(
 						SatisfyAll(
 							HaveNoAnswer(),
@@ -137,7 +144,7 @@ var _ = Describe("EdeResolver", func() {
 			})
 
 			It("should return it", func() {
-				resp, err := sut.Resolve(newRequest("example.com", A))
+				resp, err := sut.Resolve(ctx, newRequest("example.com", A))
 				Expect(resp).To(BeNil())
 				Expect(err).To(Equal(resolveErr))
 			})

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
@@ -21,7 +23,7 @@ func NewFilteringResolver(cfg config.FilteringConfig) *FilteringResolver {
 	}
 }
 
-func (r *FilteringResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *FilteringResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	qType := request.Req.Question[0].Qtype
 	if r.cfg.QueryTypes.Contains(dns.Type(qType)) {
 		response := new(dns.Msg)
@@ -30,5 +32,5 @@ func (r *FilteringResolver) Resolve(request *model.Request) (*model.Response, er
 		return &model.Response{Res: response, RType: model.ResponseTypeFILTERED}, nil
 	}
 
-	return r.next.Resolve(request)
+	return r.next.Resolve(ctx, request)
 }

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
 	"github.com/0xERR0R/blocky/log"
@@ -18,6 +20,9 @@ var _ = Describe("FilteringResolver", func() {
 		sutConfig  config.FilteringConfig
 		m          *mockResolver
 		mockAnswer *dns.Msg
+
+		ctx      context.Context
+		cancelFn context.CancelFunc
 	)
 
 	Describe("Type", func() {
@@ -27,6 +32,9 @@ var _ = Describe("FilteringResolver", func() {
 	})
 
 	BeforeEach(func() {
+		ctx, cancelFn = context.WithCancel(context.Background())
+		DeferCleanup(cancelFn)
+
 		mockAnswer = new(dns.Msg)
 	})
 
@@ -60,7 +68,7 @@ var _ = Describe("FilteringResolver", func() {
 			}
 		})
 		It("Should delegate to next resolver if request query has other type", func() {
-			Expect(sut.Resolve(newRequest("example.com.", A))).
+			Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 				Should(
 					SatisfyAll(
 						HaveNoAnswer(),
@@ -72,7 +80,7 @@ var _ = Describe("FilteringResolver", func() {
 			Expect(m.Calls).Should(HaveLen(1))
 		})
 		It("Should return empty answer for defined query type", func() {
-			Expect(sut.Resolve(newRequest("example.com.", AAAA))).
+			Expect(sut.Resolve(ctx, newRequest("example.com.", AAAA))).
 				Should(
 					SatisfyAll(
 						HaveNoAnswer(),
@@ -90,7 +98,7 @@ var _ = Describe("FilteringResolver", func() {
 			sutConfig = config.FilteringConfig{}
 		})
 		It("Should return empty answer without error", func() {
-			Expect(sut.Resolve(newRequest("example.com.", AAAA))).
+			Expect(sut.Resolve(ctx, newRequest("example.com.", AAAA))).
 				Should(
 					SatisfyAll(
 						HaveNoAnswer(),

--- a/resolver/fqdn_only_resolver.go
+++ b/resolver/fqdn_only_resolver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
@@ -22,7 +23,7 @@ func NewFQDNOnlyResolver(cfg config.FQDNOnly) *FQDNOnlyResolver {
 	}
 }
 
-func (r *FQDNOnlyResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *FQDNOnlyResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	if r.IsEnabled() {
 		domainFromQuestion := util.ExtractDomain(request.Req.Question[0])
 		if !strings.Contains(domainFromQuestion, ".") {
@@ -33,5 +34,5 @@ func (r *FQDNOnlyResolver) Resolve(request *model.Request) (*model.Response, err
 		}
 	}
 
-	return r.next.Resolve(request)
+	return r.next.Resolve(ctx, request)
 }

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -109,9 +109,9 @@ func (r *HostsFileResolver) handleReverseDNS(request *model.Request) *model.Resp
 	return nil
 }
 
-func (r *HostsFileResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *HostsFileResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	if !r.IsEnabled() {
-		return r.next.Resolve(request)
+		return r.next.Resolve(ctx, request)
 	}
 
 	reverseResp := r.handleReverseDNS(request)
@@ -134,7 +134,7 @@ func (r *HostsFileResolver) Resolve(request *model.Request) (*model.Response, er
 
 	r.log().WithField("next_resolver", Name(r.next)).Trace("go to next resolver")
 
-	return r.next.Resolve(request)
+	return r.next.Resolve(ctx, request)
 }
 
 func (r *HostsFileResolver) resolve(req *dns.Msg, question dns.Question, domain string) *dns.Msg {

--- a/resolver/metrics_resolver.go
+++ b/resolver/metrics_resolver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -25,8 +26,8 @@ type MetricsResolver struct {
 }
 
 // Resolve resolves the passed request
-func (r *MetricsResolver) Resolve(request *model.Request) (*model.Response, error) {
-	response, err := r.next.Resolve(request)
+func (r *MetricsResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
+	response, err := r.next.Resolve(ctx, request)
 
 	if r.cfg.Enable {
 		r.totalQueries.With(prometheus.Labels{

--- a/resolver/mock_udp_upstream_server.go
+++ b/resolver/mock_udp_upstream_server.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/util"
@@ -58,6 +59,21 @@ func (t *MockUDPUpstreamServer) WithAnswerError(errorCode int) *MockUDPUpstreamS
 
 func (t *MockUDPUpstreamServer) WithAnswerFn(fn func(request *dns.Msg) (response *dns.Msg)) *MockUDPUpstreamServer {
 	t.answerFn = fn
+
+	return t
+}
+
+func (t *MockUDPUpstreamServer) WithDelay(delay time.Duration) *MockUDPUpstreamServer {
+	answerFn := t.answerFn
+	if answerFn == nil {
+		panic("WithDelay must be called after a WithAnswer function")
+	}
+
+	t.answerFn = func(request *dns.Msg) *dns.Msg {
+		time.Sleep(delay)
+
+		return answerFn(request)
+	}
 
 	return t
 }

--- a/resolver/mocks_test.go
+++ b/resolver/mocks_test.go
@@ -23,7 +23,7 @@ type mockResolver struct {
 	mock.Mock
 	NextResolver
 
-	ResolveFn  func(req *model.Request) (*model.Response, error)
+	ResolveFn  func(ctx context.Context, req *model.Request) (*model.Response, error)
 	ResponseFn func(req *dns.Msg) *dns.Msg
 	AnswerFn   func(qType dns.Type, qName string) (*dns.Msg, error)
 }
@@ -45,11 +45,11 @@ func (r *mockResolver) LogConfig(*logrus.Entry) {
 	r.Called()
 }
 
-func (r *mockResolver) Resolve(req *model.Request) (*model.Response, error) {
+func (r *mockResolver) Resolve(ctx context.Context, req *model.Request) (*model.Response, error) {
 	args := r.Called(req)
 
 	if r.ResolveFn != nil {
-		return r.ResolveFn(req)
+		return r.ResolveFn(ctx, req)
 	}
 
 	if r.ResponseFn != nil {

--- a/resolver/noop_resolver.go
+++ b/resolver/noop_resolver.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/0xERR0R/blocky/model"
 	"github.com/sirupsen/logrus"
 )
@@ -28,6 +30,6 @@ func (NoOpResolver) IsEnabled() bool {
 func (NoOpResolver) LogConfig(*logrus.Entry) {
 }
 
-func (NoOpResolver) Resolve(*model.Request) (*model.Response, error) {
+func (NoOpResolver) Resolve(context.Context, *model.Request) (*model.Response, error) {
 	return NoResponse, nil
 }

--- a/resolver/noop_resolver_test.go
+++ b/resolver/noop_resolver_test.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"context"
+
 	. "github.com/0xERR0R/blocky/helpertest"
 	"github.com/0xERR0R/blocky/log"
 	. "github.com/onsi/ginkgo/v2"
@@ -8,7 +10,12 @@ import (
 )
 
 var _ = Describe("NoOpResolver", func() {
-	var sut *NoOpResolver
+	var (
+		sut *NoOpResolver
+
+		ctx      context.Context
+		cancelFn context.CancelFunc
+	)
 
 	Describe("Type", func() {
 		It("follows conventions", func() {
@@ -17,12 +24,15 @@ var _ = Describe("NoOpResolver", func() {
 	})
 
 	BeforeEach(func() {
+		ctx, cancelFn = context.WithCancel(context.Background())
+		DeferCleanup(cancelFn)
+
 		sut = NewNoOpResolver()
 	})
 
 	Describe("Resolving", func() {
 		It("returns no response", func() {
-			resp, err := sut.Resolve(newRequest("test.tld", A))
+			resp, err := sut.Resolve(ctx, newRequest("test.tld", A))
 			Expect(err).Should(Succeed())
 			Expect(resp).Should(Equal(NoResponse))
 		})

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -323,7 +323,7 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 		Describe("Name", func() {
 			It("should contain correct resolver", func() {
 				Expect(sut.Name()).ShouldNot(BeEmpty())
-				Expect(sut.Name()).Should(ContainSubstring(parallelResolverType))
+				Expect(sut.Name()).Should(ContainSubstring(randomResolverType))
 			})
 		})
 

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -111,12 +111,12 @@ func (r *QueryLoggingResolver) doCleanUp() {
 }
 
 // Resolve logs the query, duration and the result
-func (r *QueryLoggingResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *QueryLoggingResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	logger := log.WithPrefix(request.Log, queryLoggingResolverType)
 
 	start := time.Now()
 
-	resp, err := r.next.Resolve(request)
+	resp, err := r.next.Resolve(ctx, request)
 
 	duration := time.Since(start).Milliseconds()
 

--- a/resolver/rewriter_resolver_test.go
+++ b/resolver/rewriter_resolver_test.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
@@ -94,7 +96,7 @@ var _ = Describe("RewriterResolver", func() {
 				return res
 			}
 
-			resp, err := sut.Resolve(request)
+			resp, err := sut.Resolve(context.Background(), request)
 			Expect(err).Should(Succeed())
 			if resp != mNextResponse {
 				Expect(resp.Res.Question[0].Name).Should(Equal(fqdnOriginal))
@@ -132,18 +134,18 @@ var _ = Describe("RewriterResolver", func() {
 			expectNilAnswer = true
 
 			// Make inner call the NoOpResolver
-			mInner.ResolveFn = func(req *model.Request) (*model.Response, error) {
+			mInner.ResolveFn = func(ctx context.Context, req *model.Request) (*model.Response, error) {
 				Expect(req).Should(Equal(request))
 
 				// Inner should see fqdnRewritten
 				Expect(req.Req.Question[0].Name).Should(Equal(fqdnRewritten))
 
-				return mInner.next.Resolve(req)
+				return mInner.next.Resolve(ctx, req)
 			}
 
 			// Resolver after RewriterResolver should see `fqdnOriginal`
 			mNext.On("Resolve", mock.Anything)
-			mNext.ResolveFn = func(req *model.Request) (*model.Response, error) {
+			mNext.ResolveFn = func(ctx context.Context, req *model.Request) (*model.Response, error) {
 				Expect(req.Req.Question[0].Name).Should(Equal(fqdnOriginal))
 
 				return mNextResponse, nil
@@ -156,7 +158,7 @@ var _ = Describe("RewriterResolver", func() {
 			expectNilAnswer = true
 
 			// Make inner return a nil Answer but not an empty Response
-			mInner.ResolveFn = func(req *model.Request) (*model.Response, error) {
+			mInner.ResolveFn = func(ctx context.Context, req *model.Request) (*model.Response, error) {
 				Expect(req).Should(Equal(request))
 
 				// Inner should see fqdnRewritten
@@ -179,7 +181,7 @@ var _ = Describe("RewriterResolver", func() {
 				fqdnRewritten = sampleRewritten
 
 				// Make inner return a nil Answer but not an empty Response
-				mInner.ResolveFn = func(req *model.Request) (*model.Response, error) {
+				mInner.ResolveFn = func(ctx context.Context, req *model.Request) (*model.Response, error) {
 					Expect(req).Should(Equal(request))
 
 					// Inner should see fqdnRewritten
@@ -190,7 +192,7 @@ var _ = Describe("RewriterResolver", func() {
 
 				// Resolver after RewriterResolver should see `fqdnOriginal`
 				mNext.On("Resolve", mock.Anything)
-				mNext.ResolveFn = func(req *model.Request) (*model.Response, error) {
+				mNext.ResolveFn = func(ctx context.Context, req *model.Request) (*model.Response, error) {
 					Expect(req.Req.Question[0].Name).Should(Equal(fqdnOriginal))
 
 					return mNextResponse, nil

--- a/resolver/sudn_resolver.go
+++ b/resolver/sudn_resolver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"net"
 	"strings"
 
@@ -99,7 +100,7 @@ func NewSpecialUseDomainNamesResolver(cfg config.SUDN) *SpecialUseDomainNamesRes
 	}
 }
 
-func (r *SpecialUseDomainNamesResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *SpecialUseDomainNamesResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	handler := r.handler(request)
 	if handler != nil {
 		resp := handler(request, r.cfg)
@@ -108,7 +109,7 @@ func (r *SpecialUseDomainNamesResolver) Resolve(request *model.Request) (*model.
 		}
 	}
 
-	return r.next.Resolve(request)
+	return r.next.Resolve(ctx, request)
 }
 
 func (r *SpecialUseDomainNamesResolver) handler(request *model.Request) sudnHandler {

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -80,21 +80,18 @@ func createUpstreamClient(cfg config.Upstream) upstreamClient {
 	case config.NetProtocolTcpTls:
 		return &dnsUpstreamClient{
 			tcpClient: &dns.Client{
-				TLSConfig:      &tlsConfig,
-				Net:            cfg.Net.String(),
-				SingleInflight: true,
+				TLSConfig: &tlsConfig,
+				Net:       cfg.Net.String(),
 			},
 		}
 
 	case config.NetProtocolTcpUdp:
 		return &dnsUpstreamClient{
 			tcpClient: &dns.Client{
-				Net:            "tcp",
-				SingleInflight: true,
+				Net: "tcp",
 			},
 			udpClient: &dns.Client{
-				Net:            "udp",
-				SingleInflight: true,
+				Net: "udp",
 			},
 		}
 

--- a/resolver/upstream_tree_resolver.go
+++ b/resolver/upstream_tree_resolver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -64,7 +65,7 @@ func (r *UpstreamTreeResolver) String() string {
 	return fmt.Sprintf("%s upstreams %q", upstreamTreeResolverType, strings.Join(result, ", "))
 }
 
-func (r *UpstreamTreeResolver) Resolve(request *model.Request) (*model.Response, error) {
+func (r *UpstreamTreeResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	logger := log.WithPrefix(request.Log, upstreamTreeResolverType)
 
 	group := r.upstreamGroupByClient(request)
@@ -72,7 +73,7 @@ func (r *UpstreamTreeResolver) Resolve(request *model.Request) (*model.Response,
 	// delegate request to group resolver
 	logger.WithField("resolver", fmt.Sprintf("%s (%s)", group, r.branches[group].Type())).Debug("delegating to resolver")
 
-	return r.branches[group].Resolve(request)
+	return r.branches[group].Resolve(ctx, request)
 }
 
 func (r *UpstreamTreeResolver) upstreamGroupByClient(request *model.Request) string {

--- a/server/server_endpoints.go
+++ b/server/server_endpoints.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"html/template"
@@ -149,7 +150,7 @@ func (s *Server) processDohMessage(rawMsg []byte, rw http.ResponseWriter, req *h
 
 	r := newRequest(net.ParseIP(extractIP(req)), model.RequestProtocolTCP, clientID, msg)
 
-	resResponse, err := s.queryResolver.Resolve(r)
+	resResponse, err := s.queryResolver.Resolve(req.Context(), r)
 	if err != nil {
 		logAndResponseWithError(err, "unable to process query: ", rw)
 
@@ -192,11 +193,11 @@ func extractIP(r *http.Request) string {
 	return hostPort
 }
 
-func (s *Server) Query(question string, qType dns.Type) (*model.Response, error) {
+func (s *Server) Query(ctx context.Context, question string, qType dns.Type) (*model.Response, error) {
 	dnsRequest := util.NewMsgWithQuestion(question, qType)
 	r := createResolverRequest(nil, dnsRequest)
 
-	return s.queryResolver.Resolve(r)
+	return s.queryResolver.Resolve(ctx, r)
 }
 
 func createHTTPSRouter(cfg *config.Config) *chi.Mux {


### PR DESCRIPTION
> - `CacheControl.FlushCaches`
> - `Querier.Query`
> - `Resolver.Resolve`
> 
> Besides all the API churn, this leads to `ParallelBestResolver`,
> `StrictResolver` and `UpstreamResolver` simplification: timeouts only
> need to be setup in one place, `upstreamResolverStatus`.
> 
> We also benefit from using HTTP request contexts, so if the client
> closes the connection we stop processing on our side.

I split the changes to make reviewing easier since most of the changes are just adding `ctx` to function definitions and calls. Here's the interesting commits:
- [refactor: make use of contexts in more places](https://github.com/0xERR0R/blocky/commit/5a01265f60280cb663d019057ce486b60570c1f8) all the interesting `ctx` changes
- [fix(parallel_best): set typeName to "random" when appropriate](https://github.com/0xERR0R/blocky/commit/9af89728c225090fca7a5eae471d9b49d5dbebb7) not related to the `ctx` stuff but did it at the same time
- [refactor: remove deprecated and no-op SingleInflight](https://github.com/0xERR0R/blocky/commit/0dc01c3ee1f75c3027df844cc31d90363631ffbe) also a small but unrelated change

I'd say it's easier to read the commits mentioned above individually, and then scan through the whole lot of changes more quickly.

Progress #1264 