### PR TITLE
fix: Obfuscate the question_name field

### DIFF
--- a/querylog/logger_writer.go
+++ b/querylog/logger_writer.go
@@ -36,7 +36,7 @@ func LogEntryFields(entry *LogEntry) logrus.Fields {
 		"response_reason": entry.ResponseReason,
 		"response_type":   entry.ResponseType,
 		"response_code":   entry.ResponseCode,
-		"question_name":   entry.QuestionName,
+		"question_name":   util.Obfuscate(entry.QuestionName),
 		"question_type":   entry.QuestionType,
 		"answer":          entry.Answer,
 		"duration_ms":     entry.DurationMs,


### PR DESCRIPTION
Currently blocky attempts to obfuscate queries (which I find a little questionable, given that you can still potentially deduce what has been asked for, but alas). However question_name is not obfuscated at all, so while the answer is, the plaintext query will still end up in the log. This change routes the field through the obfuscator, which will obfuscate if needed.