### PR TITLE
fix(docs): mark config mount as read-only

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,7 +84,7 @@ services:
       # Optional to synchronize the log timestamp with host
       - /etc/localtime:/etc/localtime:ro
       # config file
-      - ./config.yml:/app/config.yml
+      - ./config.yml:/app/config.yml:ro
 ```
 
 and start docker container with
@@ -116,7 +116,7 @@ services:
       - TZ=Europe/Berlin
     volumes:
       # config file
-      - ./config.yml:/app/config.yml
+      - ./config.yml:/app/config.yml:ro
       # write query logs in this volume
       - queryLogs:/logs
       # put your custom allow/denylists in these directories


### PR DESCRIPTION
This default config results in the following error:

```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/x/blocky/config.yml" to rootfs at "/app/config.yml": mount /home/x/blocky/config.yml:/app/config.yml (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```