### PR TITLE
refactor: Use package local metrics

### DIFF
--- a/evt/events.go
+++ b/evt/events.go
@@ -8,9 +8,6 @@ const (
 	// BlockingEnabledEvent fires if blocking status will be changed. Parameter: boolean (enabled = true)
 	BlockingEnabledEvent = "blocking:enabled"
 
-	// BlockingCacheGroupChanged fires, if a list group is changed. Parameter: list type, group name, element count
-	BlockingCacheGroupChanged = "blocking:cachingGroupChanged"
-
 	// CachingDomainPrefetched fires if a domain will be prefetched, Parameter: domain name
 	CachingDomainPrefetched = "caching:prefetched"
 
@@ -22,9 +19,6 @@ const (
 
 	// CachingDomainsToPrefetchCountChanged fires, if a number of domains being prefetched changed, Parameter: new count
 	CachingDomainsToPrefetchCountChanged = "caching:domainsToPrefetchCountChanged"
-
-	// CachingFailedDownloadChanged fires, if a download of a blocking list or hosts file fails
-	CachingFailedDownloadChanged = "caching:failedDownload"
 
 	// ApplicationStarted fires on start of the application. Parameter: version number, build time
 	ApplicationStarted = "application:started"

--- a/lists/list_cache_test.go
+++ b/lists/list_cache_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
-	. "github.com/0xERR0R/blocky/evt"
 	"github.com/0xERR0R/blocky/lists/parsers"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/google/uuid"
@@ -249,25 +248,6 @@ var _ = Describe("ListCache", func() {
 
 				group = sut.Match("blocked1a.com", []string{"gr2"})
 				Expect(group).Should(ContainElement("gr2"))
-			})
-		})
-		When("List will be updated", func() {
-			resultCnt := 0
-
-			BeforeEach(func() {
-				lists = map[string][]config.BytesSource{
-					"gr1": config.NewBytesSources(server1.URL),
-				}
-
-				_ = Bus().SubscribeOnce(BlockingCacheGroupChanged, func(listType ListCacheType, group string, cnt int) {
-					resultCnt = cnt
-				})
-			})
-
-			It("event should be fired and contain count of elements in downloaded lists", func() {
-				group := sut.Match("blocked1.com", []string{})
-				Expect(group).Should(BeEmpty())
-				Expect(resultCnt).Should(Equal(3))
 			})
 		})
 		When("multiple groups are passed", func() {

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -2,10 +2,8 @@ package metrics
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/0xERR0R/blocky/evt"
-	"github.com/0xERR0R/blocky/lists"
 	"github.com/0xERR0R/blocky/util"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,27 +13,6 @@ import (
 func RegisterEventListeners() {
 	registerBlockingEventListeners()
 	registerCachingEventListeners()
-	registerApplicationEventListeners()
-}
-
-func registerApplicationEventListeners() {
-	v := versionNumberGauge()
-	RegisterMetric(v)
-
-	subscribe(evt.ApplicationStarted, func(version, buildTime string) {
-		v.WithLabelValues(version, buildTime).Set(1)
-	})
-}
-
-func versionNumberGauge() *prometheus.GaugeVec {
-	denylistCnt := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "blocky_build_info",
-			Help: "Version number and build info",
-		}, []string{"version", "build_time"},
-	)
-
-	return denylistCnt
 }
 
 func registerBlockingEventListeners() {
@@ -51,26 +28,9 @@ func registerBlockingEventListeners() {
 		}
 	})
 
-	denylistCnt := denylistGauge()
-
-	allowlistCnt := allowlistGauge()
-
 	lastListGroupRefresh := lastListGroupRefresh()
 
-	RegisterMetric(denylistCnt)
-	RegisterMetric(allowlistCnt)
 	RegisterMetric(lastListGroupRefresh)
-
-	subscribe(evt.BlockingCacheGroupChanged, func(listType lists.ListCacheType, groupName string, cnt int) {
-		lastListGroupRefresh.Set(float64(time.Now().Unix()))
-
-		switch listType {
-		case lists.ListCacheTypeDenylist:
-			denylistCnt.WithLabelValues(groupName).Set(float64(cnt))
-		case lists.ListCacheTypeAllowlist:
-			allowlistCnt.WithLabelValues(groupName).Set(float64(cnt))
-		}
-	})
 }
 
 func enabledGauge() prometheus.Gauge {
@@ -81,28 +41,6 @@ func enabledGauge() prometheus.Gauge {
 	enabledGauge.Set(1)
 
 	return enabledGauge
-}
-
-func denylistGauge() *prometheus.GaugeVec {
-	denylistCnt := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "blocky_denylist_cache_entries",
-			Help: "Number of entries in the denylist cache",
-		}, []string{"group"},
-	)
-
-	return denylistCnt
-}
-
-func allowlistGauge() *prometheus.GaugeVec {
-	allowlistCnt := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "blocky_allowlist_cache_entries",
-			Help: "Number of entries in the allowlist cache",
-		}, []string{"group"},
-	)
-
-	return allowlistCnt
 }
 
 func lastListGroupRefresh() prometheus.Gauge {
@@ -119,13 +57,11 @@ func registerCachingEventListeners() {
 	prefetchDomainCount := prefetchDomainCacheCount()
 	prefetchCount := domainPrefetchCount()
 	prefetchHitCount := domainPrefetchHitCount()
-	failedDownloadCount := failedDownloadCount()
 
 	RegisterMetric(entryCount)
 	RegisterMetric(prefetchDomainCount)
 	RegisterMetric(prefetchCount)
 	RegisterMetric(prefetchHitCount)
-	RegisterMetric(failedDownloadCount)
 
 	subscribe(evt.CachingDomainsToPrefetchCountChanged, func(cnt int) {
 		prefetchDomainCount.Set(float64(cnt))
@@ -141,17 +77,6 @@ func registerCachingEventListeners() {
 
 	subscribe(evt.CachingResultCacheChanged, func(cnt int) {
 		entryCount.Set(float64(cnt))
-	})
-
-	subscribe(evt.CachingFailedDownloadChanged, func(_ string) {
-		failedDownloadCount.Inc()
-	})
-}
-
-func failedDownloadCount() prometheus.Counter {
-	return prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "blocky_failed_downloads_total",
-		Help: "Failed download counter",
 	})
 }
 

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/evt"
 	. "github.com/0xERR0R/blocky/helpertest"
-	"github.com/0xERR0R/blocky/lists"
 	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/redis"
@@ -105,17 +104,9 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("List is refreshed", func() {
 			It("event should be fired", func() {
-				groupCnt := make(map[string]int)
-				err := Bus().Subscribe(BlockingCacheGroupChanged, func(listType lists.ListCacheType, group string, cnt int) {
-					groupCnt[group] = cnt
-				})
-				Expect(err).Should(Succeed())
-
 				// recreate to trigger a reload
-				sut, err = NewBlockingResolver(ctx, sutConfig, nil, systemResolverBootstrap)
+				_, err := NewBlockingResolver(ctx, sutConfig, nil, systemResolverBootstrap)
 				Expect(err).Should(Succeed())
-
-				Eventually(groupCnt, "1s").Should(HaveLen(2))
 			})
 		})
 	})


### PR DESCRIPTION
Part 2 (#1578)

Improve performance of metrics by moving them to the package that needs them. This reduces the overhead to a simple atomic increment for basic counters like cache hits/misses. This also uses `promauto` to avoid the second step of having to register metrics.