### PR TITLE
ci: minor changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,12 @@ name: docs
 
 on:
   push:
-    branches:
-      - "**"
     tags:
       - v*
+    paths:
+      - .github/workflows/**
+      - mkdocs.yml
+      - docs/**
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -26,7 +26,12 @@ jobs:
           else
             echo "enabled=0" >> $GITHUB_OUTPUT
 
-            echo "Workflow is disabled(create FORK_SYNC_TOKEN secret with repo write permission to enable it)"
+            (
+              echo 'Workflow is disabled (create `FORK_SYNC_TOKEN` secret with repo write permission to enable it)'
+              echo
+              echo 'Alternatively, you can disable it for your repo from the web UI:'
+              echo 'https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow'
+            ) | tee "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Sync

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,6 +2,13 @@ name: Makefile
 
 on:
   push:
+    paths:
+      - .github/workflows/**
+      - Dockerfile
+      - Makefile
+      - '**.go'
+      - 'go.*'
+      - 'helpertest/data/**'
   pull_request:
 
 permissions:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -9,10 +9,6 @@ permissions:
   actions: read
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   GINKGO_PROCS: --procs=1
 


### PR DESCRIPTION
- Add `on: push: paths:` to limit when some workflows are run
- Add a hint that the fork sync workflow can be disabled without modifying the file
- Remove the concurrency limit for the Makefile workflow:

   I like to push my commits one by one so they all get the full CI validation.
   This limits forces me to push a commit, and wait for the result before pushing another.
