### PR TITLE
Refactoring/e2e tests

### DIFF
--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Basic functional tests", func() {
 		})
 		When("wrong port configuration is provided", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky, err = createBlockyContainer(ctx, tmpDir,
+				blocky, err = createBlockyContainer(ctx,
 					"upstreams:",
 					"  groups:",
 					"    default:",
@@ -50,7 +50,7 @@ var _ = Describe("Basic functional tests", func() {
 		})
 		When("Minimal configuration is provided", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky, err = createBlockyContainer(ctx, tmpDir,
+				blocky, err = createBlockyContainer(ctx,
 					"upstreams:",
 					"  groups:",
 					"    default:",
@@ -81,7 +81,7 @@ var _ = Describe("Basic functional tests", func() {
 		Context("http port configuration", func() {
 			When("'httpPort' is not defined", func() {
 				BeforeEach(func(ctx context.Context) {
-					blocky, err = createBlockyContainer(ctx, tmpDir,
+					blocky, err = createBlockyContainer(ctx,
 						"upstreams:",
 						"  groups:",
 						"    default:",
@@ -101,7 +101,7 @@ var _ = Describe("Basic functional tests", func() {
 			})
 			When("'httpPort' is defined", func() {
 				BeforeEach(func(ctx context.Context) {
-					blocky, err = createBlockyContainer(ctx, tmpDir,
+					blocky, err = createBlockyContainer(ctx,
 						"upstreams:",
 						"  groups:",
 						"    default:",
@@ -142,7 +142,7 @@ var _ = Describe("Basic functional tests", func() {
 		})
 		When("log privacy is enabled", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky, err = createBlockyContainer(ctx, tmpDir,
+				blocky, err = createBlockyContainer(ctx,
 					"upstreams:",
 					"  groups:",
 					"    default:",

--- a/e2e/blocking_test.go
+++ b/e2e/blocking_test.go
@@ -21,7 +21,7 @@ var _ = Describe("External lists and query blocking", func() {
 		When("external blacklist ist not available", func() {
 			Context("loading.strategy = blocking", func() {
 				BeforeEach(func(ctx context.Context) {
-					blocky, err = createBlockyContainer(ctx, tmpDir,
+					blocky, err = createBlockyContainer(ctx,
 						"log:",
 						"  level: warn",
 						"upstreams:",
@@ -56,7 +56,7 @@ var _ = Describe("External lists and query blocking", func() {
 			})
 			Context("loading.strategy = failOnError", func() {
 				BeforeEach(func(ctx context.Context) {
-					blocky, err = createBlockyContainer(ctx, tmpDir,
+					blocky, err = createBlockyContainer(ctx,
 						"log:",
 						"  level: warn",
 						"upstreams:",
@@ -96,7 +96,7 @@ var _ = Describe("External lists and query blocking", func() {
 				_, err = createHTTPServerContainer(ctx, "httpserver", tmpDir, "list.txt", "blockeddomain.com")
 				Expect(err).Should(Succeed())
 
-				blocky, err = createBlockyContainer(ctx, tmpDir,
+				blocky, err = createBlockyContainer(ctx,
 					"log:",
 					"  level: warn",
 					"upstreams:",

--- a/e2e/blocking_test.go
+++ b/e2e/blocking_test.go
@@ -93,7 +93,7 @@ var _ = Describe("External lists and query blocking", func() {
 	Describe("Query blocking against external blacklists", func() {
 		When("external blacklists are defined and available", func() {
 			BeforeEach(func(ctx context.Context) {
-				_, err = createHTTPServerContainer(ctx, "httpserver", tmpDir, "list.txt", "blockeddomain.com")
+				_, err = createHTTPServerContainer(ctx, "httpserver", "list.txt", "blockeddomain.com")
 				Expect(err).Should(Succeed())
 
 				blocky, err = createBlockyContainer(ctx,

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -266,22 +265,15 @@ func createTempFile(lines ...string) string {
 		return os.Remove(file.Name())
 	})
 
-	first := true
-	w := bufio.NewWriter(file)
-
-	for _, l := range lines {
-		if first {
-			first = false
-		} else {
-			_, err := w.WriteString("\n")
+	for i, l := range lines {
+		if i != 0 {
+			_, err := file.WriteString("\n")
 			Expect(err).Should(Succeed())
 		}
 
-		_, err := w.WriteString(l)
+		_, err := file.WriteString(l)
 		Expect(err).Should(Succeed())
 	}
-
-	w.Flush()
 
 	return file.Name()
 }

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -44,6 +44,9 @@ const (
 	startupTimeout = 30 * time.Second
 )
 
+// createDNSMokkaContainer creates a DNS mokka container with the given rules attached to the test network
+// under the given alias.
+// It is automatically terminated when the test is finished.
 func createDNSMokkaContainer(ctx context.Context, alias string, rules ...string) (testcontainers.Container, error) {
 	mokaRules := make(map[string]string)
 
@@ -61,6 +64,9 @@ func createDNSMokkaContainer(ctx context.Context, alias string, rules ...string)
 	return startContainerWithNetwork(ctx, req, alias)
 }
 
+// createHTTPServerContainer creates a static HTTP server container that serves one file with the given lines
+// and is attached to the test network under the given alias.
+// It is automatically terminated when the test is finished.
 func createHTTPServerContainer(ctx context.Context, alias string, filename string, lines ...string,
 ) (testcontainers.Container, error) {
 	file := createTempFile(lines...)
@@ -82,6 +88,8 @@ func createHTTPServerContainer(ctx context.Context, alias string, filename strin
 	return startContainerWithNetwork(ctx, req, alias)
 }
 
+// createRedisContainer creates a redis container attached to the test network under the alias 'redis'.
+// It is automatically terminated when the test is finished.
 func createRedisContainer(ctx context.Context) (*redis.RedisContainer, error) {
 	return deferTerminate(redis.RunContainer(ctx,
 		testcontainers.WithImage(redisImage),
@@ -90,6 +98,9 @@ func createRedisContainer(ctx context.Context) (*redis.RedisContainer, error) {
 	))
 }
 
+// createPostgresContainer creates a postgres container attached to the test network under the alias 'postgres'.
+// It creates a database 'user' with user 'user' and password 'user'.
+// It is automatically terminated when the test is finished.
 func createPostgresContainer(ctx context.Context) (*postgres.PostgresContainer, error) {
 	const waitLogOccurrence = 2
 
@@ -107,6 +118,9 @@ func createPostgresContainer(ctx context.Context) (*postgres.PostgresContainer, 
 	))
 }
 
+// createMariaDBContainer creates a mariadb container attached to the test network under the alias 'mariaDB'.
+// It creates a database 'user' with user 'user' and password 'user'.
+// It is automatically terminated when the test is finished.
 func createMariaDBContainer(ctx context.Context) (*mariadb.MariaDBContainer, error) {
 	return deferTerminate(mariadb.RunContainer(ctx,
 		testcontainers.WithImage(mariaDBImage),
@@ -117,6 +131,9 @@ func createMariaDBContainer(ctx context.Context) (*mariadb.MariaDBContainer, err
 	))
 }
 
+// createBlockyContainer creates a blocky container with a config provided by the given lines.
+// It is attached to the test network under the alias 'blocky'.
+// It is automatically terminated when the test is finished.
 func createBlockyContainer(ctx context.Context,
 	lines ...string,
 ) (testcontainers.Container, error) {
@@ -239,6 +256,8 @@ func doHTTPRequest(ctx context.Context, container testcontainers.Container, cont
 	return err
 }
 
+// createTempFile creates a temporary file with the given lines which is deleted after the test
+// Each created file is prefixed with 'blocky_e2e_file-'
 func createTempFile(lines ...string) string {
 	file, err := os.CreateTemp("", "blocky_e2e_file-")
 	Expect(err).Should(Succeed())

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xERR0R/blocky/helpertest"
-
 	"github.com/0xERR0R/blocky/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,10 +19,6 @@ func TestLists(t *testing.T) {
 	RunSpecs(t, "e2e Suite", Label("e2e"))
 }
 
-var tmpDir *helpertest.TmpFolder
-
 var _ = BeforeSuite(func(ctx context.Context) {
-	tmpDir = helpertest.NewTmpFolder("config")
-
 	SetDefaultEventuallyTimeout(5 * time.Second)
 })

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -6,12 +6,10 @@ import (
 	"time"
 
 	"github.com/0xERR0R/blocky/helpertest"
-	"github.com/avast/retry-go/v4"
 
 	"github.com/0xERR0R/blocky/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/testcontainers/testcontainers-go"
 )
 
 func init() {
@@ -23,35 +21,9 @@ func TestLists(t *testing.T) {
 	RunSpecs(t, "e2e Suite", Label("e2e"))
 }
 
-var (
-	network testcontainers.Network
-	tmpDir  *helpertest.TmpFolder
-)
+var tmpDir *helpertest.TmpFolder
 
 var _ = BeforeSuite(func(ctx context.Context) {
-	var err error
-
-	network, err = testcontainers.GenericNetwork(ctx, testcontainers.GenericNetworkRequest{
-		NetworkRequest: testcontainers.NetworkRequest{
-			Name:           NetworkName,
-			CheckDuplicate: false,
-			Attachable:     true,
-		},
-	})
-
-	Expect(err).Should(Succeed())
-
-	DeferCleanup(func(ctx context.Context) {
-		err := retry.Do(
-			func() error {
-				return network.Remove(ctx)
-			},
-			retry.Attempts(3),
-			retry.DelayType(retry.BackOffDelay),
-			retry.Delay(time.Second))
-		Expect(err).Should(Succeed())
-	})
-
 	tmpDir = helpertest.NewTmpFolder("config")
 
 	SetDefaultEventuallyTimeout(5 * time.Second)

--- a/e2e/helper.go
+++ b/e2e/helper.go
@@ -1,0 +1,149 @@
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/miekg/dns"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+//nolint:gochecknoglobals
+var (
+	// currentNetwork is the global test network instance.
+	currentNetwork = testNetwork{}
+)
+
+// WithNetwork attaches the container with the given alias to the test network
+func WithNetwork(ctx context.Context, alias string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) {
+		networkName := currentNetwork.Name()
+		network, err := testcontainers.GenericNetwork(ctx, testcontainers.GenericNetworkRequest{
+			NetworkRequest: testcontainers.NetworkRequest{
+				Name:           networkName,
+				CheckDuplicate: true, // force the Docker provider to reuse an existing network
+				Attachable:     true,
+			},
+		})
+
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			ginkgo.Fail(fmt.Sprintf("Failed to create network '%s'. Container won't be attached to this network: %v",
+				networkName, err))
+
+			return
+		}
+
+		// decrement the network counter when the test is finished and remove the network if it is not used anymore.
+		ginkgo.DeferCleanup(func(ctx context.Context) error {
+			if currentNetwork.Detach() {
+				if err := network.Remove(ctx); err != nil &&
+					!strings.Contains(err.Error(), "removing") &&
+					!strings.Contains(err.Error(), "not found") {
+					return err
+				}
+			}
+
+			return nil
+		})
+
+		// increment the network counter when the container is created.
+		currentNetwork.Attach()
+
+		// attaching to the network because it was created with success or it already existed.
+		req.Networks = append(req.Networks, networkName)
+
+		if req.NetworkAliases == nil {
+			req.NetworkAliases = make(map[string][]string)
+		}
+
+		req.NetworkAliases[networkName] = []string{alias}
+	}
+}
+
+// deferTerminate is a helper function to terminate the container when the test is finished.
+func deferTerminate[T testcontainers.Container](container T, err error) (T, error) {
+	ginkgo.DeferCleanup(func(ctx context.Context) error {
+		if container.IsRunning() {
+			return container.Terminate(ctx)
+		}
+
+		return nil
+	})
+
+	return container, err
+}
+
+// startContainerWithNetwork starts the container with the given alias and attaches it to the test network.
+// The container is wrapped with deferTerminate to terminate the container when the test is finished.
+func startContainerWithNetwork(ctx context.Context, req testcontainers.ContainerRequest, alias string,
+) (testcontainers.Container, error) {
+	greq := testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	}
+	WithNetwork(ctx, alias).Customize(&greq)
+
+	return deferTerminate(testcontainers.GenericContainer(ctx, greq))
+}
+
+// doDNSRequest sends the given DNS message to the container and returns the response.
+func doDNSRequest(ctx context.Context, container testcontainers.Container, message *dns.Msg) (*dns.Msg, error) {
+	const timeout = 5 * time.Second
+
+	c := &dns.Client{
+		Net:     "tcp",
+		Timeout: timeout,
+	}
+
+	host, port, err := getContainerHostPort(ctx, container, "53/tcp")
+	if err != nil {
+		return nil, err
+	}
+
+	msg, _, err := c.Exchange(message, net.JoinHostPort(host, port))
+
+	return msg, err
+}
+
+// getContainerHostPort returns the host and port of the given container and port.
+func getContainerHostPort(ctx context.Context, c testcontainers.Container, p nat.Port) (host, port string, err error) {
+	res, err := c.MappedPort(ctx, p)
+	if err != nil {
+		return "", "", err
+	}
+
+	host, err = c.Host(ctx)
+
+	if err != nil {
+		return "", "", err
+	}
+
+	return host, res.Port(), err
+}
+
+// getContainerLogs returns the logs of the given container.
+func getContainerLogs(ctx context.Context, c testcontainers.Container) (lines []string, err error) {
+	if r, err := c.Logs(ctx); err == nil {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if len(strings.TrimSpace(line)) > 0 {
+				lines = append(lines, line)
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			return nil, err
+		}
+
+		return lines, nil
+	}
+
+	return nil, err
+}

--- a/e2e/metrics_test.go
+++ b/e2e/metrics_test.go
@@ -25,14 +25,14 @@ var _ = Describe("Metrics functional tests", func() {
 			_, err = createDNSMokkaContainer(ctx, "moka1", `A google/NOERROR("A 1.2.3.4 123")`)
 			Expect(err).Should(Succeed())
 
-			_, err = createHTTPServerContainer(ctx, "httpserver1", tmpDir, "list1.txt", "domain1.com")
+			_, err = createHTTPServerContainer(ctx, "httpserver1", "list1.txt", "domain1.com")
 			Expect(err).Should(Succeed())
 
-			_, err = createHTTPServerContainer(ctx, "httpserver2", tmpDir, "list2.txt",
+			_, err = createHTTPServerContainer(ctx, "httpserver2", "list2.txt",
 				"domain1.com", "domain2", "domain3")
 			Expect(err).Should(Succeed())
 
-			_, err = createHTTPServerContainer(ctx, "httpserver2", tmpDir, "list2.txt", "domain1.com", "domain2", "domain3")
+			_, err = createHTTPServerContainer(ctx, "httpserver2", "list2.txt", "domain1.com", "domain2", "domain3")
 			Expect(err).Should(Succeed())
 
 			blocky, err = createBlockyContainer(ctx,

--- a/e2e/metrics_test.go
+++ b/e2e/metrics_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Metrics functional tests", func() {
 			_, err = createHTTPServerContainer(ctx, "httpserver2", tmpDir, "list2.txt", "domain1.com", "domain2", "domain3")
 			Expect(err).Should(Succeed())
 
-			blocky, err = createBlockyContainer(ctx, tmpDir,
+			blocky, err = createBlockyContainer(ctx,
 				"upstreams:",
 				"  groups:",
 				"    default:",

--- a/e2e/querylog_test.go
+++ b/e2e/querylog_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Query logs functional tests", func() {
 			mariaDB, err = createMariaDBContainer(ctx)
 			Expect(err).Should(Succeed())
 
-			blocky, err = createBlockyContainer(ctx, tmpDir,
+			blocky, err = createBlockyContainer(ctx,
 				"log:",
 				"  level: warn",
 				"upstreams:",
@@ -107,7 +107,7 @@ var _ = Describe("Query logs functional tests", func() {
 			postgresDB, err = createPostgresContainer(ctx)
 			Expect(err).Should(Succeed())
 
-			blocky, err = createBlockyContainer(ctx, tmpDir,
+			blocky, err = createBlockyContainer(ctx,
 				"log:",
 				"  level: warn",
 				"upstreams:",

--- a/e2e/redis_test.go
+++ b/e2e/redis_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Redis configuration tests", func() {
 	Describe("Cache sharing between blocky instances", func() {
 		When("Redis and 2 blocky instances are configured", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky1, err = createBlockyContainer(ctx, tmpDir,
+				blocky1, err = createBlockyContainer(ctx,
 					"log:",
 					"  level: warn",
 					"upstreams:",
@@ -51,7 +51,7 @@ var _ = Describe("Redis configuration tests", func() {
 				)
 				Expect(err).Should(Succeed())
 
-				blocky2, err = createBlockyContainer(ctx, tmpDir,
+				blocky2, err = createBlockyContainer(ctx,
 					"log:",
 					"  level: warn",
 					"upstreams:",
@@ -102,7 +102,7 @@ var _ = Describe("Redis configuration tests", func() {
 	Describe("Cache loading on startup", func() {
 		When("Redis and 1 blocky instance are configured", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky1, err = createBlockyContainer(ctx, tmpDir,
+				blocky1, err = createBlockyContainer(ctx,
 					"log:",
 					"  level: warn",
 					"upstreams:",
@@ -130,7 +130,7 @@ var _ = Describe("Redis configuration tests", func() {
 				})
 
 				By("start other instance of blocky now -> it should load the cache from redis", func() {
-					blocky2, err = createBlockyContainer(ctx, tmpDir,
+					blocky2, err = createBlockyContainer(ctx,
 						"log:",
 						"  level: warn",
 						"upstreams:",

--- a/e2e/testNetwork.go
+++ b/e2e/testNetwork.go
@@ -1,0 +1,52 @@
+package e2e
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// testNetwork is a helper struct to create a unique network name and count the number of attached containers.
+type testNetwork struct {
+	name    atomic.Value
+	counter atomic.Int32
+}
+
+// Name returns the name of the test network.
+func (n *testNetwork) Name() string {
+	if v := n.name.Load(); v != nil {
+		return v.(string)
+	}
+
+	n.Reset()
+
+	return n.Name()
+}
+
+// Reset generates a new network name.
+func (n *testNetwork) Reset() {
+	n.name.Store(fmt.Sprintf("blocky-e2e-network_%d", time.Now().Unix()))
+}
+
+// Attach increments the network counter.
+func (n *testNetwork) Attach() {
+	n.counter.Add(1)
+}
+
+// Detach decrements the network counter and returns true if the counter hits zero which indicates that the
+// network can be removed.
+func (n *testNetwork) Detach() bool {
+	if n.counter.Load() <= 0 {
+		return false
+	}
+
+	n.counter.Add(-1)
+
+	if n.counter.Load() == 0 {
+		n.Reset()
+
+		return true
+	}
+
+	return false
+}

--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 	Describe("'upstreams.init.strategy' parameter handling", func() {
 		When("'upstreams.init.strategy' is fast and upstream server as IP is not reachable", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky, err = createBlockyContainer(ctx, tmpDir,
+				blocky, err = createBlockyContainer(ctx,
 					"log:",
 					"  level: warn",
 					"upstreams:",
@@ -39,7 +39,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 		})
 		When("'upstreams.init.strategy' is fast and upstream server as host name is not reachable", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky, err = createBlockyContainer(ctx, tmpDir,
+				blocky, err = createBlockyContainer(ctx,
 					"log:",
 					"  level: warn",
 					"upstreams:",
@@ -58,7 +58,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 		})
 		When("'upstreams.init.strategy' is failOnError and upstream as IP address server is not reachable", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky, err = createBlockyContainer(ctx, tmpDir,
+				blocky, err = createBlockyContainer(ctx,
 					"upstreams:",
 					"  groups:",
 					"    default:",
@@ -76,7 +76,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 		})
 		When("'upstreams.init.strategy' is failOnError and upstream server as host name is not reachable", func() {
 			BeforeEach(func(ctx context.Context) {
-				blocky, err = createBlockyContainer(ctx, tmpDir,
+				blocky, err = createBlockyContainer(ctx,
 					"upstreams:",
 					"  groups:",
 					"    default:",
@@ -100,7 +100,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 				`A delay.com/delay(NOERROR("A 1.1.1.1 100"), "300ms")`)
 			Expect(err).Should(Succeed())
 
-			blocky, err = createBlockyContainer(ctx, tmpDir,
+			blocky, err = createBlockyContainer(ctx,
 				"upstreams:",
 				"  groups:",
 				"    default:",


### PR DESCRIPTION
Changes:
- removed tmpDir in favor of individual testfiles
- replaced `WithNetwork` with a modified version of the [testcontainer PR](https://github.com/testcontainers/testcontainers-go/pull/1894)
- moved some functions to different files to declutter `containers.go`

I opted for a modified version since the original one doesn't remove the network after the tests finish and also use `context.Background()`(which could be avoided with the Ginkgo context).

Behavior change to ensure only containers for the current test are inside the network:
- it is created during the first `WithNetwork` costomization
- it is deleted after the last container detaches
- during deletion a new network name is generated

Closes #1224