### PR TITLE
Refactoring server.go

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -63,7 +63,7 @@ func startServer(_ *cobra.Command, _ []string) error {
 		select {
 		case <-signals:
 			log.Log().Infof("Terminating...")
-			util.LogOnError("can't stop server: ", srv.Stop())
+			util.LogOnError("can't stop server: ", srv.Stop(ctx))
 			done <- true
 
 		case err := <-errChan:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -148,10 +148,14 @@ var _ = Describe("Config", func() {
 
 	Describe("Creation of Config", func() {
 		When("Test config file will be parsed", func() {
-			It("should return a valid config struct", func() {
-				confFile := writeConfigYml(tmpDir)
-				Expect(confFile.Error).Should(Succeed())
+			var confFile *helpertest.TmpFile
 
+			BeforeEach(func() {
+				confFile = writeConfigYml(tmpDir)
+				Expect(confFile.Error).Should(Succeed())
+			})
+
+			It("should return a valid config struct", func() {
 				c, err = LoadConfig(confFile.Path, true)
 				Expect(err).Should(Succeed())
 
@@ -165,20 +169,19 @@ var _ = Describe("Config", func() {
 			})
 		})
 		When("Multiple config files are used", func() {
-			It("should return a valid config struct", func() {
+			BeforeEach(func() {
 				err = writeConfigDir(tmpDir)
 				Expect(err).Should(Succeed())
+			})
 
-				_, err := LoadConfig(tmpDir.Path, true)
+			It("should return a valid config struct", func() {
+				c, err := LoadConfig(tmpDir.Path, true)
 				Expect(err).Should(Succeed())
 
 				defaultTestFileConfig(c)
 			})
 
 			It("should ignore non YAML files", func() {
-				err = writeConfigDir(tmpDir)
-				Expect(err).Should(Succeed())
-
 				tmpDir.CreateStringFile("ignore-me.txt", "THIS SHOULD BE IGNORED!")
 
 				_, err := LoadConfig(tmpDir.Path, true)
@@ -186,9 +189,6 @@ var _ = Describe("Config", func() {
 			})
 
 			It("should ignore non regular files", func() {
-				err = writeConfigDir(tmpDir)
-				Expect(err).Should(Succeed())
-
 				tmpDir.CreateSubFolder("subfolder")
 				tmpDir.CreateSubFolder("subfolder.yml")
 

--- a/helpertest/helper.go
+++ b/helpertest/helper.go
@@ -2,6 +2,7 @@ package helpertest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -68,10 +69,10 @@ func TestServer(data string) *httptest.Server {
 }
 
 // DoGetRequest performs a GET request
-func DoGetRequest(url string,
+func DoGetRequest(ctx context.Context, url string,
 	fn func(w http.ResponseWriter, r *http.Request),
 ) (*httptest.ResponseRecorder, *bytes.Buffer) {
-	r, _ := http.NewRequest(http.MethodGet, url, nil)
+	r, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(fn)

--- a/resolver/parallel_best_resolver_test.go
+++ b/resolver/parallel_best_resolver_test.go
@@ -196,7 +196,6 @@ var _ = Describe("ParallelBestResolver", Label("parallelBestResolver"), func() {
 						WithDelay(timeout / 2)
 					DeferCleanup(slowTestUpstream.Close)
 					upstreams = []config.Upstream{{Host: "wrong"}, slowTestUpstream.Start()}
-					Expect(err).Should(Succeed())
 				})
 				It("Should use result from successful resolver", func() {
 					request := newRequest("example.com.", A)

--- a/resolver/strict_resolver_test.go
+++ b/resolver/strict_resolver_test.go
@@ -165,7 +165,7 @@ var _ = Describe("StrictResolver", Label("strictResolver"), func() {
 				})
 				When("first upstream exceeds upstreamTimeout", func() {
 					BeforeEach(func() {
-						timeout := sut.cfg.Timeout.ToDuration()
+						timeout := defaultUpstreamsConfig.Timeout.ToDuration()
 						testUpstream1 := NewMockUDPUpstreamServer().WithAnswerFn(func(request *dns.Msg) (response *dns.Msg) {
 							response, err := util.NewMsgWithAnswer("example.com", 123, A, "123.124.122.1")
 							time.Sleep(2 * timeout)
@@ -194,7 +194,7 @@ var _ = Describe("StrictResolver", Label("strictResolver"), func() {
 				})
 				When("all upstreams exceed upsteamTimeout", func() {
 					BeforeEach(func() {
-						timeout := sut.cfg.Timeout.ToDuration()
+						timeout := defaultUpstreamsConfig.Timeout.ToDuration()
 						testUpstream1 := NewMockUDPUpstreamServer().WithAnswerFn(func(request *dns.Msg) (response *dns.Msg) {
 							response, err := util.NewMsgWithAnswer("example.com", 123, A, "123.124.122.1")
 							time.Sleep(2 * timeout)

--- a/server/server.go
+++ b/server/server.go
@@ -416,6 +416,7 @@ func (s *Server) registerDNSHandlers(ctx context.Context) {
 	wrappedOnRequest := func(w dns.ResponseWriter, request *dns.Msg) {
 		s.OnRequest(ctx, w, request)
 	}
+
 	for _, server := range s.dnsServers {
 		handler := server.Handler.(*dns.ServeMux)
 		handler.HandleFunc(".", wrappedOnRequest)

--- a/server/server.go
+++ b/server/server.go
@@ -526,11 +526,11 @@ func (s *Server) Start(ctx context.Context, errCh chan<- error) {
 }
 
 // Stop stops the server
-func (s *Server) Stop() error {
+func (s *Server) Stop(ctx context.Context) error {
 	logger().Info("Stopping server")
 
 	for _, server := range s.dnsServers {
-		if err := server.Shutdown(); err != nil {
+		if err := server.ShutdownContext(ctx); err != nil {
 			return fmt.Errorf("stop %s listener failed: %w", server.Net, err)
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -187,7 +187,7 @@ var _ = BeforeSuite(func() {
 
 	// start server
 	go sut.Start(ctx, errChan)
-	DeferCleanup(sut.Stop)
+	DeferCleanup(func() { sut.Stop(ctx) })
 
 	Consistently(errChan, "1s").ShouldNot(Receive())
 })
@@ -681,13 +681,13 @@ var _ = Describe("Running DNS server", func() {
 
 				time.Sleep(100 * time.Millisecond)
 
-				err = server.Stop()
+				err = server.Stop(ctx)
 
 				// stop server, should be ok
 				Expect(err).Should(Succeed())
 
 				// stop again, should raise error
-				err = server.Stop()
+				err = server.Stop(ctx)
 
 				Expect(err).Should(HaveOccurred())
 			})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -187,7 +187,7 @@ var _ = BeforeSuite(func() {
 
 	// start server
 	go sut.Start(ctx, errChan)
-	DeferCleanup(func() { sut.Stop(ctx) })
+	DeferCleanup(func() { Expect(sut.Stop(ctx)).Should(Succeed()) })
 
 	Consistently(errChan, "1s").ShouldNot(Receive())
 })


### PR DESCRIPTION
Changes:
- server.go: removed `context.Background` from `OnRequest` in favor of ctx
- server.go: `Stop` uses `ShutdownContext`
- helper.go: `DoGetRequest` uses `NewRequestWithContext`
- fixed some flakyness in tests


Part of #1264