### PR TITLE
feat: configurable request header read timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -405,9 +405,10 @@ func recoverToError(do func(context.Context) error, onPanic func(any) error) fun
 }
 
 type Downloader struct {
-	Timeout  Duration `yaml:"timeout" default:"5s"`
-	Attempts uint     `yaml:"attempts" default:"3"`
-	Cooldown Duration `yaml:"cooldown" default:"500ms"`
+	Timeout           Duration `yaml:"timeout" default:"5s"`
+	ReadHeaderTimeout Duration `yaml:"readHeaderTimeout" default:"20s"`
+	Attempts          uint     `yaml:"attempts" default:"3"`
+	Cooldown          Duration `yaml:"cooldown" default:"500ms"`
 }
 
 func (c *Downloader) LogConfig(logger *logrus.Entry) {

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -120,6 +120,10 @@ blocking:
       # optional: timeout for list download (each url). Use large values for big lists or slow internet connections
       # default: 5s
       timeout: 60s
+      # optional: timeout for reading request headers for the download (each url). Use large values for slow internet connections
+      # to disable, set to -1.
+      # default: 20s
+      readHeaderTimeout: 60s
       # optional: Maximum download attempts
       # default: 3
       attempts: 5

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -884,11 +884,12 @@ A value of zero or less will disable this feature.
 
 Configures how HTTP(S) sources are downloaded:
 
-| Parameter | Type     | Mandatory | Default value | Description                                    |
-| --------- | -------- | --------- | ------------- | ---------------------------------------------- |
-| timeout   | duration | no        | 5s            | Download attempt timeout                       |
-| attempts  | int      | no        | 3             | How many download attempts should be performed |
-| cooldown  | duration | no        | 500ms         | Time between the download attempts             |
+| Parameter         | Type     | Mandatory | Default value | Description                                    |
+| ----------------- | -------- | --------- | ------------- | ---------------------------------------------- |
+| timeout           | duration | no        | 5s            | Download attempt timeout                       |
+| readHeaderTimeout | duration | no        | 20s           | Download request header read timeout           |
+| attempts          | int      | no        | 3             | How many download attempts should be performed |
+| cooldown          | duration | no        | 500ms         | Time between the download attempts             |
 
 !!! example
 

--- a/server/http.go
+++ b/server/http.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/0xERR0R/blocky/config"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
 )
@@ -16,17 +17,20 @@ type httpServer struct {
 	name string
 }
 
-func newHTTPServer(name string, handler http.Handler) *httpServer {
+func newHTTPServer(name string, handler http.Handler, cfg *config.Config) *httpServer {
 	const (
-		readHeaderTimeout = 20 * time.Second
 		readTimeout       = 20 * time.Second
 		writeTimeout      = 20 * time.Second
+	)
+
+	var (
+		readHeaderTimeout = cfg.Blocking.Loading.Downloads.ReadHeaderTimeout
 	)
 
 	return &httpServer{
 		inner: http.Server{
 			ReadTimeout:       readTimeout,
-			ReadHeaderTimeout: readHeaderTimeout,
+			ReadHeaderTimeout: time.Duration(readHeaderTimeout),
 			WriteTimeout:      writeTimeout,
 
 			Handler: withCommonMiddleware(handler),

--- a/server/server.go
+++ b/server/server.go
@@ -162,7 +162,7 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 	server.registerDoHEndpoints(httpRouter)
 
 	if len(cfg.Ports.HTTP) != 0 {
-		srv := newHTTPServer("http", httpRouter)
+		srv := newHTTPServer("http", httpRouter, cfg)
 
 		for _, l := range httpListeners {
 			server.servers[l] = srv
@@ -170,7 +170,7 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 	}
 
 	if len(cfg.Ports.HTTPS) != 0 {
-		srv := newHTTPServer("https", httpRouter)
+		srv := newHTTPServer("https", httpRouter, cfg)
 
 		for _, l := range httpsListeners {
 			server.servers[l] = srv


### PR DESCRIPTION
As discussed in #1653, this pull request introduces changes to the HTTP server configuration, adding a new configuration parameter for request header read timeouts, updating the HTTP server initialization to use this new parameter, and adjusting the server creation logic accordingly.