### PR TITLE
Log the rule which is the cause of blocking

### DIFF
--- a/cache/stringcache/string_caches.go
+++ b/cache/stringcache/string_caches.go
@@ -50,7 +50,11 @@ func (cache stringMap) contains(searchString string) bool {
 	})
 
 	if idx < searchBucketLen {
-		return cache[searchLen][idx*searchLen:idx*searchLen+searchLen] == strings.ToLower(normalized)
+		blockRule := cache[searchLen][idx*searchLen : idx*searchLen+searchLen]
+		if blockRule == normalized {
+			log.PrefixedLog("stringMap").Debugf("block rule '%s' matched with '%s'", blockRule, searchString)
+			return true
+		}
 	}
 
 	return false

--- a/cache/stringcache/string_caches.go
+++ b/cache/stringcache/string_caches.go
@@ -52,7 +52,8 @@ func (cache stringMap) contains(searchString string) bool {
 	if idx < searchBucketLen {
 		blockRule := cache[searchLen][idx*searchLen : idx*searchLen+searchLen]
 		if blockRule == normalized {
-			log.PrefixedLog("stringMap").Debugf("block rule '%s' matched with '%s'", blockRule, searchString)
+			log.PrefixedLog("string_map").Debugf("block rule '%s' matched with '%s'", blockRule, searchString)
+
 			return true
 		}
 	}
@@ -136,7 +137,7 @@ func (cache regexCache) elementCount() int {
 func (cache regexCache) contains(searchString string) bool {
 	for _, regex := range cache {
 		if regex.MatchString(searchString) {
-			log.PrefixedLog("regexCache").Debugf("regex '%s' matched with '%s'", regex, searchString)
+			log.PrefixedLog("regex_cache").Debugf("regex '%s' matched with '%s'", regex, searchString)
 
 			return true
 		}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1,5 +1,10 @@
 package trie
 
+import (
+	"github.com/0xERR0R/blocky/log"
+	"strings"
+)
+
 // Trie stores a set of strings and can quickly check
 // if it contains an element, or one of its parents.
 //
@@ -108,8 +113,11 @@ func (n *parent) insert(key string, split SplitFunc) {
 }
 
 func (n *parent) hasParentOf(key string, split SplitFunc) bool {
+	searchString := key
+	rule := ""
 	for {
 		label, rest := split(key)
+		rule = strings.Join([]string{label, rule}, ".")
 
 		child, ok := n.children[label]
 		if !ok {
@@ -132,7 +140,13 @@ func (n *parent) hasParentOf(key string, split SplitFunc) bool {
 
 		case terminal:
 			// Continue down the trie
-			return child.hasParentOf(rest, split)
+			matched := child.hasParentOf(rest, split)
+			if matched {
+				rule = strings.Join([]string{child.String(), rule}, ".")
+				rule = strings.Trim(rule, ".")
+				log.PrefixedLog("Trie").Debugf("wildcard block rule '%s' matched with '%s'", rule, searchString)
+			}
+			return matched
 		}
 	}
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -115,6 +115,7 @@ func (n *parent) insert(key string, split SplitFunc) {
 func (n *parent) hasParentOf(key string, split SplitFunc) bool {
 	searchString := key
 	rule := ""
+
 	for {
 		label, rest := split(key)
 		rule = strings.Join([]string{label, rule}, ".")
@@ -144,8 +145,9 @@ func (n *parent) hasParentOf(key string, split SplitFunc) bool {
 			if matched {
 				rule = strings.Join([]string{child.String(), rule}, ".")
 				rule = strings.Trim(rule, ".")
-				log.PrefixedLog("Trie").Debugf("wildcard block rule '%s' matched with '%s'", rule, searchString)
+				log.PrefixedLog("trie").Debugf("wildcard block rule '%s' matched with '%s'", rule, searchString)
 			}
+
 			return matched
 		}
 	}


### PR DESCRIPTION
Part of #1458

Examples:
```
DEBUG Trie: wildcard block rule 'crashlytics.com' matched with 'firebase-settings.crashlytics.com'
DEBUG Trie: wildcard block rule 'telemetry.gfe.nvidia.com' matched with 'telemetry.gfe.nvidia.com'
DEBUG Trie: wildcard block rule 'mobile.events.data.microsoft.com' matched with 'mobile.events.data.microsoft.com'

DEBUG stringMap: block rule 'appboy.com' matched with 'appboy.com'
DEBUG stringMap: block rule 'app.adjust.com' matched with 'app.adjust.com'
```