### PR TITLE
feat: CLI command for configuration validation

### DIFF
--- a/cmd/blocking.go
+++ b/cmd/blocking.go
@@ -13,9 +13,10 @@ import (
 
 func newBlockingCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:     "blocking",
-		Aliases: []string{"block"},
-		Short:   "Control status of blocking resolver",
+		Use:               "blocking",
+		Aliases:           []string{"block"},
+		Short:             "Control status of blocking resolver",
+		PersistentPreRunE: initConfigPreRun,
 	}
 	c.AddCommand(&cobra.Command{
 		Use:     "enable",

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -10,8 +10,9 @@ import (
 
 func newCacheCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "cache",
-		Short: "Performs cache operations",
+		Use:               "cache",
+		Short:             "Performs cache operations",
+		PersistentPreRunE: initConfigPreRun,
 	}
 	c.AddCommand(&cobra.Command{
 		Use:     "flush",

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -11,8 +11,9 @@ import (
 // NewListsCommand creates new command instance
 func NewListsCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "lists",
-		Short: "lists operations",
+		Use:               "lists",
+		Short:             "lists operations",
+		PersistentPreRunE: initConfigPreRun,
 	}
 
 	c.AddCommand(newRefreshCommand())

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -14,10 +14,11 @@ import (
 // NewQueryCommand creates new command instance
 func NewQueryCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "query <domain>",
-		Args:  cobra.ExactArgs(1),
-		Short: "performs DNS query",
-		RunE:  query,
+		Use:               "query <domain>",
+		Args:              cobra.ExactArgs(1),
+		Short:             "performs DNS query",
+		RunE:              query,
+		PersistentPreRunE: initConfigPreRun,
 	}
 
 	c.Flags().StringP("type", "t", "A", "query type (A, AAAA, ...)")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -53,7 +53,7 @@ var _ = Describe("root command", func() {
 			os.Setenv(configFileEnvVarOld, tmpFile.Path)
 			DeferCleanup(func() { os.Unsetenv(configFileEnvVarOld) })
 
-			initConfig()
+			Expect(initConfig()).Should(Succeed())
 
 			Expect(configPath).Should(Equal(tmpFile.Path))
 		})
@@ -62,7 +62,7 @@ var _ = Describe("root command", func() {
 			os.Setenv(configFileEnvVar, tmpFile.Path)
 			DeferCleanup(func() { os.Unsetenv(configFileEnvVar) })
 
-			initConfig()
+			Expect(initConfig()).Should(Succeed())
 
 			Expect(configPath).Should(Equal(tmpFile.Path))
 		})

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -25,10 +25,12 @@ var (
 
 func newServeCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "serve",
-		Args:  cobra.NoArgs,
-		Short: "start blocky DNS server (default command)",
-		RunE:  startServer,
+		Use:               "serve",
+		Args:              cobra.NoArgs,
+		Short:             "start blocky DNS server (default command)",
+		RunE:              startServer,
+		PersistentPreRunE: initConfigPreRun,
+		SilenceUsage:      true,
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Serve command", func() {
 				os.Setenv(configFileEnvVar, cfgFile.Path)
 				DeferCleanup(func() { os.Unsetenv(configFileEnvVar) })
 
-				initConfig()
+				Expect(initConfig()).Should(Succeed())
 			})
 
 			errChan := make(chan error)
@@ -89,7 +89,7 @@ var _ = Describe("Serve command", func() {
 				os.Setenv(configFileEnvVar, cfgFile.Path)
 				DeferCleanup(func() { os.Unsetenv(configFileEnvVar) })
 
-				initConfig()
+				Expect(initConfig()).Should(Succeed())
 			})
 
 			errChan := make(chan error)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/0xERR0R/blocky/log"
+
+	"github.com/spf13/cobra"
+)
+
+// NewValidateCommand creates new command instance
+func NewValidateCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate",
+		Args:  cobra.NoArgs,
+		Short: "Validates the configuration",
+		RunE:  validateConfiguration,
+	}
+}
+
+func validateConfiguration(_ *cobra.Command, _ []string) error {
+	log.Log().Infof("Validating configuration file: %s", configPath)
+
+	_, err := os.Stat(configPath)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return errors.New("configuration path does not exist")
+	}
+
+	err = initConfig()
+	if err != nil {
+		return err
+	}
+
+	log.Log().Info("Configuration is valid")
+
+	return nil
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"github.com/0xERR0R/blocky/helpertest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validate command", func() {
+	var tmpDir *helpertest.TmpFolder
+	BeforeEach(func() {
+		tmpDir = helpertest.NewTmpFolder("config")
+	})
+	When("Validate is called with not existing configuration file", func() {
+		It("should terminate with error", func() {
+			c := NewRootCommand()
+			c.SetArgs([]string{"validate", "--config", "/notexisting/path.yaml"})
+
+			Expect(c.Execute()).Should(HaveOccurred())
+		})
+	})
+
+	When("Validate is called with existing valid configuration file", func() {
+		It("should terminate without error", func() {
+			cfgFile := tmpDir.CreateStringFile("config.yaml",
+				"upstreams:",
+				"  groups:",
+				"    default:",
+				"      - 1.1.1.1")
+
+			c := NewRootCommand()
+			c.SetArgs([]string{"validate", "--config", cfgFile.Path})
+
+			Expect(c.Execute()).Should(Succeed())
+		})
+	})
+
+	When("Validate is called with existing invalid configuration file", func() {
+		It("should terminate with error", func() {
+			cfgFile := tmpDir.CreateStringFile("config.yaml",
+				"upstreams:",
+				"  groups:",
+				"    default:",
+				"      - 1.broken file")
+
+			c := NewRootCommand()
+			c.SetArgs([]string{"validate", "--config", cfgFile.Path})
+
+			Expect(c.Execute()).Should(HaveOccurred())
+		})
+	})
+})

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -28,6 +28,7 @@ To run the CLI, please ensure, that blocky DNS server is running, then execute `
 - `./blocky query <domain>` execute DNS query (A) (simple replacement for dig, useful for debug purposes)
 - `./blocky query <domain> --type <queryType>` execute DNS query with passed query type (A, AAAA, MX, ...)
 - `./blocky lists refresh` reloads all allow/denylists
+- `./blocky validate [--config /path/to/config.yaml]` validates configuration file
 
 !!! tip 
 


### PR DESCRIPTION
new command for configuration validation

`blocky validate` to validate default config path

or

`blocky validate --config /path/to/config.yaml`

closes #1463