### PR TITLE
fix: don't use upstream ServFail responses besides forwarding them

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -625,7 +626,13 @@ func (s *Server) resolve(ctx context.Context, request *model.Request) (*model.Re
 
 		response, err = s.queryResolver.Resolve(ctx, request)
 		if err != nil {
-			return nil, err
+			var upstreamErr *resolver.UpstreamServerError
+
+			if errors.As(err, &upstreamErr) {
+				response = &model.Response{Res: upstreamErr.Msg, RType: model.ResponseTypeRESOLVED, Reason: upstreamErr.Error()}
+			} else {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Don't consider `ServFail` as a TCP/UDP race win.
Use an error to also make sure we don't, for instance, cache such
responses.

Fixe #1337 