### PR TITLE
feat: add queryLog.ignore.sudn option to ignore SUDN responses

### DIFF
--- a/config/query_log.go
+++ b/config/query_log.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/0xERR0R/blocky/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,6 +17,11 @@ type QueryLog struct {
 	CreationCooldown Duration        `yaml:"creationCooldown" default:"2s"`
 	Fields           []QueryLogField `yaml:"fields"`
 	FlushInterval    Duration        `yaml:"flushInterval" default:"30s"`
+	Ignore           QueryLogIgnore  `yaml:"ignore"`
+}
+
+type QueryLogIgnore struct {
+	SUDN bool `yaml:"sudn" default:"false"`
 }
 
 // SetDefaults implements `defaults.Setter`.
@@ -43,6 +49,11 @@ func (c *QueryLog) LogConfig(logger *logrus.Entry) {
 	logger.Debugf("creationCooldown: %s", c.CreationCooldown)
 	logger.Infof("flushInterval: %s", c.FlushInterval)
 	logger.Infof("fields: %s", c.Fields)
+
+	logger.Infof("ignore:")
+	log.WithIndent(logger, "  ", func(e *logrus.Entry) {
+		logger.Infof("sudn: %t", c.Ignore.SUDN)
+	})
 }
 
 func (c *QueryLog) censoredTarget() string {

--- a/config/query_log_test.go
+++ b/config/query_log_test.go
@@ -54,6 +54,7 @@ var _ = Describe("QueryLogConfig", func() {
 
 			Expect(hook.Calls).ShouldNot(BeEmpty())
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("logRetentionDays:")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("sudn:")))
 		})
 
 		DescribeTable("secret censoring", func(target string) {

--- a/querylog/logger_writer.go
+++ b/querylog/logger_writer.go
@@ -1,6 +1,7 @@
 package querylog
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/0xERR0R/blocky/log"
@@ -19,22 +20,36 @@ func NewLoggerWriter() *LoggerWriter {
 }
 
 func (d *LoggerWriter) Write(entry *LogEntry) {
-	d.logger.WithFields(
-		logrus.Fields{
-			"client_ip":       entry.ClientIP,
-			"client_names":    strings.Join(entry.ClientNames, "; "),
-			"response_reason": entry.ResponseReason,
-			"response_type":   entry.ResponseType,
-			"response_code":   entry.ResponseCode,
-			"question_name":   entry.QuestionName,
-			"question_type":   entry.QuestionType,
-			"answer":          entry.Answer,
-			"duration_ms":     entry.DurationMs,
-			"hostname":        util.HostnameString(),
-		},
-	).Infof("query resolved")
+	fields := LogEntryFields(entry)
+
+	d.logger.WithFields(fields).Infof("query resolved")
 }
 
 func (d *LoggerWriter) CleanUp() {
 	// Nothing to do
+}
+
+func LogEntryFields(entry *LogEntry) logrus.Fields {
+	return withoutZeroes(logrus.Fields{
+		"client_ip":       entry.ClientIP,
+		"client_names":    strings.Join(entry.ClientNames, "; "),
+		"response_reason": entry.ResponseReason,
+		"response_type":   entry.ResponseType,
+		"response_code":   entry.ResponseCode,
+		"question_name":   entry.QuestionName,
+		"question_type":   entry.QuestionType,
+		"answer":          entry.Answer,
+		"duration_ms":     entry.DurationMs,
+		"hostname":        util.HostnameString(),
+	})
+}
+
+func withoutZeroes(fields logrus.Fields) logrus.Fields {
+	for k, v := range fields {
+		if reflect.ValueOf(v).IsZero() {
+			delete(fields, k)
+		}
+	}
+
+	return fields
 }


### PR DESCRIPTION
Basic query log `ignore` config with only SUDN support, as suggested by @kwitsch!

We still log the ignored entries to the console at debug level.

Progress #1390