### PR TITLE
fix(log): don't print querylog target password when using a database

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,8 @@ const (
 	udpPort   = 53
 	tlsPort   = 853
 	httpsPort = 443
+
+	secretObfuscator = "********"
 )
 
 type Configurable interface {

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -57,14 +57,10 @@ func (c *QueryLog) censoredTarget() string {
 		return c.Target
 	}
 
-	if target.User == nil {
+	pass, ok := target.User.Password()
+	if !ok {
 		return c.Target
 	}
 
-	// Drop the password since special chars like * get URL escaped
-	if pass, hasPass :=target.User.Password(); hasPass {
-		return strings.Replace(target.String(), pass, strings.Repeat("*", len(pass)), 1)
-	}
-
-	return target.String()
+	return strings.ReplaceAll(c.Target, pass, secretObfuscator)
 }

--- a/config/query_log_test.go
+++ b/config/query_log_test.go
@@ -55,6 +55,21 @@ var _ = Describe("QueryLogConfig", func() {
 			Expect(hook.Calls).ShouldNot(BeEmpty())
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("logRetentionDays:")))
 		})
+
+		DescribeTable("doesn't print the target password", func(target string) {
+			cfg.Type = QueryLogTypeMysql
+			cfg.Target = target
+
+			cfg.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("password")))
+		},
+			Entry("without scheme", "user:password@localhost"),
+			Entry("with scheme", "scheme://user:password@localhost"),
+			Entry("no password", "localhost"),
+			Entry("not a URL", "invalid!://"),
+		)
 	})
 
 	Describe("SetDefaults", func() {

--- a/config/query_log_test.go
+++ b/config/query_log_test.go
@@ -56,7 +56,7 @@ var _ = Describe("QueryLogConfig", func() {
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("logRetentionDays:")))
 		})
 
-		DescribeTable("doesn't print the target password", func(target string) {
+		DescribeTable("secret censoring", func(target string) {
 			cfg.Type = QueryLogTypeMysql
 			cfg.Target = target
 

--- a/config/redis.go
+++ b/config/redis.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"strings"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -32,7 +30,7 @@ func (c *Redis) LogConfig(logger *logrus.Entry) {
 	}
 
 	logger.Info("username: ", c.Username)
-	logger.Info("password: ", obfuscatePassword(c.Password))
+	logger.Info("password: ", secretObfuscator)
 	logger.Info("database: ", c.Database)
 	logger.Info("required: ", c.Required)
 	logger.Info("connectionAttempts: ", c.ConnectionAttempts)
@@ -42,16 +40,11 @@ func (c *Redis) LogConfig(logger *logrus.Entry) {
 		logger.Info("sentinel:")
 		logger.Info("  master: ", c.Address)
 		logger.Info("  username: ", c.SentinelUsername)
-		logger.Info("  password: ", obfuscatePassword(c.SentinelPassword))
+		logger.Info("  password: ", secretObfuscator)
 		logger.Info("  addresses:")
 
 		for _, addr := range c.SentinelAddresses {
 			logger.Info("    - ", addr)
 		}
 	}
-}
-
-// obfuscatePassword replaces all characters of a password except the first and last with *
-func obfuscatePassword(pass string) string {
-	return strings.Repeat("*", len(pass))
 }

--- a/config/redis_test.go
+++ b/config/redis_test.go
@@ -86,19 +86,23 @@ var _ = Describe("Redis", func() {
 						ContainElement(ContainSubstring("  - localhost:26380"))))
 			})
 		})
-	})
 
-	Describe("obfuscatePassword", func() {
-		When("password is empty", func() {
-			It("should return empty string", func() {
-				Expect(obfuscatePassword("")).Should(Equal(""))
-			})
+		const secretValue = "secret-value"
+
+		It("should not log the password", func() {
+			c.Password = secretValue
+			c.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring(secretValue)))
 		})
 
-		When("password is not empty", func() {
-			It("should return obfuscated password", func() {
-				Expect(obfuscatePassword("test123")).Should(Equal("*******"))
-			})
+		It("should not log the sentinel password", func() {
+			c.SentinelPassword = secretValue
+			c.LogConfig(logger)
+
+			Expect(hook.Calls).ShouldNot(BeEmpty())
+			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring(secretValue)))
 		})
 	})
 })


### PR DESCRIPTION
Ideally we could add a e2e test that configures trace level logging and all config options that have a secret, does a query, and then checks the container logs don't contain any secret (making all secrets contain a unique token would make that easy).

Fixes #1421
