### PR TITLE
Use package local metrics

### DIFF
--- a/evt/events.go
+++ b/evt/events.go
@@ -20,12 +20,6 @@ const (
 	// CachingPrefetchCacheHit fires if a query result was found in the prefetch cache, Parameter: domain name
 	CachingPrefetchCacheHit = "caching:prefetchHit"
 
-	// CachingResultCacheHit fires, if a query result was found in the cache
-	CachingResultCacheHit = "caching:cacheHit"
-
-	// CachingResultCacheMiss fires, if a query result was not found in the cache
-	CachingResultCacheMiss = "caching:cacheMiss"
-
 	// CachingDomainsToPrefetchCountChanged fires, if a number of domains being prefetched changed, Parameter: new count
 	CachingDomainsToPrefetchCountChanged = "caching:domainsToPrefetchCountChanged"
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -10,19 +10,19 @@ import (
 )
 
 //nolint:gochecknoglobals
-var reg = prometheus.NewRegistry()
+var Reg = prometheus.NewRegistry()
 
 // RegisterMetric registers prometheus collector
 func RegisterMetric(c prometheus.Collector) {
-	_ = reg.Register(c)
+	_ = Reg.Register(c)
 }
 
 // Start starts prometheus endpoint
 func Start(router *chi.Mux, cfg config.Metrics) {
 	if cfg.Enable {
-		_ = reg.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-		_ = reg.Register(collectors.NewGoCollector())
-		router.Handle(cfg.Path, promhttp.InstrumentMetricHandler(reg,
-			promhttp.HandlerFor(reg, promhttp.HandlerOpts{})))
+		_ = Reg.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+		_ = Reg.Register(collectors.NewGoCollector())
+		router.Handle(cfg.Path, promhttp.InstrumentMetricHandler(Reg,
+			promhttp.HandlerFor(Reg, promhttp.HandlerOpts{})))
 	}
 }

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -117,30 +117,18 @@ func lastListGroupRefresh() prometheus.Gauge {
 func registerCachingEventListeners() {
 	entryCount := cacheEntryCount()
 	prefetchDomainCount := prefetchDomainCacheCount()
-	hitCount := cacheHitCount()
-	missCount := cacheMissCount()
 	prefetchCount := domainPrefetchCount()
 	prefetchHitCount := domainPrefetchHitCount()
 	failedDownloadCount := failedDownloadCount()
 
 	RegisterMetric(entryCount)
 	RegisterMetric(prefetchDomainCount)
-	RegisterMetric(hitCount)
-	RegisterMetric(missCount)
 	RegisterMetric(prefetchCount)
 	RegisterMetric(prefetchHitCount)
 	RegisterMetric(failedDownloadCount)
 
 	subscribe(evt.CachingDomainsToPrefetchCountChanged, func(cnt int) {
 		prefetchDomainCount.Set(float64(cnt))
-	})
-
-	subscribe(evt.CachingResultCacheMiss, func(_ string) {
-		missCount.Inc()
-	})
-
-	subscribe(evt.CachingResultCacheHit, func(_ string) {
-		hitCount.Inc()
 	})
 
 	subscribe(evt.CachingDomainPrefetched, func(_ string) {
@@ -165,24 +153,6 @@ func failedDownloadCount() prometheus.Counter {
 		Name: "blocky_failed_downloads_total",
 		Help: "Failed download counter",
 	})
-}
-
-func cacheHitCount() prometheus.Counter {
-	return prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "blocky_cache_hits_total",
-			Help: "Cache hit counter",
-		},
-	)
-}
-
-func cacheMissCount() prometheus.Counter {
-	return prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "blocky_cache_misses_total",
-			Help: "Cache miss counter",
-		},
-	)
 }
 
 func domainPrefetchCount() prometheus.Counter {

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -15,10 +15,28 @@ import (
 	"github.com/0xERR0R/blocky/util"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
 )
 
 const defaultCachingCleanUpInterval = 5 * time.Second
+
+//nolint:gochecknoglobals
+var (
+	cacheHits = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "blocky_cache_hits_total",
+			Help: "Cache hit counter",
+		},
+	)
+	cacheMisses = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "blocky_cache_misses_total",
+			Help: "Cache miss counter",
+		},
+	)
+)
 
 // CachingResolver caches answers from dns queries with their TTL time,
 // to avoid external resolver calls for recurrent queries
@@ -70,10 +88,10 @@ func configureCaches(ctx context.Context, c *CachingResolver, cfg *config.Cachin
 		CleanupInterval: defaultCachingCleanUpInterval,
 		MaxSize:         uint(cfg.MaxItemsCount),
 		OnCacheHitFn: func(key string) {
-			c.publishMetricsIfEnabled(evt.CachingResultCacheHit, key)
+			cacheHits.Inc()
 		},
 		OnCacheMissFn: func(key string) {
-			c.publishMetricsIfEnabled(evt.CachingResultCacheMiss, key)
+			cacheMisses.Inc()
 		},
 		OnAfterPutFn: func(newSize int) {
 			c.publishMetricsIfEnabled(evt.CachingResultCacheChanged, newSize)

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/0xERR0R/blocky/cache/expirationcache"
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/evt"
+	"github.com/0xERR0R/blocky/metrics"
 	"github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/redis"
 	"github.com/0xERR0R/blocky/util"
@@ -24,13 +25,13 @@ const defaultCachingCleanUpInterval = 5 * time.Second
 
 //nolint:gochecknoglobals
 var (
-	cacheHits = promauto.NewCounter(
+	cacheHits = promauto.With(metrics.Reg).NewCounter(
 		prometheus.CounterOpts{
 			Name: "blocky_cache_hits_total",
 			Help: "Cache hit counter",
 		},
 	)
-	cacheMisses = promauto.NewCounter(
+	cacheMisses = promauto.With(metrics.Reg).NewCounter(
 		prometheus.CounterOpts{
 			Name: "blocky_cache_misses_total",
 			Help: "Cache miss counter",

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -209,11 +209,6 @@ var _ = Describe("CachingResolver", func() {
 
 				It("should cache response and use response's TTL", func() {
 					By("first request", func() {
-						domain := make(chan bool, 1)
-						_ = Bus().SubscribeOnce(CachingResultCacheMiss, func(d string) {
-							domain <- true
-						})
-
 						totalCacheCount := make(chan int, 1)
 						_ = Bus().SubscribeOnce(CachingResultCacheChanged, func(d int) {
 							totalCacheCount <- d
@@ -228,17 +223,11 @@ var _ = Describe("CachingResolver", func() {
 
 						Expect(m.Calls).Should(HaveLen(1))
 
-						Expect(domain).Should(Receive(Equal(true)))
 						Expect(totalCacheCount).Should(Receive(Equal(1)))
 					})
 
 					By("second request", func() {
 						Eventually(func(g Gomega) {
-							domain := make(chan bool, 1)
-							_ = Bus().SubscribeOnce(CachingResultCacheHit, func(d string) {
-								domain <- true
-							})
-
 							g.Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 								Should(
 									SatisfyAll(
@@ -251,7 +240,6 @@ var _ = Describe("CachingResolver", func() {
 							// still one call to upstream
 							g.Expect(m.Calls).Should(HaveLen(1))
 
-							g.Expect(domain).Should(Receive(Equal(true)))
 						}, "1s").Should(Succeed())
 					})
 				})


### PR DESCRIPTION
Improve performance of metrics by moving them to the package that needs them. This reduces the overhead to a simple atomic increment for basic counters like cache hits/misses. This also uses `promauto` to avoid the second step of having to register metrics.