### PR TITLE
docs(grafana): overview supporting native histograms

### DIFF
--- a/docs/blocky-grafana.json
+++ b/docs/blocky-grafana.json
@@ -1605,7 +1605,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(increase(blocky_request_duration_seconds_bucket{response_type=\"RESOLVED\"}[$__range])) by (le)",
+          "expr": "sum(increase(blocky_request_duration_seconds_bucket{response_type=\"RESOLVED\"}[$__range]) or increase(blocky_request_duration_seconds{response_type=\"RESOLVED\"}[$__range])) by (le)",
           "format": "heatmap",
           "instant": false,
           "interval": "",


### PR DESCRIPTION
This updates the request duration (upstream) query on blocky-grafana to support native histograms in prometheus. Normal generates the `_bucket` metric, however native do not and manage it all under one metric.