### PR TITLE
feat: remove "||" and "^" from host names to allow Adblock plus flavored lists

### DIFF
--- a/lists/parsers/hosts.go
+++ b/lists/parsers/hosts.go
@@ -247,6 +247,10 @@ func normalizeHostsListEntry(host string) (string, error) {
 		}
 	}
 
+	// remove optional start and end markers for ABP styled lists
+	host = strings.TrimPrefix(host, "||")
+	host = strings.TrimSuffix(host, "^")
+
 	if err := validateHostsListEntry(host); err != nil {
 		return "", err
 	}

--- a/lists/parsers/hosts_test.go
+++ b/lists/parsers/hosts_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Hosts", func() {
 				`/^(.*\.)?2023\.xn--aptslabs-6fd\.net$/`,
 				`müller.com`,
 				`*.example.com`,
+				`||0-c1j0.lat^`,
 			)
 		})
 
@@ -76,11 +77,16 @@ var _ = Describe("Hosts", func() {
 			Expect(iteratorToList(it.ForEach)).Should(Equal([]string{"*.example.com"}))
 			Expect(sut.Position()).Should(Equal("line 9"))
 
+			it, err = sut.Next(context.Background())
+			Expect(err).Should(Succeed())
+			Expect(iteratorToList(it.ForEach)).Should(Equal([]string{"0-c1j0.lat"}))
+			Expect(sut.Position()).Should(Equal("line 10"))
+
 			_, err = sut.Next(context.Background())
 			Expect(err).Should(HaveOccurred())
 			Expect(err).Should(MatchError(io.EOF))
 			Expect(IsNonResumableErr(err)).Should(BeTrue())
-			Expect(sut.Position()).Should(Equal("line 10"))
+			Expect(sut.Position()).Should(Equal("line 11"))
 		})
 	})
 


### PR DESCRIPTION


closes #1718
