### PR TITLE
refactor(config): remove `GetConfig` and `config` global

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,7 +96,12 @@ linters-settings:
     dot-import-whitelist:
       - "github.com/onsi/ginkgo"
       - "github.com/onsi/gomega"
+      - "github.com/0xERR0R/blocky/config/migration"
       - "github.com/0xERR0R/blocky/helpertest"
+  revive:
+    rules:
+      - name: dot-imports
+        disabled: true # prefer stylecheck since it's more configurable
 
 issues:
   exclude-rules:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,7 +88,7 @@ func initConfig() {
 		util.FatalOnError("unable to load configuration: ", err)
 	}
 
-	log.ConfigureLogger(&cfg.Log)
+	log.Configure(&cfg.Log)
 
 	if len(cfg.Ports.HTTP) != 0 {
 		split := strings.Split(cfg.Ports.HTTP[0], ":")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -40,7 +40,7 @@ func startServer(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to load configuration: %w", err)
 	}
 
-	log.ConfigureLogger(&cfg.Log)
+	log.Configure(&cfg.Log)
 
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 

--- a/config/blocking.go
+++ b/config/blocking.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	. "github.com/0xERR0R/blocky/config/migration" //nolint:revive,stylecheck
+	. "github.com/0xERR0R/blocky/config/migration"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/sirupsen/logrus"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -201,7 +201,6 @@ type Config struct {
 	Redis            RedisConfig         `yaml:"redis"`
 	Log              log.Config          `yaml:"log"`
 	Ports            PortsConfig         `yaml:"ports"`
-	DoHUserAgent     string              `yaml:"dohUserAgent"`
 	MinTLSServeVer   string              `yaml:"minTlsServeVersion" default:"1.2"`
 	CertFile         string              `yaml:"certFile"`
 	KeyFile          string              `yaml:"keyFile"`
@@ -227,6 +226,7 @@ type Config struct {
 		HTTPSPorts          *ListenConfig   `yaml:"httpsPort"`
 		TLSPorts            *ListenConfig   `yaml:"tlsPort"`
 		StartVerifyUpstream *bool           `yaml:"startVerifyUpstream"`
+		DoHUserAgent        *string         `yaml:"dohUserAgent"`
 	} `yaml:",inline"`
 }
 
@@ -523,6 +523,7 @@ func (cfg *Config) migrate(logger *logrus.Entry) bool {
 		"logPrivacy":          Move(To("log.privacy", &cfg.Log)),
 		"logTimestamp":        Move(To("log.timestamp", &cfg.Log)),
 		"startVerifyUpstream": Move(To("upstreams.startVerify", &cfg.Upstreams)),
+		"dohUserAgent":        Move(To("upstreams.userAgent", &cfg.Upstreams)),
 	})
 
 	usesDepredOpts = cfg.Blocking.migrate(logger) || usesDepredOpts

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
 
-	. "github.com/0xERR0R/blocky/config/migration" //nolint:revive,stylecheck
+	. "github.com/0xERR0R/blocky/config/migration"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/util"
 	"github.com/creasty/defaults"

--- a/config/config.go
+++ b/config/config.go
@@ -538,14 +538,6 @@ func (cfg *Config) migrate(logger *logrus.Entry) bool {
 	return usesDepredOpts
 }
 
-// GetConfig returns the current config
-func GetConfig() *Config {
-	cfgLock.RLock()
-	defer cfgLock.RUnlock()
-
-	return config
-}
-
 // ConvertPort converts string representation into a valid port (0 - 65535)
 func ConvertPort(in string) (uint16, error) {
 	const (

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/miekg/dns"
@@ -385,17 +384,8 @@ func WithDefaults[T any]() (T, error) {
 	return cfg, nil
 }
 
-//nolint:gochecknoglobals
-var (
-	config  = &Config{}
-	cfgLock sync.RWMutex
-)
-
 // LoadConfig creates new config from YAML file or a directory containing YAML files
 func LoadConfig(path string, mandatory bool) (rCfg *Config, rerr error) {
-	cfgLock.Lock()
-	defer cfgLock.Unlock()
-
 	cfg, err := WithDefaults[Config]()
 	if err != nil {
 		return nil, err
@@ -404,9 +394,6 @@ func LoadConfig(path string, mandatory bool) (rCfg *Config, rerr error) {
 	defer func() {
 		if rerr == nil {
 			util.LogPrivacy.Store(rCfg.Log.Privacy)
-
-			// We're still holding the lock
-			config = rCfg
 		}
 	}()
 

--- a/config/config.go
+++ b/config/config.go
@@ -189,44 +189,44 @@ func (b *BootstrappedUpstreamConfig) UnmarshalYAML(unmarshal func(interface{}) e
 //
 //nolint:maligned
 type Config struct {
-	Upstreams           Upstreams           `yaml:"upstreams"`
-	ConnectIPVersion    IPVersion           `yaml:"connectIPVersion"`
-	CustomDNS           CustomDNS           `yaml:"customDNS"`
-	Conditional         ConditionalUpstream `yaml:"conditional"`
-	Blocking            Blocking            `yaml:"blocking"`
-	ClientLookup        ClientLookup        `yaml:"clientLookup"`
-	Caching             CachingConfig       `yaml:"caching"`
-	QueryLog            QueryLogConfig      `yaml:"queryLog"`
-	Prometheus          MetricsConfig       `yaml:"prometheus"`
-	Redis               RedisConfig         `yaml:"redis"`
-	Log                 log.Config          `yaml:"log"`
-	Ports               PortsConfig         `yaml:"ports"`
-	DoHUserAgent        string              `yaml:"dohUserAgent"`
-	MinTLSServeVer      string              `yaml:"minTlsServeVersion" default:"1.2"`
-	StartVerifyUpstream bool                `yaml:"startVerifyUpstream" default:"false"`
-	CertFile            string              `yaml:"certFile"`
-	KeyFile             string              `yaml:"keyFile"`
-	BootstrapDNS        BootstrapDNSConfig  `yaml:"bootstrapDns"`
-	HostsFile           HostsFileConfig     `yaml:"hostsFile"`
-	FQDNOnly            FQDNOnly            `yaml:"fqdnOnly"`
-	Filtering           FilteringConfig     `yaml:"filtering"`
-	EDE                 EDE                 `yaml:"ede"`
-	ECS                 ECS                 `yaml:"ecs"`
-	SUDN                SUDN                `yaml:"specialUseDomains"`
+	Upstreams        Upstreams           `yaml:"upstreams"`
+	ConnectIPVersion IPVersion           `yaml:"connectIPVersion"`
+	CustomDNS        CustomDNS           `yaml:"customDNS"`
+	Conditional      ConditionalUpstream `yaml:"conditional"`
+	Blocking         Blocking            `yaml:"blocking"`
+	ClientLookup     ClientLookup        `yaml:"clientLookup"`
+	Caching          CachingConfig       `yaml:"caching"`
+	QueryLog         QueryLogConfig      `yaml:"queryLog"`
+	Prometheus       MetricsConfig       `yaml:"prometheus"`
+	Redis            RedisConfig         `yaml:"redis"`
+	Log              log.Config          `yaml:"log"`
+	Ports            PortsConfig         `yaml:"ports"`
+	DoHUserAgent     string              `yaml:"dohUserAgent"`
+	MinTLSServeVer   string              `yaml:"minTlsServeVersion" default:"1.2"`
+	CertFile         string              `yaml:"certFile"`
+	KeyFile          string              `yaml:"keyFile"`
+	BootstrapDNS     BootstrapDNSConfig  `yaml:"bootstrapDns"`
+	HostsFile        HostsFileConfig     `yaml:"hostsFile"`
+	FQDNOnly         FQDNOnly            `yaml:"fqdnOnly"`
+	Filtering        FilteringConfig     `yaml:"filtering"`
+	EDE              EDE                 `yaml:"ede"`
+	ECS              ECS                 `yaml:"ecs"`
+	SUDN             SUDN                `yaml:"specialUseDomains"`
 
 	// Deprecated options
 	Deprecated struct {
-		Upstream        *UpstreamGroups `yaml:"upstream"`
-		UpstreamTimeout *Duration       `yaml:"upstreamTimeout"`
-		DisableIPv6     *bool           `yaml:"disableIPv6"`
-		LogLevel        *log.Level      `yaml:"logLevel"`
-		LogFormat       *log.FormatType `yaml:"logFormat"`
-		LogPrivacy      *bool           `yaml:"logPrivacy"`
-		LogTimestamp    *bool           `yaml:"logTimestamp"`
-		DNSPorts        *ListenConfig   `yaml:"port"`
-		HTTPPorts       *ListenConfig   `yaml:"httpPort"`
-		HTTPSPorts      *ListenConfig   `yaml:"httpsPort"`
-		TLSPorts        *ListenConfig   `yaml:"tlsPort"`
+		Upstream            *UpstreamGroups `yaml:"upstream"`
+		UpstreamTimeout     *Duration       `yaml:"upstreamTimeout"`
+		DisableIPv6         *bool           `yaml:"disableIPv6"`
+		LogLevel            *log.Level      `yaml:"logLevel"`
+		LogFormat           *log.FormatType `yaml:"logFormat"`
+		LogPrivacy          *bool           `yaml:"logPrivacy"`
+		LogTimestamp        *bool           `yaml:"logTimestamp"`
+		DNSPorts            *ListenConfig   `yaml:"port"`
+		HTTPPorts           *ListenConfig   `yaml:"httpPort"`
+		HTTPSPorts          *ListenConfig   `yaml:"httpsPort"`
+		TLSPorts            *ListenConfig   `yaml:"tlsPort"`
+		StartVerifyUpstream *bool           `yaml:"startVerifyUpstream"`
 	} `yaml:",inline"`
 }
 
@@ -514,14 +514,15 @@ func (cfg *Config) migrate(logger *logrus.Entry) bool {
 				cfg.Filtering.QueryTypes.Insert(dns.Type(dns.TypeAAAA))
 			}
 		}),
-		"port":         Move(To("ports.dns", &cfg.Ports)),
-		"httpPort":     Move(To("ports.http", &cfg.Ports)),
-		"httpsPort":    Move(To("ports.https", &cfg.Ports)),
-		"tlsPort":      Move(To("ports.tls", &cfg.Ports)),
-		"logLevel":     Move(To("log.level", &cfg.Log)),
-		"logFormat":    Move(To("log.format", &cfg.Log)),
-		"logPrivacy":   Move(To("log.privacy", &cfg.Log)),
-		"logTimestamp": Move(To("log.timestamp", &cfg.Log)),
+		"port":                Move(To("ports.dns", &cfg.Ports)),
+		"httpPort":            Move(To("ports.http", &cfg.Ports)),
+		"httpsPort":           Move(To("ports.https", &cfg.Ports)),
+		"tlsPort":             Move(To("ports.tls", &cfg.Ports)),
+		"logLevel":            Move(To("log.level", &cfg.Log)),
+		"logFormat":           Move(To("log.format", &cfg.Log)),
+		"logPrivacy":          Move(To("log.privacy", &cfg.Log)),
+		"logTimestamp":        Move(To("log.timestamp", &cfg.Log)),
+		"startVerifyUpstream": Move(To("upstreams.startVerify", &cfg.Upstreams)),
 	})
 
 	usesDepredOpts = cfg.Blocking.migrate(logger) || usesDepredOpts

--- a/config/config_enum.go
+++ b/config/config_enum.go
@@ -478,6 +478,98 @@ func (x *StartStrategyType) UnmarshalText(text []byte) error {
 }
 
 const (
+	// TLSVersion10 is a TLSVersion of type 1.0.
+	TLSVersion10 TLSVersion = iota + 769
+	// TLSVersion11 is a TLSVersion of type 1.1.
+	TLSVersion11
+	// TLSVersion12 is a TLSVersion of type 1.2.
+	TLSVersion12
+	// TLSVersion13 is a TLSVersion of type 1.3.
+	TLSVersion13
+)
+
+var ErrInvalidTLSVersion = fmt.Errorf("not a valid TLSVersion, try [%s]", strings.Join(_TLSVersionNames, ", "))
+
+const _TLSVersionName = "1.01.11.21.3"
+
+var _TLSVersionNames = []string{
+	_TLSVersionName[0:3],
+	_TLSVersionName[3:6],
+	_TLSVersionName[6:9],
+	_TLSVersionName[9:12],
+}
+
+// TLSVersionNames returns a list of possible string values of TLSVersion.
+func TLSVersionNames() []string {
+	tmp := make([]string, len(_TLSVersionNames))
+	copy(tmp, _TLSVersionNames)
+	return tmp
+}
+
+// TLSVersionValues returns a list of the values for TLSVersion
+func TLSVersionValues() []TLSVersion {
+	return []TLSVersion{
+		TLSVersion10,
+		TLSVersion11,
+		TLSVersion12,
+		TLSVersion13,
+	}
+}
+
+var _TLSVersionMap = map[TLSVersion]string{
+	TLSVersion10: _TLSVersionName[0:3],
+	TLSVersion11: _TLSVersionName[3:6],
+	TLSVersion12: _TLSVersionName[6:9],
+	TLSVersion13: _TLSVersionName[9:12],
+}
+
+// String implements the Stringer interface.
+func (x TLSVersion) String() string {
+	if str, ok := _TLSVersionMap[x]; ok {
+		return str
+	}
+	return fmt.Sprintf("TLSVersion(%d)", x)
+}
+
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
+func (x TLSVersion) IsValid() bool {
+	_, ok := _TLSVersionMap[x]
+	return ok
+}
+
+var _TLSVersionValue = map[string]TLSVersion{
+	_TLSVersionName[0:3]:  TLSVersion10,
+	_TLSVersionName[3:6]:  TLSVersion11,
+	_TLSVersionName[6:9]:  TLSVersion12,
+	_TLSVersionName[9:12]: TLSVersion13,
+}
+
+// ParseTLSVersion attempts to convert a string to a TLSVersion.
+func ParseTLSVersion(name string) (TLSVersion, error) {
+	if x, ok := _TLSVersionValue[name]; ok {
+		return x, nil
+	}
+	return TLSVersion(0), fmt.Errorf("%s is %w", name, ErrInvalidTLSVersion)
+}
+
+// MarshalText implements the text marshaller method.
+func (x TLSVersion) MarshalText() ([]byte, error) {
+	return []byte(x.String()), nil
+}
+
+// UnmarshalText implements the text unmarshaller method.
+func (x *TLSVersion) UnmarshalText(text []byte) error {
+	name := string(text)
+	tmp, err := ParseTLSVersion(name)
+	if err != nil {
+		return err
+	}
+	*x = tmp
+	return nil
+}
+
+const (
 	// UpstreamStrategyParallelBest is a UpstreamStrategy of type Parallel_best.
 	UpstreamStrategyParallelBest UpstreamStrategy = iota
 	// UpstreamStrategyStrict is a UpstreamStrategy of type Strict.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -771,6 +771,7 @@ bootstrapDns:
 func defaultTestFileConfig() {
 	Expect(config.Ports.DNS).Should(Equal(ListenConfig{"55553", ":55554", "[::1]:55555"}))
 	Expect(config.Upstreams.StartVerify).Should(BeFalse())
+	Expect(config.Upstreams.UserAgent).Should(Equal("testBlocky"))
 	Expect(config.Upstreams.Groups["default"]).Should(HaveLen(3))
 	Expect(config.Upstreams.Groups["default"][0].Host).Should(Equal("8.8.8.8"))
 	Expect(config.Upstreams.Groups["default"][1].Host).Should(Equal("8.8.4.4"))
@@ -797,7 +798,6 @@ func defaultTestFileConfig() {
 	Expect(config.Caching.MaxCachingTime).Should(BeZero())
 	Expect(config.Caching.MinCachingTime).Should(BeZero())
 
-	Expect(config.DoHUserAgent).Should(Equal("testBlocky"))
 	Expect(config.MinTLSServeVer).Should(Equal("1.3"))
 
 	Expect(GetConfig()).Should(Not(BeNil()))
@@ -807,6 +807,7 @@ func writeConfigYml(tmpDir *helpertest.TmpFolder) *helpertest.TmpFile {
 	return tmpDir.CreateStringFile("config.yml",
 		"upstreams:",
 		"  startVerify: false",
+		"  userAgent: testBlocky",
 		"  groups:",
 		"    default:",
 		"      - tcp+udp:8.8.8.8",
@@ -859,7 +860,6 @@ func writeConfigYml(tmpDir *helpertest.TmpFolder) *helpertest.TmpFile {
 		"  target: /opt/log",
 		"port: 55553,:55554,[::1]:55555",
 		"logLevel: debug",
-		"dohUserAgent: testBlocky",
 		"minTlsServeVersion: 1.3",
 	)
 }
@@ -868,6 +868,7 @@ func writeConfigDir(tmpDir *helpertest.TmpFolder) error {
 	f1 := tmpDir.CreateStringFile("config1.yaml",
 		"upstreams:",
 		"  startVerify: false",
+		"  userAgent: testBlocky",
 		"  groups:",
 		"    default:",
 		"      - tcp+udp:8.8.8.8",
@@ -884,7 +885,8 @@ func writeConfigDir(tmpDir *helpertest.TmpFolder) error {
 		"filtering:",
 		"  queryTypes:",
 		"    - AAAA",
-		"    - A")
+		"    - A",
+	)
 	if f1.Error != nil {
 		return f1.Error
 	}
@@ -925,7 +927,6 @@ func writeConfigDir(tmpDir *helpertest.TmpFolder) error {
 		"  target: /opt/log",
 		"port: 55553,:55554,[::1]:55555",
 		"logLevel: debug",
-		"dohUserAgent: testBlocky",
 		"minTlsServeVersion: 1.3",
 	)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -799,8 +799,6 @@ func defaultTestFileConfig() {
 	Expect(config.Caching.MinCachingTime).Should(BeZero())
 
 	Expect(config.MinTLSServeVer).Should(Equal("1.3"))
-
-	Expect(GetConfig()).Should(Not(BeNil()))
 }
 
 func writeConfigYml(tmpDir *helpertest.TmpFolder) *helpertest.TmpFile {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -770,6 +770,7 @@ bootstrapDns:
 
 func defaultTestFileConfig() {
 	Expect(config.Ports.DNS).Should(Equal(ListenConfig{"55553", ":55554", "[::1]:55555"}))
+	Expect(config.Upstreams.StartVerify).Should(BeFalse())
 	Expect(config.Upstreams.Groups["default"]).Should(HaveLen(3))
 	Expect(config.Upstreams.Groups["default"][0].Host).Should(Equal("8.8.8.8"))
 	Expect(config.Upstreams.Groups["default"][1].Host).Should(Equal("8.8.4.4"))
@@ -798,7 +799,6 @@ func defaultTestFileConfig() {
 
 	Expect(config.DoHUserAgent).Should(Equal("testBlocky"))
 	Expect(config.MinTLSServeVer).Should(Equal("1.3"))
-	Expect(config.StartVerifyUpstream).Should(BeFalse())
 
 	Expect(GetConfig()).Should(Not(BeNil()))
 }
@@ -806,6 +806,7 @@ func defaultTestFileConfig() {
 func writeConfigYml(tmpDir *helpertest.TmpFolder) *helpertest.TmpFile {
 	return tmpDir.CreateStringFile("config.yml",
 		"upstreams:",
+		"  startVerify: false",
 		"  groups:",
 		"    default:",
 		"      - tcp+udp:8.8.8.8",
@@ -860,12 +861,13 @@ func writeConfigYml(tmpDir *helpertest.TmpFolder) *helpertest.TmpFile {
 		"logLevel: debug",
 		"dohUserAgent: testBlocky",
 		"minTlsServeVersion: 1.3",
-		"startVerifyUpstream: false")
+	)
 }
 
 func writeConfigDir(tmpDir *helpertest.TmpFolder) error {
 	f1 := tmpDir.CreateStringFile("config1.yaml",
 		"upstreams:",
+		"  startVerify: false",
 		"  groups:",
 		"    default:",
 		"      - tcp+udp:8.8.8.8",
@@ -925,7 +927,7 @@ func writeConfigDir(tmpDir *helpertest.TmpFolder) error {
 		"logLevel: debug",
 		"dohUserAgent: testBlocky",
 		"minTlsServeVersion: 1.3",
-		"startVerifyUpstream: false")
+	)
 
 	return f2.Error
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net"
 	"sync/atomic"
@@ -800,7 +801,8 @@ func defaultTestFileConfig(config *Config) {
 	Expect(config.Caching.MaxCachingTime).Should(BeZero())
 	Expect(config.Caching.MinCachingTime).Should(BeZero())
 
-	Expect(config.MinTLSServeVer).Should(Equal("1.3"))
+	Expect(config.MinTLSServeVer).Should(Equal(TLSVersion13))
+	Expect(config.MinTLSServeVer).Should(BeEquivalentTo(tls.VersionTLS13))
 }
 
 func writeConfigYml(tmpDir *helpertest.TmpFolder) *helpertest.TmpFile {

--- a/config/hosts_file.go
+++ b/config/hosts_file.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	. "github.com/0xERR0R/blocky/config/migration" //nolint:revive,stylecheck
+	. "github.com/0xERR0R/blocky/config/migration"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/sirupsen/logrus"
 )

--- a/config/upstreams.go
+++ b/config/upstreams.go
@@ -12,6 +12,7 @@ type Upstreams struct {
 	Groups      UpstreamGroups   `yaml:"groups"`
 	Strategy    UpstreamStrategy `yaml:"strategy" default:"parallel_best"`
 	StartVerify bool             `yaml:"startVerify" default:"false"`
+	UserAgent   string           `yaml:"userAgent"`
 }
 
 type UpstreamGroups map[string][]Upstream

--- a/config/upstreams.go
+++ b/config/upstreams.go
@@ -8,9 +8,10 @@ const UpstreamDefaultCfgName = "default"
 
 // Upstreams upstream servers configuration
 type Upstreams struct {
-	Timeout  Duration         `yaml:"timeout" default:"2s"`
-	Groups   UpstreamGroups   `yaml:"groups"`
-	Strategy UpstreamStrategy `yaml:"strategy" default:"parallel_best"`
+	Timeout     Duration         `yaml:"timeout" default:"2s"`
+	Groups      UpstreamGroups   `yaml:"groups"`
+	Strategy    UpstreamStrategy `yaml:"strategy" default:"parallel_best"`
+	StartVerify bool             `yaml:"startVerify" default:"false"`
 }
 
 type UpstreamGroups map[string][]Upstream
@@ -37,13 +38,32 @@ func (c *Upstreams) LogConfig(logger *logrus.Entry) {
 
 // UpstreamGroup represents the config for one group (upstream branch)
 type UpstreamGroup struct {
-	Name      string
-	Upstreams []Upstream
+	Upstreams
+
+	Name string // group name
+}
+
+// NewUpstreamGroup creates an UpstreamGroup with the given name and upstreams.
+//
+// The upstreams from `cfg.Groups` are ignored.
+func NewUpstreamGroup(name string, cfg Upstreams, upstreams []Upstream) UpstreamGroup {
+	group := UpstreamGroup{
+		Name:      name,
+		Upstreams: cfg,
+	}
+
+	group.Groups = UpstreamGroups{name: upstreams}
+
+	return group
+}
+
+func (c *UpstreamGroup) GroupUpstreams() []Upstream {
+	return c.Groups[c.Name]
 }
 
 // IsEnabled implements `config.Configurable`.
 func (c *UpstreamGroup) IsEnabled() bool {
-	return len(c.Upstreams) != 0
+	return len(c.GroupUpstreams()) != 0
 }
 
 // LogConfig implements `config.Configurable`.
@@ -51,7 +71,7 @@ func (c *UpstreamGroup) LogConfig(logger *logrus.Entry) {
 	logger.Info("group: ", c.Name)
 	logger.Info("upstreams:")
 
-	for _, upstream := range c.Upstreams {
+	for _, upstream := range c.GroupUpstreams() {
 		logger.Infof("  - %s", upstream)
 	}
 }

--- a/config/upstreams_test.go
+++ b/config/upstreams_test.go
@@ -11,7 +11,7 @@ import (
 var _ = Describe("ParallelBestConfig", func() {
 	suiteBeforeEach()
 
-	Context("UpstreamsConfig", func() {
+	Context("Upstreams", func() {
 		var cfg Upstreams
 
 		BeforeEach(func() {
@@ -65,13 +65,13 @@ var _ = Describe("ParallelBestConfig", func() {
 		var cfg UpstreamGroup
 
 		BeforeEach(func() {
-			cfg = UpstreamGroup{
-				Name: UpstreamDefaultCfgName,
-				Upstreams: []Upstream{
-					{Host: "host1"},
-					{Host: "host2"},
-				},
-			}
+			upstreamsCfg, err := WithDefaults[Upstreams]()
+			Expect(err).Should(Succeed())
+
+			cfg = NewUpstreamGroup("test", upstreamsCfg, []Upstream{
+				{Host: "host1"},
+				{Host: "host2"},
+			})
 		})
 
 		Describe("IsEnabled", func() {
@@ -102,7 +102,7 @@ var _ = Describe("ParallelBestConfig", func() {
 				cfg.LogConfig(logger)
 
 				Expect(hook.Calls).ShouldNot(BeEmpty())
-				Expect(hook.Messages).Should(ContainElement(ContainSubstring("group: default")))
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("group: test")))
 				Expect(hook.Messages).Should(ContainElement(ContainSubstring("upstreams:")))
 				Expect(hook.Messages).Should(ContainElement(ContainSubstring(":host1:")))
 				Expect(hook.Messages).Should(ContainElement(ContainSubstring(":host2:")))

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -24,9 +24,8 @@ upstreams:
   strategy: parallel_best
   # optional: timeout to query the upstream resolver. Default: 2s
   timeout: 2s
-
-# optional: If true, blocky will fail to start unless at least one upstream server per group is reachable. Default: false
-startVerifyUpstream: true
+  # optional: If true, blocky will fail to start unless at least one upstream server per group is reachable. Default: false
+  startVerify: false
 
 # optional: Determines how blocky will create outgoing connections. This impacts both upstreams, and lists.
 # accepted: dual, v4, v6

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -26,6 +26,8 @@ upstreams:
   timeout: 2s
   # optional: If true, blocky will fail to start unless at least one upstream server per group is reachable. Default: false
   startVerify: false
+  # optional: HTTP User Agent when connecting to upstreams. Default: none
+  userAgent: "custom UA"
 
 # optional: Determines how blocky will create outgoing connections. This impacts both upstreams, and lists.
 # accepted: dual, v4, v6

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,6 @@ configuration properties as [JSON](config.yml).
 | keyFile             | path                | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated |
 | dohUserAgent        | string              | no        |               | HTTP User Agent for DoH upstreams                                                                          |
 | minTlsServeVersion  | string              | no        | 1.2           | Minimum TLS version that the DoT and DoH server use to serve those encrypted DNS requests                  |
-| startVerifyUpstream | bool                | no        | false         | If true, blocky will fail to start unless at least one upstream server per group is reachable.             |
 | connectIPVersion    | enum (dual, v4, v6) | no        | dual          | IP version to use for outgoing connections (dual, v4, v6)                                                  |
 
 !!! example
@@ -69,6 +68,16 @@ All logging options are optional.
     ```
 
 ## Upstreams configuration
+
+| Parameter             | Type                                 | Mandatory | Default value | Description                                                                                     |
+| --------------------- | ------------------------------------ | --------- | ------------- | ----------------------------------------------------------------------------------------------- |
+| usptreams.groups      | map of name to upstream              | yes       |               | Upstream DNS servers to use, in groups.                                                         |
+| usptreams.startVerify | bool                                 | no        | false         | If true, blocky will fail to start unless at least one upstream server per group is functional. |
+| usptreams.strategy    | enum (parallel_best, random, strict) | no        | parallel_best | Upstream server usage strategy.                                                                 |
+| usptreams.timeout     | duration                             | no        | 2s            | Upstream connection timeout.                                                                    |
+
+
+### Upstream Groups
 
 To resolve a DNS query, blocky needs external public or private DNS resolvers. Blocky supports DNS resolvers with
 following network protocols (net part of the resolver URL):
@@ -133,6 +142,22 @@ The logic determining what group a client belongs to follows a strict order: IP,
 
 If a client matches multiple client name or CIDR groups, a warning is logged and the first found group is used.
 
+### Upstream connection timeout
+
+Blocky will wait 2 seconds (default value) for the response from the external upstream DNS server. You can change this
+value by setting the `timeout` configuration parameter (in **duration format**).
+
+!!! example
+
+    ```yaml
+    upstreams:
+      timeout: 5s
+      groups:
+        default:
+          - 46.182.19.48
+          - 80.241.218.68
+    ```
+
 ### Upstream strategy
 
 Blocky supports different upstream strategies (default `parallel_best`) that determine how and to which upstream DNS servers requests are forwarded.
@@ -160,21 +185,6 @@ Currently available strategies:
           - 9.8.7.6
     ```
 
-### Upstream lookup timeout
-
-Blocky will wait 2 seconds (default value) for the response from the external upstream DNS server. You can change this
-value by setting the `timeout` configuration parameter (in **duration format**).
-
-!!! example
-
-    ```yaml
-    upstreams:
-      timeout: 5s
-      groups:
-        default:
-          - 46.182.19.48
-          - 80.241.218.68
-    ```
 
 ## Bootstrap DNS configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,6 @@ configuration properties as [JSON](config.yml).
 | ------------------- | ------------------- | --------- | ------------- | ---------------------------------------------------------------------------------------------------------- |
 | certFile            | path                | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated |
 | keyFile             | path                | no        |               | Path to cert and key file for SSL encryption (DoH and DoT); if empty, self-signed certificate is generated |
-| dohUserAgent        | string              | no        |               | HTTP User Agent for DoH upstreams                                                                          |
 | minTlsServeVersion  | string              | no        | 1.2           | Minimum TLS version that the DoT and DoH server use to serve those encrypted DNS requests                  |
 | connectIPVersion    | enum (dual, v4, v6) | no        | dual          | IP version to use for outgoing connections (dual, v4, v6)                                                  |
 
@@ -75,6 +74,7 @@ All logging options are optional.
 | usptreams.startVerify | bool                                 | no        | false         | If true, blocky will fail to start unless at least one upstream server per group is functional. |
 | usptreams.strategy    | enum (parallel_best, random, strict) | no        | parallel_best | Upstream server usage strategy.                                                                 |
 | usptreams.timeout     | duration                             | no        | 2s            | Upstream connection timeout.                                                                    |
+| usptreams.userAgent   | string                               | no        |               | HTTP User Agent when connecting to upstreams.                                                   |
 
 
 ### Upstream Groups

--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -13,8 +13,8 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 	var blocky testcontainers.Container
 	var err error
 
-	Describe("'startVerifyUpstream' parameter handling", func() {
-		When("'startVerifyUpstream' is false and upstream server as IP is not reachable", func() {
+	Describe("'upstreams.startVerify' parameter handling", func() {
+		When("'upstreams.startVerify' is false and upstream server as IP is not reachable", func() {
 			BeforeEach(func() {
 				blocky, err = createBlockyContainer(tmpDir,
 					"log:",
@@ -23,7 +23,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 					"  groups:",
 					"    default:",
 					"      - 192.192.192.192",
-					"startVerifyUpstream: false",
+					"  startVerify: false",
 				)
 
 				Expect(err).Should(Succeed())
@@ -34,7 +34,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 				Expect(getContainerLogs(blocky)).Should(BeEmpty())
 			})
 		})
-		When("'startVerifyUpstream' is false and upstream server as host name is not reachable", func() {
+		When("'upstreams.startVerify' is false and upstream server as host name is not reachable", func() {
 			BeforeEach(func() {
 				blocky, err = createBlockyContainer(tmpDir,
 					"log:",
@@ -43,7 +43,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 					"  groups:",
 					"    default:",
 					"      - some.wrong.host",
-					"startVerifyUpstream: false",
+					"  startVerify: false",
 				)
 
 				Expect(err).Should(Succeed())
@@ -54,14 +54,14 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 				Expect(getContainerLogs(blocky)).Should(BeEmpty())
 			})
 		})
-		When("'startVerifyUpstream' is true and upstream as IP address server is not reachable", func() {
+		When("'upstreams.startVerify' is true and upstream as IP address server is not reachable", func() {
 			BeforeEach(func() {
 				blocky, err = createBlockyContainer(tmpDir,
 					"upstreams:",
 					"  groups:",
 					"    default:",
 					"      - 192.192.192.192",
-					"startVerifyUpstream: true",
+					"  startVerify: true",
 				)
 
 				Expect(err).Should(HaveOccurred())
@@ -70,19 +70,17 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 			It("should not start", func() {
 				Expect(blocky.IsRunning()).Should(BeFalse())
 				Expect(getContainerLogs(blocky)).
-					Should(ContainElements(
-						ContainSubstring("creation of upstream branches failed: "),
-						ContainSubstring("no valid upstream for group default")))
+					Should(ContainElement(ContainSubstring("no valid upstream for group default")))
 			})
 		})
-		When("'startVerifyUpstream' is true and upstream server as host name is not reachable", func() {
+		When("'upstreams.startVerify' is true and upstream server as host name is not reachable", func() {
 			BeforeEach(func() {
 				blocky, err = createBlockyContainer(tmpDir,
 					"upstreams:",
 					"  groups:",
 					"    default:",
 					"      - some.wrong.host",
-					"startVerifyUpstream: true",
+					"  startVerify: true",
 				)
 
 				Expect(err).Should(HaveOccurred())
@@ -91,9 +89,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 			It("should not start", func() {
 				Expect(blocky.IsRunning()).Should(BeFalse())
 				Expect(getContainerLogs(blocky)).
-					Should(ContainElements(
-						ContainSubstring("creation of upstream branches failed: "),
-						ContainSubstring("no valid upstream for group default")))
+					Should(ContainElement(ContainSubstring("no valid upstream for group default")))
 			})
 		})
 	})

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -124,7 +124,7 @@ func (b *Bootstrap) resolveUpstream(ctx context.Context, r Resolver, host string
 		ctx, cancel := context.WithTimeout(ctx, b.timeout)
 		defer cancel()
 
-		return b.systemResolver.LookupIP(ctx, config.GetConfig().ConnectIPVersion.Net(), host)
+		return b.systemResolver.LookupIP(ctx, b.connectIPVersion.Net(), host)
 	}
 
 	if ips, ok := b.bootstraped[r]; ok {

--- a/resolver/bootstrap_test.go
+++ b/resolver/bootstrap_test.go
@@ -32,7 +32,6 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 	)
 
 	BeforeEach(func() {
-		config.GetConfig().Upstreams.Strategy = config.UpstreamStrategyParallelBest
 		sutConfig = &config.Config{
 			BootstrapDNS: []config.BootstrappedUpstreamConfig{
 				{
@@ -43,6 +42,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 					IPs: []net.IP{net.IPv4zero},
 				},
 			},
+			Upstreams: defaultUpstreamsConfig,
 		}
 
 		ctx, cancelFn = context.WithCancel(context.Background())
@@ -327,7 +327,7 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				upstream.Host = "localhost" // force bootstrap to do resolve, and not just return the IP as is
 
-				r := newUpstreamResolverUnchecked(upstream, sut)
+				r := newUpstreamResolverUnchecked(newUpstreamConfig(upstream, sutConfig.Upstreams), sut)
 
 				rsp, err := r.Resolve(ctx, mainReq)
 				Expect(err).Should(Succeed())

--- a/resolver/client_names_resolver.go
+++ b/resolver/client_names_resolver.go
@@ -28,11 +28,11 @@ type ClientNamesResolver struct {
 
 // NewClientNamesResolver creates new resolver instance
 func NewClientNamesResolver(ctx context.Context,
-	cfg config.ClientLookup, bootstrap *Bootstrap, shouldVerifyUpstreams bool,
+	cfg config.ClientLookup, upstreamsCfg config.Upstreams, bootstrap *Bootstrap,
 ) (cr *ClientNamesResolver, err error) {
 	var r Resolver
 	if !cfg.Upstream.IsDefault() {
-		r, err = NewUpstreamResolver(ctx, cfg.Upstream, bootstrap, shouldVerifyUpstreams)
+		r, err = NewUpstreamResolver(ctx, newUpstreamConfig(cfg.Upstream, upstreamsCfg), bootstrap)
 		if err != nil {
 			return nil, err
 		}

--- a/resolver/client_names_resolver_test.go
+++ b/resolver/client_names_resolver_test.go
@@ -39,7 +39,7 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 		ctx, cancelFn = context.WithCancel(context.Background())
 		DeferCleanup(cancelFn)
 
-		sut, err = NewClientNamesResolver(ctx, sutConfig, nil, false)
+		sut, err = NewClientNamesResolver(ctx, sutConfig, defaultUpstreamsConfig, nil)
 		Expect(err).Should(Succeed())
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
@@ -370,9 +370,12 @@ var _ = Describe("ClientResolver", Label("clientNamesResolver"), func() {
 			It("errors during construction", func() {
 				b := newTestBootstrap(ctx, &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
 
+				upstreamsCfg := defaultUpstreamsConfig
+				upstreamsCfg.StartVerify = true
+
 				r, err := NewClientNamesResolver(ctx, config.ClientLookup{
 					Upstream: config.Upstream{Host: "example.com"},
-				}, b, true)
+				}, upstreamsCfg, b)
 
 				Expect(err).ShouldNot(Succeed())
 				Expect(r).Should(BeNil())

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
@@ -24,14 +25,15 @@ type ConditionalUpstreamResolver struct {
 
 // NewConditionalUpstreamResolver returns new resolver instance
 func NewConditionalUpstreamResolver(
-	ctx context.Context, cfg config.ConditionalUpstream, bootstrap *Bootstrap, shouldVerifyUpstreams bool,
+	ctx context.Context, cfg config.ConditionalUpstream, upstreamsCfg config.Upstreams, bootstrap *Bootstrap,
 ) (*ConditionalUpstreamResolver, error) {
 	m := make(map[string]Resolver, len(cfg.Mapping.Upstreams))
 
 	for domain, upstreams := range cfg.Mapping.Upstreams {
-		cfg := config.UpstreamGroup{Name: upstreamDefaultCfgName, Upstreams: upstreams}
+		name := fmt.Sprintf("<conditional in %s>", domain)
+		cfg := config.NewUpstreamGroup(name, upstreamsCfg, upstreams)
 
-		r, err := NewParallelBestResolver(ctx, cfg, bootstrap, shouldVerifyUpstreams)
+		r, err := NewParallelBestResolver(ctx, cfg, bootstrap)
 		if err != nil {
 			return nil, err
 		}

--- a/resolver/resolver_suite_test.go
+++ b/resolver/resolver_suite_test.go
@@ -1,20 +1,33 @@
-package resolver_test
+package resolver
 
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/log"
-
 	"github.com/go-redis/redis/v8"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+var defaultUpstreamsConfig config.Upstreams
+
 func init() {
 	log.Silence()
 	redis.SetLogger(NoLogs{})
+
+	var err error
+
+	defaultUpstreamsConfig, err = config.WithDefaults[config.Upstreams]()
+	if err != nil {
+		panic(err)
+	}
+
+	// Shorter timeout for tests
+	defaultUpstreamsConfig.Timeout = config.Duration(50 * time.Millisecond)
 }
 
 func TestResolver(t *testing.T) {

--- a/resolver/strict_resolver_test.go
+++ b/resolver/strict_resolver_test.go
@@ -61,8 +61,6 @@ var _ = Describe("StrictResolver", Label("strictResolver"), func() {
 		sut, err = NewStrictResolver(ctx, sutConfig, bootstrap)
 	})
 
-	config.GetConfig().Upstreams.Timeout = config.Duration(time.Second)
-
 	Describe("IsEnabled", func() {
 		It("is true", func() {
 			Expect(sut.IsEnabled()).Should(BeTrue())
@@ -167,9 +165,10 @@ var _ = Describe("StrictResolver", Label("strictResolver"), func() {
 				})
 				When("first upstream exceeds upstreamTimeout", func() {
 					BeforeEach(func() {
+						timeout := sut.cfg.Timeout.ToDuration()
 						testUpstream1 := NewMockUDPUpstreamServer().WithAnswerFn(func(request *dns.Msg) (response *dns.Msg) {
 							response, err := util.NewMsgWithAnswer("example.com", 123, A, "123.124.122.1")
-							time.Sleep(time.Duration(config.GetConfig().Upstreams.Timeout) + 2*time.Second)
+							time.Sleep(2 * timeout)
 
 							Expect(err).To(Succeed())
 
@@ -195,9 +194,10 @@ var _ = Describe("StrictResolver", Label("strictResolver"), func() {
 				})
 				When("all upstreams exceed upsteamTimeout", func() {
 					BeforeEach(func() {
+						timeout := sut.cfg.Timeout.ToDuration()
 						testUpstream1 := NewMockUDPUpstreamServer().WithAnswerFn(func(request *dns.Msg) (response *dns.Msg) {
 							response, err := util.NewMsgWithAnswer("example.com", 123, A, "123.124.122.1")
-							time.Sleep(config.GetConfig().Upstreams.Timeout.ToDuration() + 2*time.Second)
+							time.Sleep(2 * timeout)
 
 							Expect(err).To(Succeed())
 
@@ -207,7 +207,7 @@ var _ = Describe("StrictResolver", Label("strictResolver"), func() {
 
 						testUpstream2 := NewMockUDPUpstreamServer().WithAnswerFn(func(request *dns.Msg) (response *dns.Msg) {
 							response, err := util.NewMsgWithAnswer("example.com", 123, A, "123.124.122.2")
-							time.Sleep(config.GetConfig().Upstreams.Timeout.ToDuration() + 2*time.Second)
+							time.Sleep(2 * timeout)
 
 							Expect(err).To(Succeed())
 

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -73,8 +73,9 @@ type dnsUpstreamClient struct {
 }
 
 type httpUpstreamClient struct {
-	client *http.Client
-	host   string
+	client    *http.Client
+	host      string
+	userAgent string
 }
 
 func createUpstreamClient(cfg upstreamConfig) upstreamClient {
@@ -90,6 +91,7 @@ func createUpstreamClient(cfg upstreamConfig) upstreamClient {
 	switch cfg.Net {
 	case config.NetProtocolHttps:
 		return &httpUpstreamClient{
+			userAgent: cfg.UserAgent,
 			client: &http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig:     &tlsConfig,
@@ -143,7 +145,7 @@ func (r *httpUpstreamClient) callExternal(
 		return nil, 0, fmt.Errorf("can't create the new request %w", err)
 	}
 
-	req.Header.Set("User-Agent", config.GetConfig().DoHUserAgent)
+	req.Header.Set("User-Agent", r.userAgent)
 	req.Header.Set("Content-Type", dnsContentType)
 	req.Host = r.host
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -179,9 +179,6 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	// Hacky but needed to update the global since we still have code that reads it
-	*config.GetConfig() = *cfg
-
 	// create server
 	sut, err = NewServer(ctx, cfg)
 	Expect(err).Should(Succeed())

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -697,62 +697,6 @@ var _ = Describe("Running DNS server", func() {
 		})
 	})
 
-	Describe("NewServer with strict upstream strategy", func() {
-		It("successfully returns upstream branches", func() {
-			branches, err := createUpstreamBranches(context.Background(), &config.Config{
-				Upstreams: config.Upstreams{
-					Strategy: config.UpstreamStrategyStrict,
-					Groups: config.UpstreamGroups{
-						"default": {{Host: "0.0.0.0"}},
-					},
-				},
-			}, nil)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(branches).ToNot(BeNil())
-			Expect(branches).To(HaveLen(1))
-			_ = branches["default"].(*resolver.StrictResolver)
-		})
-	})
-
-	Describe("NewServer with random upstream strategy", func() {
-		It("successfully returns upstream branches", func() {
-			branches, err := createUpstreamBranches(context.Background(), &config.Config{
-				Upstreams: config.Upstreams{
-					Strategy: config.UpstreamStrategyRandom,
-					Groups: config.UpstreamGroups{
-						"default": {{Host: "0.0.0.0"}},
-					},
-				},
-			}, nil)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(branches).ToNot(BeNil())
-			Expect(branches).To(HaveLen(1))
-			_ = branches["default"].(*resolver.ParallelBestResolver)
-		})
-	})
-
-	Describe("create query resolver", func() {
-		When("some upstream returns error", func() {
-			It("create query resolver should return error", func() {
-				r, err := createQueryResolver(ctx, &config.Config{
-					StartVerifyUpstream: true,
-					Upstreams: config.Upstreams{
-						Groups: config.UpstreamGroups{
-							"default": {{Host: "0.0.0.0"}},
-						},
-					},
-				},
-					nil, nil)
-
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("creation of upstream branches failed: ")))
-				Expect(r).To(BeNil())
-			})
-		})
-	})
-
 	Describe("resolve client IP", func() {
 		Context("UDP address", func() {
 			It("should correct resolve client IP", func() {

--- a/util/common.go
+++ b/util/common.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"net"
 	"path/filepath"
 	"regexp"
@@ -159,7 +160,14 @@ func LogOnErrorWithEntry(logEntry *logrus.Entry, message string, err error) {
 // FatalOnError logs the message only if error is not nil and exits the program execution
 func FatalOnError(message string, err error) {
 	if err != nil {
-		log.Log().Fatal(message, err)
+		logger := log.Log()
+
+		// Make sure the error is printend even if the log has been silenced
+		if logger.Out == io.Discard {
+			log.ConfigureLogger(logger, log.DefaultConfig())
+		}
+
+		logger.Fatal(message, err)
 	}
 }
 

--- a/util/common.go
+++ b/util/common.go
@@ -9,19 +9,29 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 
-	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/log"
 
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
 )
 
-var alphanumeric = regexp.MustCompile("[a-zA-Z0-9]")
+//nolint:gochecknoglobals
+var (
+	// To avoid making this package depend on config, we use a global
+	// that is set at config load.
+	// Ideally we'd move the obfuscate code somewhere else (maybe into `log`),
+	// but that would require also moving all its dependencies.
+	// This is good enough for now.
+	LogPrivacy atomic.Bool
+
+	alphanumeric = regexp.MustCompile("[a-zA-Z0-9]")
+)
 
 // Obfuscate replaces all alphanumeric characters with * to obfuscate user sensitive data if LogPrivacy is enabled
 func Obfuscate(in string) string {
-	if config.GetConfig().Log.Privacy {
+	if LogPrivacy.Load() {
 		return alphanumeric.ReplaceAllString(in, "*")
 	}
 


### PR DESCRIPTION
First step  towards completely removing the `config` global: remove `GetConfig`.  
This is done by moving a couple options under `Upstreams` and embedding `Upstreams` into `UpstreamGroup` so we can access those options from resolvers easily.

~I'll completely remove the global in a followup PR.~ It was easier than I thought, done!

---

[Rendered docs](https://thinkchaos.github.io/blocky/refactor-private-config-global/configuration/#upstreams-configuration)