### PR TITLE
Add support for SRV and TXT in custom DNS zones

### DIFF
--- a/helpertest/helper.go
+++ b/helpertest/helper.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 
 	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
@@ -25,6 +26,7 @@ const (
 	HTTPS = dns.Type(dns.TypeHTTPS)
 	MX    = dns.Type(dns.TypeMX)
 	PTR   = dns.Type(dns.TypePTR)
+	SRV   = dns.Type(dns.TypeSRV)
 	TXT   = dns.Type(dns.TypeTXT)
 	DS    = dns.Type(dns.TypeDS)
 )
@@ -216,6 +218,10 @@ func (matcher *dnsRecordMatcher) matchSingle(rr dns.RR) (success bool, err error
 		return v.Target == matcher.answer, nil
 	case *dns.PTR:
 		return v.Ptr == matcher.answer, nil
+	case *dns.SRV:
+		return fmt.Sprintf("%d %d %d %s", v.Priority, v.Weight, v.Port, v.Target) == matcher.answer, nil
+	case *dns.TXT:
+		return strings.Join(v.Txt, " ") == matcher.answer, nil
 	case *dns.MX:
 		return v.Mx == matcher.answer, nil
 	}

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -177,6 +177,10 @@ func (r *CustomDNSResolver) processDNSEntry(
 		return r.processIP(v.A, question, v.Header().Ttl)
 	case *dns.AAAA:
 		return r.processIP(v.AAAA, question, v.Header().Ttl)
+	case *dns.TXT:
+		return r.processTXT(v.Txt, question, v.Header().Ttl)
+	case *dns.SRV:
+		return r.processSRV(*v, question, v.Header().Ttl)
 	case *dns.CNAME:
 		return r.processCNAME(ctx, logger, request, *v, resolvedCnames, question, v.Header().Ttl)
 	}
@@ -208,6 +212,29 @@ func (r *CustomDNSResolver) processIP(ip net.IP, question dns.Question, ttl uint
 		result = append(result, rr)
 	}
 
+	return result, nil
+}
+
+func (r *CustomDNSResolver) processTXT(value []string, question dns.Question, ttl uint32) (result []dns.RR, err error) {
+	if question.Qtype == dns.TypeTXT {
+		txt := new(dns.TXT)
+		txt.Hdr = dns.RR_Header{Class: dns.ClassINET, Ttl: ttl, Rrtype: dns.TypeTXT, Name: question.Name}
+		txt.Txt = value
+		result = append(result, txt)
+	}
+	return result, nil
+}
+
+func (r *CustomDNSResolver) processSRV(targetSRV dns.SRV, question dns.Question, ttl uint32) (result []dns.RR, err error) {
+	if question.Qtype == dns.TypeSRV {
+		srv := new(dns.SRV)
+		srv.Hdr = dns.RR_Header{Class: dns.ClassINET, Ttl: ttl, Rrtype: dns.TypeSRV, Name: question.Name}
+		srv.Priority = targetSRV.Priority
+		srv.Weight = targetSRV.Weight
+		srv.Port = targetSRV.Port
+		srv.Target = targetSRV.Target
+		result = append(result, srv)
+	}
 	return result, nil
 }
 

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -222,10 +222,15 @@ func (r *CustomDNSResolver) processTXT(value []string, question dns.Question, tt
 		txt.Txt = value
 		result = append(result, txt)
 	}
+
 	return result, nil
 }
 
-func (r *CustomDNSResolver) processSRV(targetSRV dns.SRV, question dns.Question, ttl uint32) (result []dns.RR, err error) {
+func (r *CustomDNSResolver) processSRV(
+	targetSRV dns.SRV,
+	question dns.Question,
+	ttl uint32,
+) (result []dns.RR, err error) {
 	if question.Qtype == dns.TypeSRV {
 		srv := new(dns.SRV)
 		srv.Hdr = dns.RR_Header{Class: dns.ClassINET, Ttl: ttl, Rrtype: dns.TypeSRV, Name: question.Name}
@@ -235,6 +240,7 @@ func (r *CustomDNSResolver) processSRV(targetSRV dns.SRV, question dns.Question,
 		srv.Target = targetSRV.Target
 		result = append(result, srv)
 	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
Fixes #1587.

I wonder if there's a better way to do this more generically, but for now I've just added SRV and TXT explicitly, tests included.