### PR TITLE
fix: set capability for privileged ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN --mount=type=bind,target=. \
   --mount=type=cache,target=/go/pkg \
   make build
 
+# set capability for privileged ports
+RUN setcap cap_net_bind_service=+ep /bin/blocky
+
 # ----------- stage: final
 FROM scratch
 


### PR DESCRIPTION
This is required for running the container in a non-priviledged way without specifically adding `NET_BIND_SERVICE`.

See here as well: https://github.com/coredns/coredns/blob/master/Dockerfile#L15