### PR TITLE
fix: add `Resolver.String` so logs don't use Go's default format

### DIFF
--- a/resolver/noop_resolver.go
+++ b/resolver/noop_resolver.go
@@ -21,6 +21,11 @@ func (NoOpResolver) Type() string {
 	return "noop"
 }
 
+// String implements `fmt.Stringer`.
+func (r NoOpResolver) String() string {
+	return r.Type()
+}
+
 // IsEnabled implements `config.Configurable`.
 func (NoOpResolver) IsEnabled() bool {
 	return true

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -140,7 +140,7 @@ func (r *ParallelBestResolver) String() string {
 
 	upstreams := make([]string, len(resolvers))
 	for i, s := range resolvers {
-		upstreams[i] = fmt.Sprintf("%s", s.resolver)
+		upstreams[i] = s.resolver.String()
 	}
 
 	return fmt.Sprintf("%s upstreams '%s (%s)'", r.Type(), r.cfg.Name, strings.Join(upstreams, ","))

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -68,6 +68,7 @@ func newRequestWithClientID(question string, rType dns.Type, ip, requestClientID
 // Resolver generic interface for all resolvers
 type Resolver interface {
 	config.Configurable
+	fmt.Stringer
 
 	// Type returns a short, user-friendly, name for the resolver.
 	//
@@ -191,6 +192,11 @@ func withType(t string) typed {
 // Type implements `Resolver`.
 func (t *typed) Type() string {
 	return t.typeName
+}
+
+// String implements `fmt.Stringer`.
+func (t *typed) String() string {
+	return t.Type()
 }
 
 func (t *typed) log() *logrus.Entry {

--- a/resolver/strict_resolver.go
+++ b/resolver/strict_resolver.go
@@ -66,7 +66,7 @@ func (r *StrictResolver) String() string {
 
 	upstreams := make([]string, len(resolvers))
 	for i, s := range resolvers {
-		upstreams[i] = fmt.Sprintf("%s", s.resolver)
+		upstreams[i] = s.resolver.String()
 	}
 
 	return fmt.Sprintf("%s upstreams '%s (%s)'", strictResolverType, r.cfg.Name, strings.Join(upstreams, ","))


### PR DESCRIPTION
Related to #1337