### PR TITLE
Add Timescale DB with Hypertable and Retention support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Blocky is a DNS proxy and ad-blocker for the local network written in Go with fo
 
   - [Prometheus](https://prometheus.io/) metrics
   - Prepared [Grafana](https://grafana.com/) dashboards (Prometheus and database)
-  - Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL database - easy to analyze
+  - Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL/Timescale database - easy to
+    analyze
   - Various REST API endpoints
   - CLI tool
 

--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,7 @@ func (v *TLSVersion) validate(logger *logrus.Entry) {
 // postgresql // PostgreSQL database
 // csv // CSV file per day
 // csv-client // CSV file per day and client
+// timescale // Timescale database
 // )
 type QueryLogType int16
 
@@ -466,7 +467,6 @@ func loadConfig(logger *logrus.Entry, path string, mandatory bool) (rCfg *Config
 		prettyPath = filepath.Join(path, "*")
 
 		data, err = readFromDir(path, data)
-
 		if err != nil {
 			return nil, fmt.Errorf("can't read config files: %w", err)
 		}

--- a/config/config_enum.go
+++ b/config/config_enum.go
@@ -386,11 +386,14 @@ const (
 	// QueryLogTypeCsvClient is a QueryLogType of type Csv-Client.
 	// CSV file per day and client
 	QueryLogTypeCsvClient
+	// QueryLogTypeTimescale is a QueryLogType of type Timescale.
+	// Timescale database
+	QueryLogTypeTimescale
 )
 
 var ErrInvalidQueryLogType = fmt.Errorf("not a valid QueryLogType, try [%s]", strings.Join(_QueryLogTypeNames, ", "))
 
-const _QueryLogTypeName = "consolenonemysqlpostgresqlcsvcsv-client"
+const _QueryLogTypeName = "consolenonemysqlpostgresqlcsvcsv-clienttimescale"
 
 var _QueryLogTypeNames = []string{
 	_QueryLogTypeName[0:7],
@@ -399,6 +402,7 @@ var _QueryLogTypeNames = []string{
 	_QueryLogTypeName[16:26],
 	_QueryLogTypeName[26:29],
 	_QueryLogTypeName[29:39],
+	_QueryLogTypeName[39:48],
 }
 
 // QueryLogTypeNames returns a list of possible string values of QueryLogType.
@@ -417,6 +421,7 @@ func QueryLogTypeValues() []QueryLogType {
 		QueryLogTypePostgresql,
 		QueryLogTypeCsv,
 		QueryLogTypeCsvClient,
+		QueryLogTypeTimescale,
 	}
 }
 
@@ -427,6 +432,7 @@ var _QueryLogTypeMap = map[QueryLogType]string{
 	QueryLogTypePostgresql: _QueryLogTypeName[16:26],
 	QueryLogTypeCsv:        _QueryLogTypeName[26:29],
 	QueryLogTypeCsvClient:  _QueryLogTypeName[29:39],
+	QueryLogTypeTimescale:  _QueryLogTypeName[39:48],
 }
 
 // String implements the Stringer interface.
@@ -451,6 +457,7 @@ var _QueryLogTypeValue = map[string]QueryLogType{
 	_QueryLogTypeName[16:26]: QueryLogTypePostgresql,
 	_QueryLogTypeName[26:29]: QueryLogTypeCsv,
 	_QueryLogTypeName[29:39]: QueryLogTypeCsvClient,
+	_QueryLogTypeName[39:48]: QueryLogTypeTimescale,
 }
 
 // ParseQueryLogType attempts to convert a string to a QueryLogType.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -48,7 +48,8 @@ info:
 
       - [Prometheus](https://prometheus.io/) metrics
       - Prepared [Grafana](https://grafana.com/) dashboards (Prometheus and database)
-      - Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL database - easy to analyze
+      - Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL/Timescale database - easy to
+        analyze
       - Various REST API endpoints
       - CLI tool
 

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -193,7 +193,7 @@ prometheus:
 
 # optional: write query information (question, answer, client, duration etc.) to daily csv file
 queryLog:
-  # optional one of: mysql, postgresql, csv, csv-client. If empty, log to console
+  # optional one of: mysql, postgresql, timescale, csv, csv-client. If empty, log to console
   type: mysql
   # directory (should be mounted as volume in docker) for csv, db connection string for mysql/postgresql
   target: db_user:db_password@tcp(db_host_or_ip:3306)/db_name?charset=utf8mb4&parseTime=True&loc=Local

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -650,6 +650,7 @@ You can select one of following query log types:
 
 - `mysql` - log each query in the external MySQL/MariaDB database
 - `postgresql` - log each query in the external PostgreSQL database
+- `timescale` - log each query in the external Timescale database
 - `csv` - log into CSV file (one per day)
 - `csv-client` - log into CSV file (one per day and per client)
 - `console` - log into console output
@@ -671,15 +672,15 @@ You can choose which information from processed DNS request and response should 
 
 Configuration parameters:
 
-| Parameter                 | Type                                                                                 | Mandatory | Default value | Description                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------------ | --------- | ------------- | ---------------------------------------------------------------------------------- |
-| queryLog.type             | enum (mysql, postgresql, csv, csv-client, console, none (see above))                 | no        |               | Type of logging target. Console if empty                                           |
-| queryLog.target           | string                                                                               | no        |               | directory for writing the logs (for csv) or database url (for mysql or postgresql) |
-| queryLog.logRetentionDays | int                                                                                  | no        | 0             | if > 0, deletes log files/database entries which are older than ... days           |
-| queryLog.creationAttempts | int                                                                                  | no        | 3             | Max attempts to create specific query log writer                                   |
-| queryLog.creationCooldown | duration format                                                                      | no        | 2s            | Time between the creation attempts                                                 |
-| queryLog.fields           | list enum (clientIP, clientName, responseReason, responseAnswer, question, duration) | no        | all           | which information should be logged                                                 |
-| queryLog.flushInterval    | duration format                                                                      | no        | 30s           | Interval to write data in bulk to the external database                            |
+| Parameter                 | Type                                                                                 | Mandatory | Default value | Description                                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------ | --------- | ------------- | --------------------------------------------------------------------------------------------- |
+| queryLog.type             | enum (mysql, postgresql, timescale, csv, csv-client, console, none (see above))      | no        |               | Type of logging target. Console if empty                                                      |
+| queryLog.target           | string                                                                               | no        |               | directory for writing the logs (for csv) or database url (for mysql, postgresql or timescale) |
+| queryLog.logRetentionDays | int                                                                                  | no        | 0             | if > 0, deletes log files/database entries which are older than ... days                      |
+| queryLog.creationAttempts | int                                                                                  | no        | 3             | Max attempts to create specific query log writer                                              |
+| queryLog.creationCooldown | duration format                                                                      | no        | 2s            | Time between the creation attempts                                                            |
+| queryLog.fields           | list enum (clientIP, clientName, responseReason, responseAnswer, question, duration) | no        | all           | which information should be logged                                                            |
+| queryLog.flushInterval    | duration format                                                                      | no        | 30s           | Interval to write data in bulk to the external database                                       |
 
 !!! hint
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,8 @@ Blocky is a DNS proxy and ad-blocker for the local network written in Go with fo
 
     * [Prometheus](https://prometheus.io/) metrics
     * Prepared [Grafana](https://grafana.com/) dashboards (Prometheus and database)
-    * Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL database - easy to analyze
+    * Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL/Timescale database - easy to
+      analyze
     * Various REST API endpoints
     * CLI tool
 

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -31,6 +31,7 @@ import (
 const (
 	redisImage        = "redis:7"
 	postgresImage     = "postgres:15.2-alpine"
+	timescaleImage    = "timescale/timescaledb:latest-pg15"
 	mariaDBImage      = "mariadb:11"
 	mokaImage         = "ghcr.io/0xerr0r/dns-mokka:0.2.0"
 	staticServerImage = "halverneus/static-file-server:latest"
@@ -119,6 +120,27 @@ func createPostgresContainer(ctx context.Context, e2eNet *testcontainers.DockerN
 				WithOccurrence(waitLogOccurrence).
 				WithStartupTimeout(startupTimeout)),
 		withNetwork("postgres", e2eNet),
+	))
+}
+
+// createTimescaleContainer creates a postgres container with timescale extension attached to the test network under the
+// alias 'timescale'. It creates a database 'user' with user 'user' and password 'user'.
+// It is automatically terminated when the test is finished.
+func createTimescaleContainer(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+) (*postgres.PostgresContainer, error) {
+	const waitLogOccurrence = 2
+
+	return deferTerminate(postgres.RunContainer(ctx,
+		testcontainers.WithImage(timescaleImage),
+
+		postgres.WithDatabase("user"),
+		postgres.WithUsername("user"),
+		postgres.WithPassword("user"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(waitLogOccurrence).
+				WithStartupTimeout(startupTimeout)),
+		withNetwork("timescale", e2eNet),
 	))
 }
 

--- a/querylog/database_writer_test.go
+++ b/querylog/database_writer_test.go
@@ -40,7 +40,7 @@ var _ = Describe("DatabaseWriter", func() {
 
 		When("New log entry was created", func() {
 			BeforeEach(func() {
-				writer, err = newDatabaseWriter(ctx, sqliteDB, 7, time.Millisecond)
+				writer, err = newDatabaseWriter(ctx, sqliteDB, 7, time.Millisecond, "sqlite")
 				Expect(err).Should(Succeed())
 
 				db, err := writer.db.DB()
@@ -91,7 +91,7 @@ var _ = Describe("DatabaseWriter", func() {
 
 		When("> 10000 Entries were created", func() {
 			BeforeEach(func() {
-				writer, err = newDatabaseWriter(ctx, sqliteDB, 7, time.Millisecond)
+				writer, err = newDatabaseWriter(ctx, sqliteDB, 7, time.Millisecond, "sqlite")
 				Expect(err).Should(Succeed())
 			})
 
@@ -122,7 +122,7 @@ var _ = Describe("DatabaseWriter", func() {
 
 		When("There are log entries with timestamp exceeding the retention period", func() {
 			BeforeEach(func() {
-				writer, err = newDatabaseWriter(ctx, sqliteDB, 1, time.Millisecond)
+				writer, err = newDatabaseWriter(ctx, sqliteDB, 1, time.Millisecond, "sqlite")
 				Expect(err).Should(Succeed())
 			})
 
@@ -230,10 +230,10 @@ var _ = Describe("DatabaseWriter", func() {
 				})
 
 				By("create postgres specific manually defined primary key", func() {
-					mock.ExpectExec(`ALTER TABLE log_entries ADD column if not exists id serial primary key`).WillReturnResult(sqlmock.NewResult(0, 0))
+					mock.ExpectExec(`ALTER TABLE log_entries ADD column if not exists id bigserial primary key`).WillReturnResult(sqlmock.NewResult(0, 0))
 				})
 
-				_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond)
+				_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond, "postgres")
 				Expect(err).Should(Succeed())
 			})
 		})
@@ -265,7 +265,7 @@ var _ = Describe("DatabaseWriter", func() {
 						mock.ExpectExec("ALTER TABLE `log_entries` ADD `id` INT PRIMARY KEY AUTO_INCREMENT").WillReturnResult(sqlmock.NewResult(0, 0))
 					})
 
-					_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond)
+					_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond, "mysql")
 					Expect(err).Should(Succeed())
 				})
 			})
@@ -281,7 +281,7 @@ var _ = Describe("DatabaseWriter", func() {
 						mock.ExpectExec("ALTER TABLE `log_entries` ADD `id` INT PRIMARY KEY AUTO_INCREMENT").WillReturnError(fmt.Errorf("error 1060: duplicate column name"))
 					})
 
-					_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond)
+					_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond, "mysql")
 					Expect(err).Should(Succeed())
 				})
 
@@ -294,7 +294,7 @@ var _ = Describe("DatabaseWriter", func() {
 						mock.ExpectExec("ALTER TABLE `log_entries` ADD `id` INT PRIMARY KEY AUTO_INCREMENT").WillReturnError(fmt.Errorf("error XXX: some index error"))
 					})
 
-					_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond)
+					_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond, "mysql")
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).Should(ContainSubstring("can't perform auto migration: error XXX: some index error"))
 				})
@@ -306,7 +306,7 @@ var _ = Describe("DatabaseWriter", func() {
 						mock.ExpectExec("CREATE TABLE `log_entries`").WillReturnError(fmt.Errorf("error XXX: some db error"))
 					})
 
-					_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond)
+					_, err = newDatabaseWriter(ctx, dlc, 1, time.Millisecond, "mysql")
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).Should(ContainSubstring("can't perform auto migration: error XXX: some db error"))
 				})


### PR DESCRIPTION
With this pull I want to add support of Timescale DB to blocky. 

It uses the postgres connection (`queryLog.target=postgres://...`) of GORM to write data, but uses [hypertabels](https://docs.timescale.com/use-timescale/latest/hypertables/) to store time-series data and uses Timescales-native [retention](https://docs.timescale.com/use-timescale/latest/data-retention/create-a-retention-policy/) with `queryLog.type=timescale`.