### PR TITLE
tests(resolver): fix data race introduced by querylog ignore

### DIFF
--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -135,9 +135,6 @@ var _ = Describe("QueryLoggingResolver", func() {
 				ctx, cancelFn = context.WithCancel(context.Background())
 				DeferCleanup(cancelFn)
 
-				// Capture written logs
-				sut.logChan = make(chan *querylog.LogEntry, 16)
-
 				// Capture ignored logs
 				{
 					var logger *logrus.Entry


### PR DESCRIPTION
Race only happens in tests: the write removed here can happen at the same time as `writeLog` is reading the struct field since cancelling the context doesn't guarantee immediate shutdown.
We can just use the existing channel so the field becomes read-only, avoiding the race.

Example CI failure:
https://github.com/0xERR0R/blocky/actions/runs/8632315589/job/23662702020

For local repro, adding a 2ms sleep to `writeLog`'s startup was enough for me.