### PR TITLE
docs: installation section tweaks

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,6 @@ You can choose one of the following installation options:
 
 * Run as standalone binary
 * Run as docker container
-* Kubernetes with helm chart
 
 ## Prepare your configuration
 
@@ -147,46 +146,54 @@ For complex setups, splitting the configuration between multiple YAML files migh
 
 !!! warning
 
-    These projects are maintained by other people.
+    These projects are not associated with Blocky devs and are listed here for convenience.
 
 ### Web UI
 
-[Blocky Frontend](https://github.com/Mozart409/blocky-frontend) provides a Web UI to control blocky. See linked project for installation instructions.
+[Blocky Frontend](https://github.com/Mozart409/blocky-frontend) by [@Mozart409](https://github.com/Mozart409) provides a Web UI to control blocky.
+See linked project for installation instructions.
 
-### Run with helm chart on Kubernetes
-
-See [this repo](https://github.com/truecharts/charts/tree/master/charts/enterprise/blocky),
-the [documentation](https://truecharts.org/docs/charts/enterprise/blocky/)
-and [the configuration instructions](https://truecharts.org/docs/charts/enterprise/blocky/installation-notes) for details about running blocky via helm in kubernetes.
-
-### Run as an App for TrueNAS SCALE
-
-You can find the App in the TrueCharts [App Catalog](https://truecharts.org/docs/manual/SCALE%20Apps/Adding-TrueCharts)
-or read the [documentation](https://truecharts.org/docs/charts/enterprise/blocky/)
-and [ configuration instructions](https://truecharts.org/docs/charts/enterprise/blocky/installation-notes) for details about running blocky as a native TrueNAS SCALE App.
-
-### AUR package for Arch Linux
+### Arch Linux via AUR
 
 See [https://aur.archlinux.org/packages/blocky/](https://aur.archlinux.org/packages/blocky/)
 
-### Package for Alpine Linux
+### Alpine Linux
 
 See [https://pkgs.alpinelinux.org/package/edge/testing/x86/blocky](https://pkgs.alpinelinux.org/package/edge/testing/x86/blocky)
 
-### Installation script for CentOS/Fedora
+### CentOS/Debian/Fedora install script
 
 See [https://github.com/m0zgen/blocky-installer](https://github.com/m0zgen/blocky-installer)
 
-### Package for FreeBSD
+### FreeBSD
 
 See [https://www.freebsd.org/cgi/ports.cgi?query=blocky&stype=all](https://www.freebsd.org/cgi/ports.cgi?query=blocky&stype=all)
 
-### Package for Gentoo
+### Gentoo
 
-See [Gentoo wiki page](https://wiki.gentoo.org/wiki/Project:GURU/Information_for_End_Users) to enable GURU repository then run `emerge net-dns/blocky`
+See the [Gentoo Wiki](https://wiki.gentoo.org/wiki/Project:GURU/Information_for_End_Users) to enable the GURU repository, then run `emerge net-dns/blocky`.
 
-### Homebrew package for MacOS
+### NixOS
+
+As `pkgs.blocky` and a module:
+
+```nix
+services.blocky = {
+  enable = true;
+
+  settings = {
+    # anything from config.yml
+  };
+};
+```
+
+### macOS via Homebrew
 
 See [https://formulae.brew.sh/formula/blocky](https://formulae.brew.sh/formula/blocky)
+
+### TrueNAS SCALE via TrueCharts
+
+See [https://truecharts.org/charts/enterprise/blocky/](https://truecharts.org/charts/enterprise/blocky/)  
+(TrueCharts is not an official TrueNAS project)
 
 --8<-- "docs/includes/abbreviations.md"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,8 +7,8 @@ You can choose one of the following installation options:
 
 ## Prepare your configuration
 
-Blocky supports single or multiple YAML files as configuration. Create new `config.yaml` with your configuration (
-see [Configuration](configuration.md) for more details and all configuration options).
+Blocky supports single or multiple YAML files as configuration. Create new `config.yml` with your configuration
+(see [Configuration](configuration.md) for more details and all configuration options).
 
 Simple configuration file, which enables only basic features:
 
@@ -38,26 +38,25 @@ run `./blocky --config config.yml`.
 
 !!! warning
 
-    Please be aware, if you want to use port 53 or 953 on Linux you should add CAP_NET_BIND_SERVICE capability
-    to the binary or run with root privileges (running as root is not recommended).
+    Please be aware, if you want to use port 53 or 953 on Linux you should add `CAP_NET_BIND_SERVICE` capability
+    to the binary with `setcap 'cap_net_bind_service=+ep' ./blocky`, or run as root (not recommended).
 
 ## Run with docker
 
 ### Alternative registry
 
-Blocky docker images are deployed to DockerHub (`spx01/blocky`) and GitHub Container Registry (`ghcr.io/0xerr0r/blocky`)
-.
+Blocky docker images are deployed to DockerHub (`spx01/blocky`) and GitHub Container Registry (`ghcr.io/0xerr0r/blocky`).
 
 ### Parameters
 
-You can define the location of the config file in the container with environment variable "BLOCKY_CONFIG_FILE".
-Default value is "/app/config.yml".
+You can define the location of the config file in the container with environment variable `BLOCKY_CONFIG_FILE`.
+Default value is `/app/config.yml`.
 
 ### Docker from command line
 
 Execute following command from the command line:
 
-```    
+```sh
 docker run --name blocky -v /path/to/config.yml:/app/config.yml -p 4000:4000 -p 53:53/udp spx01/blocky
 ```
 
@@ -89,7 +88,7 @@ services:
 
 and start docker container with
 
-```
+```sh
 docker-compose up -d
 ```
 
@@ -111,7 +110,7 @@ services:
     ports:
       - "53:53/tcp"
       - "53:53/udp"
-      - "4000:4000/tcp" # Prometheus stats (if enabled).
+      - "4000:4000/tcp" # Prometheus stats (if enabled)
     environment:
       - TZ=Europe/Berlin
     volumes:
@@ -136,11 +135,13 @@ volumes:
 
 For complex setups, splitting the configuration between multiple YAML files might be desired. In this case, folder containing YAML files is passed on startup, Blocky will join all the files.
 
-`./blocky --config ./config/`
+```sh
+./blocky --config ./config/
+```
 
 !!! warning
 
-    Blocky simply joins the multiple YAML files. If a directive (e.g. `upstream`) is repeated in multiple files, the configuration will not load and start will fail.
+    Blocky simply joins the multiple YAML files. If an option (e.g. `upstream`) is present in multiple files, the configuration will not load and start will fail.
 
 ## Other installation types
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,11 +148,6 @@ For complex setups, splitting the configuration between multiple YAML files migh
 
     These projects are not associated with Blocky devs and are listed here for convenience.
 
-### Web UI
-
-[Blocky Frontend](https://github.com/Mozart409/blocky-frontend) by [@Mozart409](https://github.com/Mozart409) provides a Web UI to control blocky.
-See linked project for installation instructions.
-
 ### Arch Linux via AUR
 
 See [https://aur.archlinux.org/packages/blocky/](https://aur.archlinux.org/packages/blocky/)
@@ -195,5 +190,20 @@ See [https://formulae.brew.sh/formula/blocky](https://formulae.brew.sh/formula/b
 
 See [https://truecharts.org/charts/enterprise/blocky/](https://truecharts.org/charts/enterprise/blocky/)  
 (TrueCharts is not an official TrueNAS project)
+
+## Companion projects
+
+!!! warning
+
+    These projects are not associated with Blocky devs and are listed here for convenience.
+
+### Lists updater
+
+[Blocky lists updater](https://github.com/shizunge/blocky-lists-updater) updates list related configuration without restarting blocky DNS.
+
+### Web UI
+
+[Blocky Frontend](https://github.com/Mozart409/blocky-frontend) provides a Web UI to control blocky.
+See linked project for installation instructions.
 
 --8<-- "docs/includes/abbreviations.md"


### PR DESCRIPTION
I checked all links and they have blocky the latest release ATM.  
Just unsure about the CentOS/Fedora install script here, so I opened an issue: https://github.com/m0zgen/blocky-installer/issues/6

Rendered: https://thinkchaos.github.io/blocky/docs-installation-tweaks/installation/

Fixes #847 