### PR TITLE
Refactoring Redis

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,18 +31,12 @@
         "GitHub.vscode-github-actions"
       ],
       "settings": {
-        "go.lintFlags": ["--config=${containerWorkspaceFolder}/.golangci.yml"],
+        "go.lintFlags": [
+          "--config=${containerWorkspaceFolder}/.golangci.yml",
+          "--fast"
+        ],
         "go.alternateTools": {
           "go-langserver": "gopls"
-        },
-        "[go]": {
-          "editor.defaultFormatter": "golang.go"
-        },
-        "[json][jsonc][github-actions-workflow]": {
-          "editor.defaultFormatter": "esbenp.prettier-vscode"
-        },
-        "[markdown]": {
-          "editor.defaultFormatter": "yzhang.markdown-all-in-one"
         },
         "markiscodecoverage.searchCriteria": "**/*.lcov",
         "runItOn": {
@@ -52,6 +46,15 @@
               "cmd": "${workspaceRoot}/.devcontainer/scripts/runItOnGo.sh ${fileDirname} ${workspaceRoot}"
             }
           ]
+        },
+        "[go]": {
+          "editor.defaultFormatter": "golang.go"
+        },
+        "[json][jsonc][github-actions-workflow]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[markdown]": {
+          "editor.defaultFormatter": "yzhang.markdown-all-in-one"
         }
       }
     }

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,3 +98,7 @@ issues:
         - gochecknoinits
         - gochecknoglobals
         - gosec
+    - path: _test\.go
+      linters:
+        - staticcheck
+      text: "SA1012:"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "source.organizeImports": true,
     "source.fixAll": true
   },
+  "editor.rulers": [120],
   "go.showWelcome": false,
   "go.survey.prompt": false,
   "go.useLanguageServer": true,
@@ -18,8 +19,5 @@
     "ui.semanticTokens": true,
     "formatting.gofumpt": true,
     "build.standaloneTags": ["ignore", "tools"]
-  },
-  "[go]": {
-    "editor.rulers": [120]
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,6 @@
     "build.standaloneTags": ["ignore", "tools"]
   },
   "[go]": {
-    "editor.rulers": [111]
+    "editor.rulers": [120]
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,8 @@
     "ui.semanticTokens": true,
     "formatting.gofumpt": true,
     "build.standaloneTags": ["ignore", "tools"]
+  },
+  "[go]": {
+    "editor.rulers": [111]
   }
 }

--- a/api/api_interface_impl.go
+++ b/api/api_interface_impl.go
@@ -29,8 +29,8 @@ type BlockingStatus struct {
 
 // BlockingControl interface to control the blocking status
 type BlockingControl interface {
-	EnableBlocking()
-	DisableBlocking(duration time.Duration, disableGroups []string) error
+	EnableBlocking(ctx context.Context)
+	DisableBlocking(ctx context.Context, duration time.Duration, disableGroups []string) error
 	BlockingStatus() BlockingStatus
 }
 
@@ -71,7 +71,7 @@ func NewOpenAPIInterfaceImpl(control BlockingControl,
 	}
 }
 
-func (i *OpenAPIInterfaceImpl) DisableBlocking(_ context.Context,
+func (i *OpenAPIInterfaceImpl) DisableBlocking(ctx context.Context,
 	request DisableBlockingRequestObject,
 ) (DisableBlockingResponseObject, error) {
 	var (
@@ -91,7 +91,7 @@ func (i *OpenAPIInterfaceImpl) DisableBlocking(_ context.Context,
 		groups = strings.Split(*request.Params.Groups, ",")
 	}
 
-	err = i.control.DisableBlocking(duration, groups)
+	err = i.control.DisableBlocking(ctx, duration, groups)
 
 	if err != nil {
 		return DisableBlocking400TextResponse(log.EscapeInput(err.Error())), nil
@@ -100,9 +100,9 @@ func (i *OpenAPIInterfaceImpl) DisableBlocking(_ context.Context,
 	return DisableBlocking200Response{}, nil
 }
 
-func (i *OpenAPIInterfaceImpl) EnableBlocking(_ context.Context, _ EnableBlockingRequestObject,
+func (i *OpenAPIInterfaceImpl) EnableBlocking(ctx context.Context, _ EnableBlockingRequestObject,
 ) (EnableBlockingResponseObject, error) {
-	i.control.EnableBlocking()
+	i.control.EnableBlocking(ctx)
 
 	return EnableBlocking200Response{}, nil
 }

--- a/api/api_interface_impl_test.go
+++ b/api/api_interface_impl_test.go
@@ -37,11 +37,11 @@ func (m *ListRefreshMock) RefreshLists() error {
 	return args.Error(0)
 }
 
-func (m *BlockingControlMock) EnableBlocking() {
+func (m *BlockingControlMock) EnableBlocking(_ context.Context) {
 	_ = m.Called()
 }
 
-func (m *BlockingControlMock) DisableBlocking(t time.Duration, g []string) error {
+func (m *BlockingControlMock) DisableBlocking(_ context.Context, t time.Duration, g []string) error {
 	args := m.Called(t, g)
 
 	return args.Error(0)

--- a/config/config.go
+++ b/config/config.go
@@ -219,7 +219,7 @@ type Config struct {
 	Caching          CachingConfig       `yaml:"caching"`
 	QueryLog         QueryLogConfig      `yaml:"queryLog"`
 	Prometheus       MetricsConfig       `yaml:"prometheus"`
-	Redis            RedisConfig         `yaml:"redis"`
+	Redis            Redis               `yaml:"redis"`
 	Log              log.Config          `yaml:"log"`
 	Ports            PortsConfig         `yaml:"ports"`
 	MinTLSServeVer   TLSVersion          `yaml:"minTlsServeVersion" default:"1.2"`
@@ -280,8 +280,8 @@ type (
 	}
 )
 
-// RedisConfig configuration for the redis connection
-type RedisConfig struct {
+// Redis configuration for the redis connection
+type Redis struct {
 	Address            string   `yaml:"address"`
 	Username           string   `yaml:"username" default:""`
 	Password           string   `yaml:"password" default:""`

--- a/config/config.go
+++ b/config/config.go
@@ -280,20 +280,6 @@ type (
 	}
 )
 
-// Redis configuration for the redis connection
-type Redis struct {
-	Address            string   `yaml:"address"`
-	Username           string   `yaml:"username" default:""`
-	Password           string   `yaml:"password" default:""`
-	Database           int      `yaml:"database" default:"0"`
-	Required           bool     `yaml:"required" default:"false"`
-	ConnectionAttempts int      `yaml:"connectionAttempts" default:"3"`
-	ConnectionCooldown Duration `yaml:"connectionCooldown" default:"1s"`
-	SentinelUsername   string   `yaml:"sentinelUsername" default:""`
-	SentinelPassword   string   `yaml:"sentinelPassword" default:""`
-	SentinelAddresses  []string `yaml:"sentinelAddresses"`
-}
-
 type (
 	FQDNOnly = toEnable
 	EDE      = toEnable

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Config", func() {
 				err = writeConfigDir(tmpDir)
 				Expect(err).Should(Succeed())
 
-				_, err := LoadConfig(tmpDir.Path, true)
+				c, err = LoadConfig(tmpDir.Path, true)
 				Expect(err).Should(Succeed())
 
 				defaultTestFileConfig(c)

--- a/config/redis.go
+++ b/config/redis.go
@@ -1,0 +1,15 @@
+package config
+
+// Redis configuration for the redis connection
+type Redis struct {
+	Address            string   `yaml:"address"`
+	Username           string   `yaml:"username" default:""`
+	Password           string   `yaml:"password" default:""`
+	Database           int      `yaml:"database" default:"0"`
+	Required           bool     `yaml:"required" default:"false"`
+	ConnectionAttempts int      `yaml:"connectionAttempts" default:"3"`
+	ConnectionCooldown Duration `yaml:"connectionCooldown" default:"1s"`
+	SentinelUsername   string   `yaml:"sentinelUsername" default:""`
+	SentinelPassword   string   `yaml:"sentinelPassword" default:""`
+	SentinelAddresses  []string `yaml:"sentinelAddresses"`
+}

--- a/config/redis.go
+++ b/config/redis.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"regexp"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )

--- a/config/redis.go
+++ b/config/redis.go
@@ -53,11 +53,5 @@ func (c *Redis) LogConfig(logger *logrus.Entry) {
 
 // obfuscatePassword replaces all characters of a password except the first and last with *
 func obfuscatePassword(pass string) string {
-	if pass == "" {
-		return ""
-	}
-
-	re := regexp.MustCompile(`^(.).*(.)$`)
-
-	return re.ReplaceAllString(pass, `$1*****$2`)
+	return strings.Repeat("*", len(pass))
 }

--- a/config/redis.go
+++ b/config/redis.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+)
+
 // Redis configuration for the redis connection
 type Redis struct {
 	Address            string   `yaml:"address"`
@@ -12,4 +18,46 @@ type Redis struct {
 	SentinelUsername   string   `yaml:"sentinelUsername" default:""`
 	SentinelPassword   string   `yaml:"sentinelPassword" default:""`
 	SentinelAddresses  []string `yaml:"sentinelAddresses"`
+}
+
+// IsEnabled implements `config.Configurable`
+func (c *Redis) IsEnabled() bool {
+	return c.Address != ""
+}
+
+// LogConfig implements `config.Configurable`
+func (c *Redis) LogConfig(logger *logrus.Entry) {
+	if len(c.SentinelAddresses) == 0 {
+		logger.Info("Address: ", c.Address)
+	}
+
+	logger.Info("Username: ", c.Username)
+	logger.Info("Password: ", obfuscatePassword(c.Password))
+	logger.Info("Database: ", c.Database)
+	logger.Info("Required: ", c.Required)
+	logger.Info("ConnectionAttempts: ", c.ConnectionAttempts)
+	logger.Info("ConnectionCooldown: ", c.ConnectionCooldown)
+
+	if len(c.SentinelAddresses) > 0 {
+		logger.Info("Sentinel:")
+		logger.Info("  MasterName: ", c.Address)
+		logger.Info("  Username: ", c.SentinelUsername)
+		logger.Info("  Password: ", obfuscatePassword(c.SentinelPassword))
+		logger.Info("  Addresses:")
+
+		for _, addr := range c.SentinelAddresses {
+			logger.Info("    - ", addr)
+		}
+	}
+}
+
+// obfuscatePassword replaces all characters of a password except the first and last with *
+func obfuscatePassword(pass string) string {
+	if pass == "" {
+		return ""
+	}
+
+	re := regexp.MustCompile(`^(.).*(.)$`)
+
+	return re.ReplaceAllString(pass, `$1*****$2`)
 }

--- a/config/redis.go
+++ b/config/redis.go
@@ -28,22 +28,22 @@ func (c *Redis) IsEnabled() bool {
 // LogConfig implements `config.Configurable`
 func (c *Redis) LogConfig(logger *logrus.Entry) {
 	if len(c.SentinelAddresses) == 0 {
-		logger.Info("Address: ", c.Address)
+		logger.Info("address: ", c.Address)
 	}
 
-	logger.Info("Username: ", c.Username)
-	logger.Info("Password: ", obfuscatePassword(c.Password))
-	logger.Info("Database: ", c.Database)
-	logger.Info("Required: ", c.Required)
-	logger.Info("ConnectionAttempts: ", c.ConnectionAttempts)
-	logger.Info("ConnectionCooldown: ", c.ConnectionCooldown)
+	logger.Info("username: ", c.Username)
+	logger.Info("password: ", obfuscatePassword(c.Password))
+	logger.Info("database: ", c.Database)
+	logger.Info("required: ", c.Required)
+	logger.Info("connectionAttempts: ", c.ConnectionAttempts)
+	logger.Info("connectionCooldown: ", c.ConnectionCooldown)
 
 	if len(c.SentinelAddresses) > 0 {
-		logger.Info("Sentinel:")
-		logger.Info("  MasterName: ", c.Address)
-		logger.Info("  Username: ", c.SentinelUsername)
-		logger.Info("  Password: ", obfuscatePassword(c.SentinelPassword))
-		logger.Info("  Addresses:")
+		logger.Info("sentinel:")
+		logger.Info("  master: ", c.Address)
+		logger.Info("  username: ", c.SentinelUsername)
+		logger.Info("  password: ", obfuscatePassword(c.SentinelPassword))
+		logger.Info("  addresses:")
 
 		for _, addr := range c.SentinelAddresses {
 			logger.Info("    - ", addr)

--- a/config/redis_test.go
+++ b/config/redis_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"github.com/0xERR0R/blocky/log"
+	"github.com/creasty/defaults"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Redis", func() {
+	var (
+		c   Redis
+		err error
+	)
+
+	suiteBeforeEach()
+
+	BeforeEach(func() {
+		err = defaults.Set(&c)
+		Expect(err).Should(Succeed())
+	})
+
+	Describe("IsEnabled", func() {
+		When("all fields are default", func() {
+			It("should be disabled", func() {
+				Expect(c.IsEnabled()).Should(BeFalse())
+			})
+		})
+
+		When("Address is set", func() {
+			BeforeEach(func() {
+				c.Address = "localhost:6379"
+			})
+
+			It("should be enabled", func() {
+				Expect(c.IsEnabled()).Should(BeTrue())
+			})
+		})
+	})
+
+	Describe("LogConfig", func() {
+		BeforeEach(func() {
+			logger, hook = log.NewMockEntry()
+		})
+
+		When("all fields are default", func() {
+			It("should log default values", func() {
+				c.LogConfig(logger)
+
+				Expect(hook.Messages).Should(
+					SatisfyAll(ContainElement(ContainSubstring("Address: ")),
+						ContainElement(ContainSubstring("Username: ")),
+						ContainElement(ContainSubstring("Password: ")),
+						ContainElement(ContainSubstring("Database: ")),
+						ContainElement(ContainSubstring("Required: ")),
+						ContainElement(ContainSubstring("ConnectionAttempts: ")),
+						ContainElement(ContainSubstring("ConnectionCooldown: "))))
+			})
+		})
+
+		When("Address is set", func() {
+			BeforeEach(func() {
+				c.Address = "localhost:6379"
+			})
+
+			It("should log address", func() {
+				c.LogConfig(logger)
+
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("Address: localhost:6379")))
+			})
+		})
+
+		When("SentinelAddresses is set", func() {
+			BeforeEach(func() {
+				c.SentinelAddresses = []string{"localhost:26379", "localhost:26380"}
+			})
+
+			It("should log sentinel addresses", func() {
+				c.LogConfig(logger)
+
+				Expect(hook.Messages).Should(
+					SatisfyAll(
+						ContainElement(ContainSubstring("Sentinel:")),
+						ContainElement(ContainSubstring("  Addresses:")),
+						ContainElement(ContainSubstring("  - localhost:26379")),
+						ContainElement(ContainSubstring("  - localhost:26380"))))
+			})
+		})
+	})
+
+	Describe("obfuscatePassword", func() {
+		When("password is empty", func() {
+			It("should return empty string", func() {
+				Expect(obfuscatePassword("")).Should(Equal(""))
+			})
+		})
+
+		When("password is not empty", func() {
+			It("should return obfuscated password", func() {
+				Expect(obfuscatePassword("test123")).Should(Equal("t*****3"))
+			})
+		})
+	})
+})

--- a/config/redis_test.go
+++ b/config/redis_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Redis", func() {
 			It("should log address", func() {
 				c.LogConfig(logger)
 
-				Expect(hook.Messages).Should(ContainElement(ContainSubstring("Address: localhost:6379")))
+				Expect(hook.Messages).Should(ContainElement(ContainSubstring("address: localhost:6379")))
 			})
 		})
 

--- a/config/redis_test.go
+++ b/config/redis_test.go
@@ -80,8 +80,8 @@ var _ = Describe("Redis", func() {
 
 				Expect(hook.Messages).Should(
 					SatisfyAll(
-						ContainElement(ContainSubstring("Sentinel:")),
-						ContainElement(ContainSubstring("  Addresses:")),
+						ContainElement(ContainSubstring("sentinel:")),
+						ContainElement(ContainSubstring("  addresses:")),
 						ContainElement(ContainSubstring("  - localhost:26379")),
 						ContainElement(ContainSubstring("  - localhost:26380"))))
 			})

--- a/config/redis_test.go
+++ b/config/redis_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Redis", func() {
 
 		When("password is not empty", func() {
 			It("should return obfuscated password", func() {
-				Expect(obfuscatePassword("test123")).Should(Equal("t*****3"))
+				Expect(obfuscatePassword("test123")).Should(Equal("*******"))
 			})
 		})
 	})

--- a/config/redis_test.go
+++ b/config/redis_test.go
@@ -48,13 +48,13 @@ var _ = Describe("Redis", func() {
 				c.LogConfig(logger)
 
 				Expect(hook.Messages).Should(
-					SatisfyAll(ContainElement(ContainSubstring("Address: ")),
-						ContainElement(ContainSubstring("Username: ")),
-						ContainElement(ContainSubstring("Password: ")),
-						ContainElement(ContainSubstring("Database: ")),
-						ContainElement(ContainSubstring("Required: ")),
-						ContainElement(ContainSubstring("ConnectionAttempts: ")),
-						ContainElement(ContainSubstring("ConnectionCooldown: "))))
+					SatisfyAll(ContainElement(ContainSubstring("address: ")),
+						ContainElement(ContainSubstring("username: ")),
+						ContainElement(ContainSubstring("password: ")),
+						ContainElement(ContainSubstring("database: ")),
+						ContainElement(ContainSubstring("required: ")),
+						ContainElement(ContainSubstring("connectionAttempts: ")),
+						ContainElement(ContainSubstring("connectionCooldown: "))))
 			})
 		})
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -134,7 +134,7 @@ func (c *Client) PublishCache(key string, message *dns.Msg) {
 	}
 }
 
-func (c *Client) PublishEnabled(state *EnabledMessage) {
+func (c *Client) PublishEnabled(ctx context.Context, state *EnabledMessage) {
 	binState, sErr := json.Marshal(state)
 	if sErr == nil {
 		binMsg, mErr := json.Marshal(redisMessage{
@@ -144,7 +144,7 @@ func (c *Client) PublishEnabled(state *EnabledMessage) {
 		})
 
 		if mErr == nil {
-			c.client.Publish(c.ctx, SyncChannelName, binMsg)
+			c.client.Publish(ctx, SyncChannelName, binMsg)
 		}
 	}
 }

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -59,7 +59,6 @@ type Client struct {
 	config         *config.Redis
 	client         *redis.Client
 	l              *logrus.Entry
-	ctx            context.Context
 	id             []byte
 	sendBuffer     chan *bufferMessage
 	CacheChannel   chan *CacheMessage

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -155,13 +155,13 @@ func (c *Client) GetRedisCache(ctx context.Context) {
 	c.l.Debug("GetRedisCache")
 
 	go func() {
-		select {
-		case <-ctx.Done():
+		iter := c.client.Scan(ctx, 0, prefixKey("*"), 0).Iterator()
+		if err := iter.Err(); err != nil {
+			c.l.Error("GetRedisCache ", err)
+
 			return
-		default:
 		}
 
-		iter := c.client.Scan(ctx, 0, prefixKey("*"), 0).Iterator()
 		for iter.Next(ctx) {
 			response, err := c.getResponse(ctx, iter.Val())
 			if err == nil {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -169,8 +169,7 @@ func (c *Client) GetRedisCache(ctx context.Context) {
 					select {
 					case <-ctx.Done():
 						return
-					default:
-						c.CacheChannel <- response
+					case c.CacheChannel <- response:
 					}
 				}
 			} else {
@@ -238,12 +237,6 @@ func (c *Client) publishMessageFromBuffer(ctx context.Context, s *bufferMessage)
 }
 
 func (c *Client) processReceivedMessage(ctx context.Context, msg *redis.Message) {
-	select {
-	case <-ctx.Done():
-		return
-	default:
-	}
-
 	var rm redisMessage
 
 	if err := json.Unmarshal([]byte(msg.Payload), &rm); err != nil {
@@ -267,9 +260,7 @@ func (c *Client) processReceivedMessage(ctx context.Context, msg *redis.Message)
 
 			select {
 			case <-ctx.Done():
-				return
-			default:
-				c.CacheChannel <- cm
+			case c.CacheChannel <- cm:
 			}
 		case messageTypeEnable:
 			var msg EnabledMessage
@@ -282,9 +273,7 @@ func (c *Client) processReceivedMessage(ctx context.Context, msg *redis.Message)
 
 			select {
 			case <-ctx.Done():
-				return
-			default:
-				c.EnabledChannel <- &msg
+			case c.EnabledChannel <- &msg:
 			}
 		default:
 			c.l.Warn("Unknown message type: ", rm.Type)

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -70,10 +70,6 @@ func New(ctx context.Context, cfg *config.Redis) (*Client, error) {
 	// disable redis if no address is provided
 	if cfg == nil || len(cfg.Address) == 0 {
 		return nil, nil //nolint:nilnil
-	} else if ctx == nil {
-		return nil, fmt.Errorf("context is nil")
-	} else if ctx.Err() != nil {
-		return nil, fmt.Errorf("context is done")
 	}
 
 	var baseClient *redis.Client

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -153,12 +153,12 @@ func (c *Client) PublishEnabled(state *EnabledMessage) {
 }
 
 // GetRedisCache reads the redis cache and publish it to the channel
-func (c *Client) GetRedisCache() {
+func (c *Client) GetRedisCache(ctx context.Context) {
 	c.l.Debug("GetRedisCache")
 
 	go func() {
-		iter := c.client.Scan(c.ctx, 0, prefixKey("*"), 0).Iterator()
-		for iter.Next(c.ctx) {
+		iter := c.client.Scan(ctx, 0, prefixKey("*"), 0).Iterator()
+		for iter.Next(ctx) {
 			response, err := c.getResponse(iter.Val())
 			if err == nil {
 				if response != nil {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -56,7 +56,7 @@ type EnabledMessage struct {
 
 // Client for redis communication
 type Client struct {
-	config         *config.RedisConfig
+	config         *config.Redis
 	client         *redis.Client
 	l              *logrus.Entry
 	ctx            context.Context
@@ -67,7 +67,7 @@ type Client struct {
 }
 
 // New creates a new redis client
-func New(cfg *config.RedisConfig) (*Client, error) {
+func New(cfg *config.Redis) (*Client, error) {
 	// disable redis if no address is provided
 	if cfg == nil || len(cfg.Address) == 0 {
 		return nil, nil //nolint:nilnil

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -159,26 +159,22 @@ func (c *Client) GetRedisCache(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		default:
-			iter := c.client.Scan(ctx, 0, prefixKey("*"), 0).Iterator()
-			for iter.Next(ctx) {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-					response, err := c.getResponse(ctx, iter.Val())
-					if err == nil {
-						if response != nil {
-							select {
-							case <-ctx.Done():
-								return
-							default:
-								c.CacheChannel <- response
-							}
-						}
-					} else {
-						c.l.Error("GetRedisCache ", err)
+		}
+
+		iter := c.client.Scan(ctx, 0, prefixKey("*"), 0).Iterator()
+		for iter.Next(ctx) {
+			response, err := c.getResponse(ctx, iter.Val())
+			if err == nil {
+				if response != nil {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						c.CacheChannel <- response
 					}
 				}
+			} else {
+				c.l.Error("GetRedisCache ", err)
 			}
 		}
 	}()

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -187,6 +187,14 @@ func (c *Client) startup(ctx context.Context) error {
 					// publish message from buffer
 				case s := <-c.sendBuffer:
 					c.publishMessageFromBuffer(ctx, s)
+					// context is done
+				case <-ctx.Done():
+					close(c.sendBuffer)
+					close(c.CacheChannel)
+					close(c.EnabledChannel)
+					c.client.Close()
+
+					return
 				}
 			}
 		}()

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Redis client", func() {
 		})
 		When("Redis client publishes 'enabled' message", func() {
 			It("should propagate the message over redis", func() {
-				redisClient.PublishEnabled(&EnabledMessage{
+				redisClient.PublishEnabled(context.TODO(), &EnabledMessage{
 					State: true,
 				})
 				Eventually(func() map[string]int {

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -52,6 +52,18 @@ var _ = Describe("Redis client", func() {
 			})
 		})
 
+		When("sentinel is enabled without servers", func() {
+			BeforeEach(func() {
+				redisConfig.Address = "test"
+				redisConfig.SentinelAddresses = []string{"127.0.0.1:0"}
+			})
+
+			It("should fail with error", func(ctx context.Context) {
+				_, err = New(ctx, redisConfig)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+
 		When("redis configuration has invalid password", func() {
 			BeforeEach(func() {
 				setupRedisServer(redisConfig)
@@ -60,7 +72,6 @@ var _ = Describe("Redis client", func() {
 
 			It("should fail with error", func(ctx context.Context) {
 				_, err = New(ctx, redisConfig)
-
 				Expect(err).Should(HaveOccurred())
 			})
 		})

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -21,7 +21,7 @@ const (
 var (
 	redisServer *miniredis.Miniredis
 	redisClient *Client
-	redisConfig *config.RedisConfig
+	redisConfig *config.Redis
 	err         error
 )
 
@@ -33,7 +33,7 @@ var _ = Describe("Redis client", func() {
 
 		DeferCleanup(redisServer.Close)
 
-		var rcfg config.RedisConfig
+		var rcfg config.Redis
 		err = defaults.Set(&rcfg)
 
 		Expect(err).Should(Succeed())
@@ -48,7 +48,7 @@ var _ = Describe("Redis client", func() {
 	Describe("Client creation", func() {
 		When("redis configuration has no address", func() {
 			It("should return nil without error", func() {
-				var rcfg config.RedisConfig
+				var rcfg config.Redis
 				err = defaults.Set(&rcfg)
 
 				Expect(err).Should(Succeed())
@@ -58,7 +58,7 @@ var _ = Describe("Redis client", func() {
 		})
 		When("redis configuration has invalid address", func() {
 			It("should fail with error", func() {
-				var rcfg config.RedisConfig
+				var rcfg config.Redis
 				err = defaults.Set(&rcfg)
 				Expect(err).Should(Succeed())
 
@@ -71,7 +71,7 @@ var _ = Describe("Redis client", func() {
 		})
 		When("redis configuration has invalid password", func() {
 			It("should fail with error", func() {
-				var rcfg config.RedisConfig
+				var rcfg config.Redis
 				err = defaults.Set(&rcfg)
 				Expect(err).Should(Succeed())
 

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -317,14 +317,11 @@ var _ = Describe("Redis client", func() {
 				})
 
 				By("call GetRedisCache - It should read one entry from redis and propagate it via channel", func() {
-     redisClient2, err := New(ctx, redisConfig)
-				 Expect(err).Should(Succeed())
+					redisClient.GetRedisCache(ctx)
 
-					redisClient2.GetRedisCache(ctx)
-
-					Eventually(redisClient2.CacheChannel).Should(HaveLen(1))
+					Eventually(redisClient.CacheChannel).Should(HaveLen(1))
 				})
-			})
+			}, SpecTimeout(time.Second*4))
 		})
 		When("GetRedisCache is called and database contains not valid entry", func() {
 			It("Should do nothing (only log error)", func(ctx context.Context) {

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -317,9 +317,12 @@ var _ = Describe("Redis client", func() {
 				})
 
 				By("call GetRedisCache - It should read one entry from redis and propagate it via channel", func() {
-					redisClient.GetRedisCache(ctx)
+     redisClient2, err := New(ctx, redisConfig)
+				 Expect(err).Should(Succeed())
 
-					Eventually(redisClient.CacheChannel).Should(HaveLen(1))
+					redisClient2.GetRedisCache(ctx)
+
+					Eventually(redisClient2.CacheChannel).Should(HaveLen(1))
 				})
 			})
 		})

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -19,67 +19,47 @@ const (
 	exampleComKey = CacheStorePrefix + "example.com"
 )
 
-var (
-	redisServer *miniredis.Miniredis
-	redisClient *Client
-	redisConfig *config.Redis
-	err         error
-)
-
 var _ = Describe("Redis client", func() {
+	var (
+		redisConfig *config.Redis
+
+		redisClient *Client
+
+		err error
+	)
+
 	BeforeEach(func() {
-		redisServer, err = miniredis.Run()
-
-		Expect(err).Should(Succeed())
-
-		DeferCleanup(redisServer.Close)
-
 		var rcfg config.Redis
-		err = defaults.Set(&rcfg)
-
-		Expect(err).Should(Succeed())
-
-		rcfg.Address = redisServer.Addr()
+		Expect(defaults.Set(&rcfg)).Should(Succeed())
 		redisConfig = &rcfg
-		redisClient, err = New(context.TODO(), redisConfig)
-
-		Expect(err).Should(Succeed())
-		Expect(redisClient).ShouldNot(BeNil())
 	})
+
 	Describe("Client creation", func() {
 		When("redis configuration has no address", func() {
-			It("should return nil without error", func() {
-				var rcfg config.Redis
-				err = defaults.Set(&rcfg)
-
-				Expect(err).Should(Succeed())
-
-				Expect(New(context.TODO(), &rcfg)).Should(BeNil())
+			It("should return nil without error", func(ctx context.Context) {
+				Expect(New(ctx, redisConfig)).Should(BeNil())
 			})
 		})
+
 		When("redis configuration has invalid address", func() {
-			It("should fail with error", func() {
-				var rcfg config.Redis
-				err = defaults.Set(&rcfg)
-				Expect(err).Should(Succeed())
+			BeforeEach(func() {
+				redisConfig.Address = "127.0.0.1:0"
+			})
 
-				rcfg.Address = "127.0.0.1:0"
-
-				_, err = New(context.TODO(), &rcfg)
-
+			It("should fail with error", func(ctx context.Context) {
+				_, err = New(ctx, redisConfig)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
+
 		When("redis configuration has invalid password", func() {
-			It("should fail with error", func() {
-				var rcfg config.Redis
-				err = defaults.Set(&rcfg)
-				Expect(err).Should(Succeed())
+			BeforeEach(func() {
+				setupRedisServer(redisConfig)
+				redisConfig.Password = "wrong"
+			})
 
-				rcfg.Address = redisServer.Addr()
-				rcfg.Password = "wrong"
-
-				_, err = New(context.TODO(), &rcfg)
+			It("should fail with error", func(ctx context.Context) {
+				_, err = New(ctx, redisConfig)
 
 				Expect(err).Should(HaveOccurred())
 			})
@@ -87,8 +67,16 @@ var _ = Describe("Redis client", func() {
 	})
 
 	Describe("Publish message", func() {
+		var redisServer *miniredis.Miniredis
+		BeforeEach(func() {
+			redisServer = setupRedisServer(redisConfig)
+		})
+
 		When("Redis client publishes 'cache' message", func() {
-			It("One new entry with TTL > 0 should be persisted in the database", func() {
+			It("One new entry with TTL > 0 should be persisted in the database", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
 				By("Database is empty", func() {
 					Eventually(func() []string {
 						return redisServer.DB(redisConfig.Database).Keys()
@@ -113,7 +101,10 @@ var _ = Describe("Redis client", func() {
 				})
 			})
 
-			It("One new entry with default TTL should be persisted in the database", func() {
+			It("One new entry with default TTL should be persisted in the database", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
 				By("Database is empty", func() {
 					Eventually(func() []string {
 						return redisServer.DB(redisConfig.Database).Keys()
@@ -139,20 +130,30 @@ var _ = Describe("Redis client", func() {
 			})
 		})
 		When("Redis client publishes 'enabled' message", func() {
-			It("should propagate the message over redis", func() {
-				redisClient.PublishEnabled(context.TODO(), &EnabledMessage{
+			It("should propagate the message over redis", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
+				redisClient.PublishEnabled(ctx, &EnabledMessage{
 					State: true,
 				})
 				Eventually(func() map[string]int {
 					return redisServer.PubSubNumSub(SyncChannelName)
 				}).Should(HaveLen(1))
-			})
+			}, SpecTimeout(time.Second*6))
 		})
 	})
 
 	Describe("Receive message", func() {
+		var redisServer *miniredis.Miniredis
+		BeforeEach(func() {
+			redisServer = setupRedisServer(redisConfig)
+		})
 		When("'enabled' message is received", func() {
-			It("should propagate the message over the channel", func() {
+			It("should propagate the message over the channel", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
 				var binState []byte
 				binState, err = json.Marshal(EnabledMessage{State: true})
 				Expect(err).Should(Succeed())
@@ -180,7 +181,10 @@ var _ = Describe("Redis client", func() {
 			})
 		})
 		When("'cache' message is received", func() {
-			It("should propagate the message over the channel", func() {
+			It("should propagate the message over the channel", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
 				res, err := util.NewMsgWithAnswer("example.com.", 123, dns.Type(dns.TypeA), "123.124.122.123")
 
 				Expect(err).Should(Succeed())
@@ -210,10 +214,13 @@ var _ = Describe("Redis client", func() {
 				Eventually(func() chan *CacheMessage {
 					return redisClient.CacheChannel
 				}).Should(HaveLen(lenE + 1))
-			})
+			}, SpecTimeout(time.Second*6))
 		})
 		When("wrong data is received", func() {
-			It("should not propagate the message over the channel if data is wrong", func() {
+			It("should not propagate the message over the channel if data is wrong", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
 				var id []byte
 				id, err = uuid.New().MarshalBinary()
 				Expect(err).Should(Succeed())
@@ -240,8 +247,11 @@ var _ = Describe("Redis client", func() {
 				Eventually(func() chan *CacheMessage {
 					return redisClient.CacheChannel
 				}).Should(HaveLen(lenC))
-			})
-			It("should not propagate the message over the channel if type is wrong", func() {
+			}, SpecTimeout(time.Second*6))
+			It("should not propagate the message over the channel if type is wrong", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
 				var id []byte
 				id, err = uuid.New().MarshalBinary()
 				Expect(err).Should(Succeed())
@@ -270,13 +280,20 @@ var _ = Describe("Redis client", func() {
 				Eventually(func() chan *CacheMessage {
 					return redisClient.CacheChannel
 				}).Should(HaveLen(lenC))
-			})
+			}, SpecTimeout(time.Second*6))
 		})
 	})
 
 	Describe("Read the redis cache and publish it to the channel", func() {
+		var redisServer *miniredis.Miniredis
+		BeforeEach(func() {
+			redisServer = setupRedisServer(redisConfig)
+		})
 		When("GetRedisCache is called with valid database entries", func() {
-			It("Should read data from Redis and propagate it via cache channel", func() {
+			It("Should read data from Redis and propagate it via cache channel", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
 				By("Database is empty", func() {
 					Eventually(func() []string {
 						return redisServer.DB(redisConfig.Database).Keys()
@@ -300,18 +317,30 @@ var _ = Describe("Redis client", func() {
 				})
 
 				By("call GetRedisCache - It should read one entry from redis and propagate it via channel", func() {
-					redisClient.GetRedisCache(context.TODO())
+					redisClient.GetRedisCache(ctx)
 
 					Eventually(redisClient.CacheChannel).Should(HaveLen(1))
 				})
 			})
 		})
 		When("GetRedisCache is called and database contains not valid entry", func() {
-			It("Should do nothing (only log error)", func() {
+			It("Should do nothing (only log error)", func(ctx context.Context) {
+				redisClient, err = New(ctx, redisConfig)
+				Expect(err).Should(Succeed())
+
 				Expect(redisServer.DB(redisConfig.Database).Set(CacheStorePrefix+"test", "test")).Should(Succeed())
-				redisClient.GetRedisCache(context.TODO())
+				redisClient.GetRedisCache(ctx)
 				Consistently(redisClient.CacheChannel).Should(BeEmpty())
-			})
+			}, SpecTimeout(time.Second*2))
 		})
 	})
 })
+
+func setupRedisServer(cfg *config.Redis) *miniredis.Miniredis {
+	redisServer, err := miniredis.Run()
+	Expect(err).Should(Succeed())
+	DeferCleanup(redisServer.Close)
+	cfg.Address = redisServer.Addr()
+
+	return redisServer
+}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Redis client", func() {
 
 		rcfg.Address = redisServer.Addr()
 		redisConfig = &rcfg
-		redisClient, err = New(redisConfig)
+		redisClient, err = New(context.TODO(), redisConfig)
 
 		Expect(err).Should(Succeed())
 		Expect(redisClient).ShouldNot(BeNil())
@@ -54,7 +54,7 @@ var _ = Describe("Redis client", func() {
 
 				Expect(err).Should(Succeed())
 
-				Expect(New(&rcfg)).Should(BeNil())
+				Expect(New(context.TODO(), &rcfg)).Should(BeNil())
 			})
 		})
 		When("redis configuration has invalid address", func() {
@@ -65,7 +65,7 @@ var _ = Describe("Redis client", func() {
 
 				rcfg.Address = "127.0.0.1:0"
 
-				_, err = New(&rcfg)
+				_, err = New(context.TODO(), &rcfg)
 
 				Expect(err).Should(HaveOccurred())
 			})
@@ -79,7 +79,7 @@ var _ = Describe("Redis client", func() {
 				rcfg.Address = redisServer.Addr()
 				rcfg.Password = "wrong"
 
-				_, err = New(&rcfg)
+				_, err = New(context.TODO(), &rcfg)
 
 				Expect(err).Should(HaveOccurred())
 			})

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -299,7 +300,7 @@ var _ = Describe("Redis client", func() {
 				})
 
 				By("call GetRedisCache - It should read one entry from redis and propagate it via channel", func() {
-					redisClient.GetRedisCache()
+					redisClient.GetRedisCache(context.TODO())
 
 					Eventually(redisClient.CacheChannel).Should(HaveLen(1))
 				})
@@ -308,7 +309,7 @@ var _ = Describe("Redis client", func() {
 		When("GetRedisCache is called and database contains not valid entry", func() {
 			It("Should do nothing (only log error)", func() {
 				Expect(redisServer.DB(redisConfig.Database).Set(CacheStorePrefix+"test", "test")).Should(Succeed())
-				redisClient.GetRedisCache()
+				redisClient.GetRedisCache(context.TODO())
 				Consistently(redisClient.CacheChannel).Should(BeEmpty())
 			})
 		})

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -183,7 +183,7 @@ func (r *BlockingResolver) redisSubscriber(ctx context.Context) {
 				if em.State {
 					r.internalEnableBlocking()
 				} else {
-					err := r.internalDisableBlocking(em.Duration, em.Groups)
+					err := r.internalDisableBlocking(ctx, em.Duration, em.Groups)
 					if err != nil {
 						r.log().Warn("Blocking couldn't be disabled:", err)
 					}
@@ -216,11 +216,11 @@ func (r *BlockingResolver) retrieveAllBlockingGroups() []string {
 }
 
 // EnableBlocking enables the blocking against the blacklists
-func (r *BlockingResolver) EnableBlocking() {
+func (r *BlockingResolver) EnableBlocking(ctx context.Context) {
 	r.internalEnableBlocking()
 
 	if r.redisClient != nil {
-		r.redisClient.PublishEnabled(&redis.EnabledMessage{State: true})
+		r.redisClient.PublishEnabled(ctx, &redis.EnabledMessage{State: true})
 	}
 }
 
@@ -236,10 +236,10 @@ func (r *BlockingResolver) internalEnableBlocking() {
 }
 
 // DisableBlocking deactivates the blocking for a particular duration (or forever if 0).
-func (r *BlockingResolver) DisableBlocking(duration time.Duration, disableGroups []string) error {
-	err := r.internalDisableBlocking(duration, disableGroups)
+func (r *BlockingResolver) DisableBlocking(ctx context.Context, duration time.Duration, disableGroups []string) error {
+	err := r.internalDisableBlocking(ctx, duration, disableGroups)
 	if err == nil && r.redisClient != nil {
-		r.redisClient.PublishEnabled(&redis.EnabledMessage{
+		r.redisClient.PublishEnabled(ctx, &redis.EnabledMessage{
 			State:    false,
 			Duration: duration,
 			Groups:   disableGroups,
@@ -249,7 +249,7 @@ func (r *BlockingResolver) DisableBlocking(duration time.Duration, disableGroups
 	return err
 }
 
-func (r *BlockingResolver) internalDisableBlocking(duration time.Duration, disableGroups []string) error {
+func (r *BlockingResolver) internalDisableBlocking(ctx context.Context, duration time.Duration, disableGroups []string) error {
 	s := r.status
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -280,7 +280,7 @@ func (r *BlockingResolver) internalDisableBlocking(duration time.Duration, disab
 		log.Log().Infof("disable blocking for %s for group(s) '%s'", duration,
 			log.EscapeInput(strings.Join(s.disabledGroups, "; ")))
 		s.enableTimer = time.AfterFunc(duration, func() {
-			r.EnableBlocking()
+			r.EnableBlocking(ctx)
 			log.Log().Info("blocking enabled again")
 		})
 	}

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -249,7 +249,9 @@ func (r *BlockingResolver) DisableBlocking(ctx context.Context, duration time.Du
 	return err
 }
 
-func (r *BlockingResolver) internalDisableBlocking(ctx context.Context, duration time.Duration, disableGroups []string) error {
+func (r *BlockingResolver) internalDisableBlocking(ctx context.Context, duration time.Duration,
+	disableGroups []string,
+) error {
 	s := r.status
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -842,7 +842,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				By("Calling Rest API to deactivate all groups", func() {
-					err := sut.DisableBlocking(0, []string{})
+					err := sut.DisableBlocking(context.TODO(), 0, []string{})
 					Expect(err).Should(Succeed())
 				})
 
@@ -875,7 +875,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				By("Calling Rest API to deactivate only defaultGroup", func() {
-					err := sut.DisableBlocking(0, []string{"defaultGroup"})
+					err := sut.DisableBlocking(context.TODO(), 0, []string{"defaultGroup"})
 					Expect(err).Should(Succeed())
 				})
 
@@ -935,7 +935,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						enabled <- state
 					})
 					Expect(err).Should(Succeed())
-					err = sut.DisableBlocking(500*time.Millisecond, []string{})
+					err = sut.DisableBlocking(context.TODO(), 500*time.Millisecond, []string{})
 					Expect(err).Should(Succeed())
 					Eventually(enabled, "1s").Should(Receive(BeFalse()))
 				})
@@ -1025,7 +1025,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						enabled <- false
 					})
 					Expect(err).Should(Succeed())
-					err = sut.DisableBlocking(500*time.Millisecond, []string{"group1"})
+					err = sut.DisableBlocking(context.TODO(), 500*time.Millisecond, []string{"group1"})
 					Expect(err).Should(Succeed())
 					Eventually(enabled, "1s").Should(Receive(BeFalse()))
 				})
@@ -1086,7 +1086,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 		When("Disable blocking is called with wrong group name", func() {
 			It("should fail", func() {
-				err := sut.DisableBlocking(500*time.Millisecond, []string{"unknownGroupName"})
+				err := sut.DisableBlocking(context.TODO(), 500*time.Millisecond, []string{"unknownGroupName"})
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -1094,7 +1094,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("Blocking status is called", func() {
 			It("should return correct status", func() {
 				By("enable blocking via API", func() {
-					sut.EnableBlocking()
+					sut.EnableBlocking(context.TODO())
 				})
 
 				By("Query blocking status via API should return 'enabled'", func() {
@@ -1103,7 +1103,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				By("disable blocking via API", func() {
-					err := sut.DisableBlocking(500*time.Millisecond, []string{})
+					err := sut.DisableBlocking(context.TODO(), 500*time.Millisecond, []string{})
 					Expect(err).Should(Succeed())
 				})
 
@@ -1154,7 +1154,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 			Expect(err).Should(Succeed())
 			rcfg.Address = redisServer.Addr()
-			redisClient, err = redis.New(&rcfg)
+			redisClient, err = redis.New(context.TODO(), &rcfg)
 
 			Expect(err).Should(Succeed())
 			Expect(redisClient).ShouldNot(BeNil())
@@ -1171,7 +1171,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("disable", func() {
 			It("should return disable", func() {
-				sut.EnableBlocking()
+				sut.EnableBlocking(context.TODO())
 
 				redisMockMsg := &redis.EnabledMessage{
 					State: false,
@@ -1185,7 +1185,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("disable", func() {
 			It("should return disable", func() {
-				sut.EnableBlocking()
+				sut.EnableBlocking(context.TODO())
 				redisMockMsg := &redis.EnabledMessage{
 					State:  false,
 					Groups: []string{"unknown"},
@@ -1199,7 +1199,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("enable", func() {
 			It("should return enable", func() {
-				err = sut.DisableBlocking(time.Hour, []string{})
+				err = sut.DisableBlocking(context.TODO(), time.Hour, []string{})
 				Expect(err).Should(Succeed())
 
 				redisMockMsg := &redis.EnabledMessage{

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -1149,7 +1149,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 			Expect(err).Should(Succeed())
 
-			var rcfg config.RedisConfig
+			var rcfg config.Redis
 			err = defaults.Set(&rcfg)
 
 			Expect(err).Should(Succeed())

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -60,7 +60,7 @@ func newCachingResolver(ctx context.Context,
 
 	if c.redisClient != nil {
 		go c.redisSubscriber(ctx)
-		c.redisClient.GetRedisCache()
+		c.redisClient.GetRedisCache(ctx)
 	}
 
 	return c

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -733,7 +733,7 @@ var _ = Describe("CachingResolver", func() {
 		var (
 			redisServer *miniredis.Miniredis
 			redisClient *redis.Client
-			redisConfig *config.RedisConfig
+			redisConfig *config.Redis
 			err         error
 		)
 		BeforeEach(func() {
@@ -741,7 +741,7 @@ var _ = Describe("CachingResolver", func() {
 
 			Expect(err).Should(Succeed())
 
-			var rcfg config.RedisConfig
+			var rcfg config.Redis
 			err = defaults.Set(&rcfg)
 
 			Expect(err).Should(Succeed())

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -748,7 +748,7 @@ var _ = Describe("CachingResolver", func() {
 
 			rcfg.Address = redisServer.Addr()
 			redisConfig = &rcfg
-			redisClient, err = redis.New(redisConfig)
+			redisClient, err = redis.New(context.TODO(), redisConfig)
 
 			Expect(err).Should(Succeed())
 			Expect(redisClient).ShouldNot(BeNil())

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -452,14 +452,18 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 
 		Describe("Weighted random on resolver selection", func() {
 			When("4 upstream resolvers are defined", func() {
+				var (
+					mockUpstream1 *MockUDPUpstreamServer
+					mockUpstream2 *MockUDPUpstreamServer
+				)
 				BeforeEach(func() {
 					withError1 := config.Upstream{Host: "wrong1"}
 					withError2 := config.Upstream{Host: "wrong2"}
 
-					mockUpstream1 := NewMockUDPUpstreamServer().WithAnswerRR("example.com 123 IN A 123.124.122.122")
+					mockUpstream1 = NewMockUDPUpstreamServer().WithAnswerRR("example.com 123 IN A 123.124.122.122")
 					DeferCleanup(mockUpstream1.Close)
 
-					mockUpstream2 := NewMockUDPUpstreamServer().WithAnswerRR("example.com 123 IN A 123.124.122.122")
+					mockUpstream2 = NewMockUDPUpstreamServer().WithAnswerRR("example.com 123 IN A 123.124.122.122")
 					DeferCleanup(mockUpstream2.Close)
 
 					upstreams = []config.Upstream{withError1, mockUpstream1.Start(), mockUpstream2.Start(), withError2}

--- a/server/server.go
+++ b/server/server.go
@@ -423,6 +423,11 @@ func (s *Server) registerDNSHandlers() {
 func (s *Server) printConfiguration() {
 	logger().Info("current configuration:")
 
+	if s.cfg.Redis.IsEnabled() {
+		logger().Info("Redis:")
+		log.WithIndent(logger(), "  ", s.cfg.Redis.LogConfig)
+	}
+
 	resolver.ForEach(s.queryResolver, func(res resolver.Resolver) {
 		resolver.LogResolverConfig(res, logger())
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -135,9 +135,12 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 		return nil, err
 	}
 
-	redisClient, redisErr := redis.New(ctx, &cfg.Redis)
-	if redisErr != nil && cfg.Redis.Required {
-		return nil, redisErr
+	var redisClient *redis.Client
+	if cfg.Redis.IsEnabled() {
+		redisClient, err = redis.New(ctx, &cfg.Redis)
+		if err != nil && cfg.Redis.Required {
+			return nil, err
+		}
 	}
 
 	queryResolver, queryError := createQueryResolver(ctx, cfg, bootstrap, redisClient)

--- a/server/server.go
+++ b/server/server.go
@@ -135,7 +135,7 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 		return nil, err
 	}
 
-	redisClient, redisErr := redis.New(&cfg.Redis)
+	redisClient, redisErr := redis.New(ctx, &cfg.Redis)
 	if redisErr != nil && cfg.Redis.Required {
 		return nil, redisErr
 	}

--- a/util/context.go
+++ b/util/context.go
@@ -6,8 +6,10 @@ import "context"
 // If the message is sent, it returns true.
 // If the context is done or the channel is closed, it returns false.
 func CtxSend[T any](ctx context.Context, ch chan T, val T) (ok bool) {
-	if ctx == nil || ch == nil {
-		return false
+	if ctx == nil || ch == nil || ctx.Err() != nil {
+		ok = false
+
+		return
 	}
 
 	defer func() {

--- a/util/context.go
+++ b/util/context.go
@@ -2,8 +2,8 @@ package util
 
 import "context"
 
-// ctxSend sends a value to a channel or returns false if the context is done or the channel is closed.
-func ctxSend[T any](ctx context.Context, ch chan T, val T) (ok bool) {
+// CtxSend sends a value to a channel or returns false if the context is done or the channel is closed.
+func CtxSend[T any](ctx context.Context, ch chan T, val T) (ok bool) {
 	if ctx == nil || ch == nil {
 		return false
 	}

--- a/util/context.go
+++ b/util/context.go
@@ -2,7 +2,9 @@ package util
 
 import "context"
 
-// CtxSend sends a value to a channel or returns false if the context is done or the channel is closed.
+// CtxSend sends a value to a channel while the context isn't done.
+// If the message is sent, it returns true.
+// If the context is done or the channel is closed, it returns false.
 func CtxSend[T any](ctx context.Context, ch chan T, val T) (ok bool) {
 	if ctx == nil || ch == nil {
 		return false

--- a/util/context.go
+++ b/util/context.go
@@ -1,0 +1,25 @@
+package util
+
+import "context"
+
+// ctxSend sends a value to a channel or returns false if the context is done or the channel is closed.
+func ctxSend[T any](ctx context.Context, ch chan T, val T) (ok bool) {
+	if ctx == nil || ch == nil {
+		return false
+	}
+
+	defer func() {
+		if err := recover(); err != nil {
+			ok = false
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		ok = false
+	case ch <- val:
+		ok = true
+	}
+
+	return
+}

--- a/util/context_test.go
+++ b/util/context_test.go
@@ -1,0 +1,107 @@
+package util
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testMessage = 1
+)
+
+var _ = Describe("Context utils", func() {
+	Describe("ctxSend", func() {
+		var ch chan int
+		BeforeEach(func() {
+			ch = make(chan int, 1)
+		})
+
+		AfterEach(func() {
+			ch = nil
+		})
+
+		When("channel is not closed", func() {
+			It("should send value to channel", func(ctx context.Context) {
+				go startReader(ctx, ch)
+				Expect(ctxSend(ctx, ch, testMessage)).Should(BeTrue())
+			}, SpecTimeout(time.Second))
+		})
+
+		When("channel is closed", func() {
+			It("should return false", func(ctx context.Context) {
+				go startReader(ctx, ch)
+				close(ch)
+				Expect(ctxSend(ctx, ch, testMessage)).Should(BeFalse())
+			}, SpecTimeout(time.Second))
+		})
+
+		When("channel is nil", func() {
+			It("should return false", func(ctx context.Context) {
+				Expect(ctxSend(ctx, nil, testMessage)).Should(BeFalse())
+			}, SpecTimeout(time.Second))
+		})
+
+		When("channel is full", func() {
+			It("should wait", func(ctx context.Context) {
+				ch <- testMessage
+				go func(ctx context.Context, ch chan int) {
+					timer := time.NewTimer(time.Millisecond * 200)
+					select {
+					case <-timer.C:
+						startReader(ctx, ch)
+					case <-ctx.Done():
+						return
+					}
+				}(ctx, ch)
+				Expect(ctxSend(ctx, ch, testMessage)).Should(BeTrue())
+			}, SpecTimeout(time.Second))
+		})
+
+		When("context is done", func() {
+			It("should return false", func(ctx context.Context) {
+				go startReader(ctx, ch)
+				ctx, cancel := context.WithCancel(ctx)
+				cancel()
+				Expect(ctxSend(ctx, ch, testMessage)).Should(BeFalse())
+			}, SpecTimeout(time.Second))
+		})
+
+		When("context is nil", func() {
+			It("should return false", func(ctx context.Context) {
+				Expect(ctxSend(nil, ch, testMessage)).Should(BeFalse())
+			}, SpecTimeout(time.Second))
+		})
+
+		When("context and channel are nil", func() {
+			It("should return false", func(ctx context.Context) {
+				Expect(ctxSend(nil, nil, testMessage)).Should(BeFalse())
+			}, SpecTimeout(time.Second))
+		})
+
+		When("context is done and channel is closed", func() {
+			It("should return false", func(ctx context.Context) {
+				go startReader(ctx, ch)
+				ctx, cancel := context.WithCancel(ctx)
+				cancel()
+				close(ch)
+				Expect(ctxSend(ctx, ch, testMessage)).Should(BeFalse())
+			}, SpecTimeout(time.Second))
+		})
+	})
+})
+
+func startReader(ctx context.Context, ch <-chan int) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case i, ok := <-ch:
+			if ok {
+				Expect(i).Should(Equal(testMessage))
+			}
+		}
+	}
+}

--- a/util/context_test.go
+++ b/util/context_test.go
@@ -65,6 +65,9 @@ var _ = Describe("Context utils", func() {
 				go startReader(ctx, ch)
 				ctx, cancel := context.WithCancel(ctx)
 				cancel()
+				// wait for context to properly be done
+				timer := time.NewTimer(time.Millisecond)
+				<-timer.C
 				Expect(CtxSend(ctx, ch, testMessage)).Should(BeFalse())
 			}, SpecTimeout(time.Second))
 		})

--- a/util/context_test.go
+++ b/util/context_test.go
@@ -13,7 +13,7 @@ const (
 )
 
 var _ = Describe("Context utils", func() {
-	Describe("ctxSend", func() {
+	Describe("CtxSend", func() {
 		var ch chan int
 		BeforeEach(func() {
 			ch = make(chan int, 1)
@@ -26,7 +26,7 @@ var _ = Describe("Context utils", func() {
 		When("channel is not closed", func() {
 			It("should send value to channel", func(ctx context.Context) {
 				go startReader(ctx, ch)
-				Expect(ctxSend(ctx, ch, testMessage)).Should(BeTrue())
+				Expect(CtxSend(ctx, ch, testMessage)).Should(BeTrue())
 			}, SpecTimeout(time.Second))
 		})
 
@@ -34,13 +34,13 @@ var _ = Describe("Context utils", func() {
 			It("should return false", func(ctx context.Context) {
 				go startReader(ctx, ch)
 				close(ch)
-				Expect(ctxSend(ctx, ch, testMessage)).Should(BeFalse())
+				Expect(CtxSend(ctx, ch, testMessage)).Should(BeFalse())
 			}, SpecTimeout(time.Second))
 		})
 
 		When("channel is nil", func() {
 			It("should return false", func(ctx context.Context) {
-				Expect(ctxSend(ctx, nil, testMessage)).Should(BeFalse())
+				Expect(CtxSend(ctx, nil, testMessage)).Should(BeFalse())
 			}, SpecTimeout(time.Second))
 		})
 
@@ -56,7 +56,7 @@ var _ = Describe("Context utils", func() {
 						return
 					}
 				}(ctx, ch)
-				Expect(ctxSend(ctx, ch, testMessage)).Should(BeTrue())
+				Expect(CtxSend(ctx, ch, testMessage)).Should(BeTrue())
 			}, SpecTimeout(time.Second))
 		})
 
@@ -65,19 +65,19 @@ var _ = Describe("Context utils", func() {
 				go startReader(ctx, ch)
 				ctx, cancel := context.WithCancel(ctx)
 				cancel()
-				Expect(ctxSend(ctx, ch, testMessage)).Should(BeFalse())
+				Expect(CtxSend(ctx, ch, testMessage)).Should(BeFalse())
 			}, SpecTimeout(time.Second))
 		})
 
 		When("context is nil", func() {
 			It("should return false", func(ctx context.Context) {
-				Expect(ctxSend(nil, ch, testMessage)).Should(BeFalse())
+				Expect(CtxSend(nil, ch, testMessage)).Should(BeFalse())
 			}, SpecTimeout(time.Second))
 		})
 
 		When("context and channel are nil", func() {
 			It("should return false", func(ctx context.Context) {
-				Expect(ctxSend(nil, nil, testMessage)).Should(BeFalse())
+				Expect(CtxSend(nil, nil, testMessage)).Should(BeFalse())
 			}, SpecTimeout(time.Second))
 		})
 
@@ -87,7 +87,7 @@ var _ = Describe("Context utils", func() {
 				ctx, cancel := context.WithCancel(ctx)
 				cancel()
 				close(ch)
-				Expect(ctxSend(ctx, ch, testMessage)).Should(BeFalse())
+				Expect(CtxSend(ctx, ch, testMessage)).Should(BeFalse())
 			}, SpecTimeout(time.Second))
 		})
 	})


### PR DESCRIPTION
Changes:
- config.RedisConfig renamed to config.Redis
- config.Redis got its own file
- config.Redis implements config.Configurable
- config.Redis got unittests
- redis.Client doesn't store it's own context
- methodes of redis.Client expect a context where it's needed
- redis.Client closes its channels when the context is done

Part of #1264