### PR TITLE
feat: configurable file write timeouts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -405,9 +405,10 @@ func recoverToError(do func(context.Context) error, onPanic func(any) error) fun
 }
 
 type Downloader struct {
-	Timeout  Duration `yaml:"timeout" default:"5s"`
-	Attempts uint     `yaml:"attempts" default:"3"`
-	Cooldown Duration `yaml:"cooldown" default:"500ms"`
+	Timeout      Duration `yaml:"timeout" default:"5s"`
+	WriteTimeout Duration `yaml:"writeTimeout" default:"20s"`
+	Attempts     uint     `yaml:"attempts" default:"3"`
+	Cooldown     Duration `yaml:"cooldown" default:"500ms"`
 }
 
 func (c *Downloader) LogConfig(logger *logrus.Entry) {

--- a/server/http.go
+++ b/server/http.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/0xERR0R/blocky/config"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
 )
@@ -16,18 +17,21 @@ type httpServer struct {
 	name string
 }
 
-func newHTTPServer(name string, handler http.Handler) *httpServer {
+func newHTTPServer(name string, handler http.Handler, cfg *config.Config) *httpServer {
 	const (
 		readHeaderTimeout = 20 * time.Second
 		readTimeout       = 20 * time.Second
-		writeTimeout      = 20 * time.Second
+	)
+
+	var (
+		writeTimeout = cfg.Blocking.Loading.Downloads.WriteTimeout
 	)
 
 	return &httpServer{
 		inner: http.Server{
 			ReadTimeout:       readTimeout,
 			ReadHeaderTimeout: readHeaderTimeout,
-			WriteTimeout:      writeTimeout,
+			WriteTimeout:      time.Duration(writeTimeout),
 
 			Handler: withCommonMiddleware(handler),
 		},

--- a/server/server.go
+++ b/server/server.go
@@ -162,7 +162,7 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 	server.registerDoHEndpoints(httpRouter)
 
 	if len(cfg.Ports.HTTP) != 0 {
-		srv := newHTTPServer("http", httpRouter)
+		srv := newHTTPServer("http", httpRouter, cfg)
 
 		for _, l := range httpListeners {
 			server.servers[l] = srv
@@ -170,7 +170,7 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 	}
 
 	if len(cfg.Ports.HTTPS) != 0 {
-		srv := newHTTPServer("https", httpRouter)
+		srv := newHTTPServer("https", httpRouter, cfg)
 
 		for _, l := range httpsListeners {
 			server.servers[l] = srv


### PR DESCRIPTION
This pull request introduces changes to the HTTP server configuration to make it more flexible and configurable. The change include adding a new configuration parameter for write timeouts, updating the HTTP server initialization to use this new parameter, and adjusting the server creation logic accordingly.

This PR answers issue #1606.