### PR TITLE
ginkgolinter: enable all checks and fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,22 +75,7 @@ linters-settings:
     ignored-numbers:
       - "0666"
   ginkgolinter:
-    # Suppress the wrong length assertion warning.
-    suppress-len-assertion: true
-    # Suppress the wrong nil assertion warning.
-    suppress-nil-assertion: true
-    # Suppress the wrong error assertion warning.
-    suppress-err-assertion: true
-    # Suppress the wrong comparison assertion warning.
-    suppress-compare-assertion: true
-    # Suppress the function all in async assertion warning.
-    suppress-async-assertion: true
-    # Suppress warning for comparing values from different types, like int32 and uint32
-    suppress-type-compare-assertion: true
-    # Trigger warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt
     forbid-focus-container: true
-    # Don't trigger warnings for HaveLen(0)
-    allow-havelen-zero: true
   stylecheck:
     # Whietlist dot imports for test packages.
     dot-import-whitelist:

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -102,8 +102,7 @@ var _ = Describe("Serve command", func() {
 			By("terminate with signal", func() {
 				var startError error
 				Eventually(errChan, "10s").Should(Receive(&startError))
-				Expect(startError).ShouldNot(BeNil())
-				Expect(startError.Error()).Should(ContainSubstring("address already in use"))
+				Expect(startError).Should(MatchError(ContainSubstring("address already in use")))
 			})
 		})
 	})
@@ -121,8 +120,7 @@ var _ = Describe("Serve command", func() {
 			By("server should terminate with error", func() {
 				var startError error
 				Eventually(errChan).Should(Receive(&startError))
-				Expect(startError).ShouldNot(BeNil())
-				Expect(startError.Error()).Should(ContainSubstring("unable to load configuration"))
+				Expect(startError).Should(MatchError(ContainSubstring("unable to load configuration")))
 			})
 		})
 	})


### PR DESCRIPTION
ginkgolinter configuration argument names may be a bit misleading. Assuming the linter added to use it, this PR remove all the supress-warning configurations.

Two error checks now found by the linter and fixed as well.