### PR TITLE
Feature: binary build workflow

### DIFF
--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Setup Golang
         uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
@@ -83,8 +85,8 @@ jobs:
       - name: Rename binary
         run: |
           if [[ "${{ inputs.goos }}" == "windows" ]]; then
-            mv build/blocky.exe build/blocky.exe
-          else if [[ "${{ inputs.goarch }}" == "arm" ]]; then
+            mv build/blocky build/blocky.exe
+          elif [[ "${{ inputs.goarch }}" == "arm" ]]; then
             mv build/blocky build/blocky-${{ inputs.goos }}-${{ inputs.goarch }}${{ inputs.goarm }}
           else
             mv build/blocky build/blocky-${{ inputs.goos }}-${{ inputs.goarch }}

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       goos:
-        description: "GOOS"
+        description: "Target OS"
         required: true
         default: "linux"
         type: choice
@@ -16,7 +16,7 @@ on:
           - openbsd
           - darwin
       goarch:
-        description: "GOARCH"
+        description: "Target architecture"
         required: true
         default: "amd64"
         type: choice
@@ -25,7 +25,7 @@ on:
           - arm
           - arm64
       goarm:
-        description: "GOARM"
+        description: "Target ARM version(only used with arm architecture)"
         required: true
         default: "7"
         type: choice
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Golang
         uses: actions/setup-go@v5
@@ -80,7 +82,11 @@ jobs:
           GOOS: ${{ inputs.goos }}
           GOARCH: ${{ inputs.goarch }}
           GOARM: ${{ inputs.goarm }}
-        run: make build
+        run: |
+          if [[ "${{ inputs.goarch }}" != "arm" ]]; then
+            unset GOARM
+          fi
+          make build
 
       - name: Rename binary
         run: |
@@ -93,7 +99,7 @@ jobs:
           fi
 
       - name: Store build artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: blocky
           path: bin/blocky*

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -80,8 +80,19 @@ jobs:
           GOARM: ${{ inputs.goarm }}
         run: make build
 
+      - name: Rename binary
+        run: |
+          if [[ "${{ inputs.goos }}" == "windows" ]]; then
+            mv build/blocky.exe build/blocky.exe
+          else if [[ "${{ inputs.goarch }}" == "arm" ]]; then
+            mv build/blocky build/blocky-${{ inputs.goos }}-${{ inputs.goarch }}${{ inputs.goarm }}
+          else
+            mv build/blocky build/blocky-${{ inputs.goos }}-${{ inputs.goarch }}
+          fi
+
       - name: Store build artifact
         uses: actions/upload-artifact@v2
         with:
           name: blocky
-          path: build/blocky
+          path: build/blocky*
+          retention-days: 5

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -40,11 +40,10 @@ jobs:
       - name: Input Check
         id: check
         run: |
-          if [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm" ]]; then
-            echo "Combination goos=windows goarch=arm is not supported"
-            exit 1
-          elif [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm64" ]]; then
-            echo "Combination goos=windows goarch=arm64 is not supported"
+          if [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm" ]] || \
+            [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm64" ]]; then
+            echo "::error title='Unsupported input'::Combination goos=windows goarch=${{ inputs.goarch }} is not supported" \
+              >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 
@@ -72,13 +71,11 @@ jobs:
       - name: Get variables
         id: get_vars
         run: |
-          if [[ "${{ github.repository_owner }}" == "0xERR0R" ]]; then
-            echo "version=$(git describe --always --tags)" >> $GITHUB_OUTPUT
-          else
+          if [[ "${{ github.repository_owner }}" != "0xERR0R" ]]; then
             git remote add upstream https://github.com/0xERR0R/blocky.git
             git fetch upstream
-            echo "version=$(git describe --always --tags upstream/main)" >> $GITHUB_OUTPUT
           fi
+          echo "version=$(git describe --always --tags)" >> $GITHUB_OUTPUT
           if [[ "${{ inputs.goarch }}" == "arm" ]]; then
             echo "arch=${{ inputs.goarch }}${{ inputs.goarm }}" >> $GITHUB_OUTPUT
           else
@@ -102,16 +99,12 @@ jobs:
           make build
 
       - name: Rename binary
-        run: |
-          if [[ "${{ inputs.goos }}" == "windows" ]]; then
-            mv bin/blocky bin/blocky.exe
-          else
-            mv bin/blocky bin/blocky-${{ inputs.goos }}-${{ steps.get_vars.outputs.arch }}
-          fi
+        if: inputs.goos  == 'windows'
+        run: mv bin/blocky bin/blocky.exe
 
       - name: Store build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: blocky-${{ steps.get_vars.outputs.version }}-${{ inputs.goos }}-${{ steps.get_vars.outputs.arch }}
+          name: blocky_${{ steps.get_vars.outputs.version }}_${{ inputs.goos }}_${{ steps.get_vars.outputs.arch }}
           path: bin/blocky*
           retention-days: 5

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -45,7 +45,9 @@ jobs:
             [[ "${{ inputs.goos }}" == "darwin" && "${{ inputs.goarch }}" == "arm" ]]; then
             echo "## Unsupported input" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Combination goos=${{ inputs.goarch }} goarch=${{ inputs.goarch }} is not supported" >> $GITHUB_STEP_SUMMARY
+            echo "Combination not supported: ">> $GITHUB_STEP_SUMMARY
+            echo " - goos=${{ inputs.goos }}" >> $GITHUB_STEP_SUMMARY
+            echo " - goarch=${{ inputs.goarch }}" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -81,7 +81,7 @@ jobs:
           else
             git remote add upstream https://github.com/0xERR0R/blocky.git
             git fetch upstream
-            echo "version=$(git describe --always --tags upstream)" >> $GITHUB_OUTPUT
+            echo "version=$(git describe --always --tags upstream/main)" >> $GITHUB_OUTPUT
           fi
           if [[ "${{ inputs.goarch }}" == "arm" ]]; then
             echo "arch=${{ inputs.goarch }}${{ inputs.goarm }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -41,8 +41,10 @@ jobs:
         id: check
         run: |
           if [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm" ]] || \
-            [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm64" ]]; then
-            echo "Unsupported input: Combination goos=windows goarch=${{ inputs.goarch }} is not supported" \
+            [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm64" ]] || \
+            [[ "${{ inputs.goos }}" == "netbsd" && "${{ inputs.goarch }}" == "arm64" ]] || \
+            [[ "${{ inputs.goos }}" == "darwin" && "${{ inputs.goarch }}" == "arm" ]]; then
+            echo "## Unsupported input: Combination goos=${{ inputs.goarch }} goarch=${{ inputs.goarch }} is not supported" \
               >> $GITHUB_STEP_SUMMARY
             exit 1
           fi

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -34,7 +34,7 @@ on:
           - 7
 
 jobs:
-  check:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Input Check
@@ -48,10 +48,6 @@ jobs:
             exit 1
           fi
 
-  build:
-    runs-on: ubuntu-latest
-    needs: check
-    steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -83,6 +83,7 @@ jobs:
           GOARCH: ${{ inputs.goarch }}
           GOARM: ${{ inputs.goarm }}
         run: |
+          export VERSION=$(git describe --tags --always origin/main)
           if [[ "${{ inputs.goarch }}" != "arm" ]]; then
             unset GOARM
           fi

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -73,6 +73,22 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Get variables
+        id: get_vars
+        run: |
+          if [[ "${{ github.repository_owner }}" == "0xERR0R" ]]; then
+            echo "version=$(git describe --always --tags)" >> $GITHUB_OUTPUT
+          else
+            git remote add upstream https://github.com/0xERR0R/blocky.git
+            git fetch upstream
+            echo "version=$(git describe --always --tags upstream)" >> $GITHUB_OUTPUT
+          fi
+          if [[ "${{ inputs.goarch }}" == "arm" ]]; then
+            echo "arch=${{ inputs.goarch }}${{ inputs.goarm }}" >> $GITHUB_OUTPUT
+          else
+            echo "arch=${{ inputs.goarch }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build
         env:
           GO_SKIP_GENERATE: 1
@@ -82,8 +98,8 @@ jobs:
           GOOS: ${{ inputs.goos }}
           GOARCH: ${{ inputs.goarch }}
           GOARM: ${{ inputs.goarm }}
+          VERSION: ${{ steps.get_vars.outputs.version }}
         run: |
-          export VERSION=$(git describe --tags --always origin/main)
           if [[ "${{ inputs.goarch }}" != "arm" ]]; then
             unset GOARM
           fi
@@ -93,15 +109,13 @@ jobs:
         run: |
           if [[ "${{ inputs.goos }}" == "windows" ]]; then
             mv bin/blocky bin/blocky.exe
-          elif [[ "${{ inputs.goarch }}" == "arm" ]]; then
-            mv bin/blocky bin/blocky-${{ inputs.goos }}-${{ inputs.goarch }}${{ inputs.goarm }}
           else
-            mv bin/blocky bin/blocky-${{ inputs.goos }}-${{ inputs.goarch }}
+            mv bin/blocky bin/blocky-${{ inputs.goos }}-${{ steps.get_vars.outputs.arch }}
           fi
 
       - name: Store build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: blocky
+          name: blocky-${{ steps.get_vars.outputs.version }}-${{ inputs.goos }}-${{ steps.get_vars.outputs.arch }}
           path: bin/blocky*
           retention-days: 5

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -85,16 +85,16 @@ jobs:
       - name: Rename binary
         run: |
           if [[ "${{ inputs.goos }}" == "windows" ]]; then
-            mv build/blocky build/blocky.exe
+            mv bin/blocky bin/blocky.exe
           elif [[ "${{ inputs.goarch }}" == "arm" ]]; then
-            mv build/blocky build/blocky-${{ inputs.goos }}-${{ inputs.goarch }}${{ inputs.goarm }}
+            mv bin/blocky bin/blocky-${{ inputs.goos }}-${{ inputs.goarch }}${{ inputs.goarm }}
           else
-            mv build/blocky build/blocky-${{ inputs.goos }}-${{ inputs.goarch }}
+            mv bin/blocky bin/blocky-${{ inputs.goos }}-${{ inputs.goarch }}
           fi
 
       - name: Store build artifact
         uses: actions/upload-artifact@v2
         with:
           name: blocky
-          path: build/blocky*
+          path: bin/blocky*
           retention-days: 5

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -1,0 +1,87 @@
+name: Build binary
+
+on:
+  workflow_dispatch:
+    inputs:
+      goos:
+        description: "GOOS"
+        required: true
+        default: "linux"
+        type: choice
+        options:
+          - linux
+          - windows
+          - freebsd
+          - netbsd
+          - openbsd
+          - darwin
+      goarch:
+        description: "GOARCH"
+        required: true
+        default: "amd64"
+        type: choice
+        options:
+          - amd64
+          - arm
+          - arm64
+      goarm:
+        description: "GOARM"
+        required: true
+        default: "7"
+        type: choice
+        options:
+          - 6
+          - 7
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Input Check
+        id: check
+        run: |
+          if [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm" ]]; then
+            echo "Combination goos=windows goarch=arm is not supported"
+            exit 1
+          elif [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm64" ]]; then
+            echo "Combination goos=windows goarch=arm64 is not supported"
+            exit 1
+          fi
+
+  build:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+
+      - name: Setup ZigCC & ZigCPP
+        run: |
+          go install github.com/dosgo/zigtool/zigcc@latest
+          go install github.com/dosgo/zigtool/zigcpp@latest
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build
+        env:
+          GO_SKIP_GENERATE: 1
+          CGO_ENABLED: 0
+          CC: zigcc
+          CXX: zigcpp
+          GOOS: ${{ inputs.goos }}
+          GOARCH: ${{ inputs.goarch }}
+          GOARM: ${{ inputs.goarm }}
+        run: make build
+
+      - name: Store build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: blocky
+          path: build/blocky

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           if [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm" ]] || \
             [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm64" ]]; then
-            echo "::error title='Unsupported input'::Combination goos=windows goarch=${{ inputs.goarch }} is not supported" \
+            echo "Unsupported input: Combination goos=windows goarch=${{ inputs.goarch }} is not supported" \
               >> $GITHUB_STEP_SUMMARY
             exit 1
           fi

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -38,14 +38,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Input Check
-        id: check
         run: |
           if [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm" ]] || \
             [[ "${{ inputs.goos }}" == "windows" && "${{ inputs.goarch }}" == "arm64" ]] || \
             [[ "${{ inputs.goos }}" == "netbsd" && "${{ inputs.goarch }}" == "arm64" ]] || \
             [[ "${{ inputs.goos }}" == "darwin" && "${{ inputs.goarch }}" == "arm" ]]; then
-            echo "## Unsupported input: Combination goos=${{ inputs.goarch }} goarch=${{ inputs.goarch }} is not supported" \
-              >> $GITHUB_STEP_SUMMARY
+            echo "## Unsupported input" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Combination goos=${{ inputs.goarch }} goarch=${{ inputs.goarch }} is not supported" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 
@@ -73,6 +73,7 @@ jobs:
       - name: Get variables
         id: get_vars
         run: |
+          # Check if the repository is forked and add upstream for correct versioning
           if [[ "${{ github.repository_owner }}" != "0xERR0R" ]]; then
             git remote add upstream https://github.com/0xERR0R/blocky.git
             git fetch upstream
@@ -80,8 +81,10 @@ jobs:
           echo "version=$(git describe --always --tags)" >> $GITHUB_OUTPUT
           if [[ "${{ inputs.goarch }}" == "arm" ]]; then
             echo "arch=${{ inputs.goarch }}${{ inputs.goarm }}" >> $GITHUB_OUTPUT
+            echo "arm=${{ inputs.goarm }}" >> $GITHUB_OUTPUT
           else
             echo "arch=${{ inputs.goarch }}" >> $GITHUB_OUTPUT
+            echo "arm=" >> $GITHUB_OUTPUT
           fi
 
       - name: Build
@@ -92,13 +95,9 @@ jobs:
           CXX: zigcpp
           GOOS: ${{ inputs.goos }}
           GOARCH: ${{ inputs.goarch }}
-          GOARM: ${{ inputs.goarm }}
+          GOARM: ${{ steps.get_vars.outputs.arm }}
           VERSION: ${{ steps.get_vars.outputs.version }}
-        run: |
-          if [[ "${{ inputs.goarch }}" != "arm" ]]; then
-            unset GOARM
-          fi
-          make build
+        run: make build
 
       - name: Rename binary
         if: inputs.goos  == 'windows'

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -3,12 +3,12 @@ name: Makefile
 on:
   push:
     paths:
-      - .github/workflows/**
+      - .github/workflows/makefile.yml
       - Dockerfile
       - Makefile
-      - '**.go'
-      - 'go.*'
-      - 'helpertest/data/**'
+      - "**.go"
+      - "go.*"
+      - "helpertest/data/**"
   pull_request:
 
 permissions:


### PR DESCRIPTION
Added a new workflow for binary artifact creation. 
It runs only on dispatch and creates a zip achive with a blocky binary in it compiled acording to the selected parameters(os, arch & arm version).
The artifact is only stored for 5 days to limit storage polution.

The idea behind it is to simplify binary distribution to users for testing purpose while working on issues. 