### PR TITLE
feat(config): support YAML arrays in `ports`

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -959,6 +959,7 @@ bootstrapDns:
 
 func defaultTestFileConfig(config *Config) {
 	Expect(config.Ports.DNS).Should(Equal(ListenConfig{":55553", ":55554", "[::1]:55555"}))
+	Expect(config.Ports.HTTP).Should(Equal(ListenConfig{":4000"}))
 	Expect(config.Upstreams.Init.Strategy).Should(Equal(InitStrategyFailOnError))
 	Expect(config.Upstreams.UserAgent).Should(Equal("testBlocky"))
 	Expect(config.Upstreams.Groups["default"]).Should(HaveLen(3))
@@ -1059,7 +1060,10 @@ func writeConfigYml(tmpDir *helpertest.TmpFolder) *helpertest.TmpFile {
 		"queryLog:",
 		"  type: csv-client",
 		"  target: /opt/log",
-		"port: 55553,:55554,[::1]:55555",
+		"ports:",
+		"  dns: 55553,:55554,[::1]:55555",
+		"  http:",
+		"    - 4000",
 		"logLevel: debug",
 		"minTlsServeVersion: 1.3",
 	)
@@ -1086,7 +1090,10 @@ func writeConfigYmlWithLocalZoneFile(tmpDir *helpertest.TmpFolder, includeStr st
 		"    - A",
 		"fqdnOnly:",
 		"  enable: true",
-		"port: 55553,:55554,[::1]:55555",
+		"ports:",
+		"  dns: 55553,:55554,[::1]:55555",
+		"  http:",
+		"    - 4000",
 		"logLevel: debug",
 		"minTlsServeVersion: 1.3",
 	)
@@ -1151,7 +1158,10 @@ func writeConfigDir(tmpDir *helpertest.TmpFolder) {
 		"queryLog:",
 		"  type: csv-client",
 		"  target: /opt/log",
-		"port: 55553,:55554,[::1]:55555",
+		"ports:",
+		"  dns: 55553,:55554,[::1]:55555",
+		"  http:",
+		"    - 4000",
 		"logLevel: debug",
 		"minTlsServeVersion: 1.3",
 	)

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -318,13 +318,22 @@ hostsFile:
 
 # optional: ports configuration
 ports:
-  # optional: DNS listener port(s) and bind ip address(es), default 53 (UDP and TCP). Example: 53, :53, "127.0.0.1:5353,[::1]:5353"
-  dns: 53
-  # optional: Port(s) and bind ip address(es) for DoT (DNS-over-TLS) listener. Example: 853, 127.0.0.1:853
+  # optional: DNS listener port(s) and bind ip address(es)
+  # default: 53 (UDP and TCP)
+  # example: [53, :53, 127.0.0.1:53, [::1]:53]
+  dns:
+    - 53
+    - localhost:5353
+  # optional: Port(s) and bind ip address(es) for DoT (DNS-over-TLS) listener.
+  #           Supports the same formats as `dns` above.
+  # default: none
+  # example: [853, :853, 127.0.0.1:853, [::1]:853]
   tls: 853
-  # optional: Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as 192.168.0.1:443. Example: 443, :443, 127.0.0.1:443,[::1]:443
+  # optional: Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH...
+  # example: [443, :443, 127.0.0.1:443, [::1]:443]
   https: 443
-  # optional: Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as 192.168.0.1:4000. Example: 4000, :4000, 127.0.0.1:4000,[::1]:4000
+  # optional: Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH...
+  # example: [4000, :4000, 127.0.0.1:4000, [::1]:4000]
   http: 4000
 
 # optional: logging configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,23 +25,26 @@ configuration properties as [JSON](config.yml).
     connectIPVersion: v4
     ```
 
-## Ports configuration
+## Ports & addresses configuration
 
-All logging port are optional.
+All values in this section are optional.
 
-| Parameter   | Type                    | Default value | Description                                                                                                                                                                                                                                       |
-| ----------- | ----------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ports.dns   | [IP]:port[,[IP]:port]\* | 53            | Port(s) and optional bind ip address(es) to serve DNS endpoint (TCP and UDP). If you wish to specify a specific IP, you can do so such as `192.168.0.1:53`. Example: `53`, `:53`, `127.0.0.1:53,[::1]:53`                                         |
-| ports.tls   | [IP]:port[,[IP]:port]\* |               | Port(s) and optional bind ip address(es) to serve DoT DNS endpoint (DNS-over-TLS). If you wish to specify a specific IP, you can do so such as `192.168.0.1:853`. Example: `83`, `:853`, `127.0.0.1:853,[::1]:853`                                |
-| ports.http  | [IP]:port[,[IP]:port]\* |               | Port(s) and optional bind ip address(es) to serve HTTP used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:4000`. Example: `4000`, `:4000`, `127.0.0.1:4000,[::1]:4000` |
-| ports.https | [IP]:port[,[IP]:port]\* |               | Port(s) and optional bind ip address(es) to serve HTTPS used for prometheus metrics, pprof, REST API, DoH... If you wish to specify a specific IP, you can do so such as `192.168.0.1:443`. Example: `443`, `:443`, `127.0.0.1:443,[::1]:443`     |
+| Parameter   | Type                  | Default value | Description                                                                                                                                       |
+| ----------- | --------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ports.dns   | One or more [IP]:Port | 53            | Listen address for DNS (TCP and UDP). Example: `53`, `:53`, `192.168.0.1:53`, `[53, "[::1]:53"]`                                                  |
+| ports.tls   | One or more [IP]:Port |               | Listen address for DoT (DNS-over-TLS). Example: `83`, `:853`, `192.168.0.1:853`, `[853, "[::1]:853"]`                                             |
+| ports.http  | One or more [IP]:Port |               | Listen address for HTTP used for prometheus metrics, pprof, REST API, DoH... Example: `4000`, `:4000`, `192.168.0.1:4000`, `[4000, "[::1]:4000"]` |
+| ports.https | One or more [IP]:Port |               | Listen address for HTTPS used for prometheus metrics, pprof, REST API, DoH... Example: `443`, `:443`, `192.168.0.1:443`, `[443, "[::1]:443"]`     |
 
 !!! example
 
     ```yaml
     ports:
       dns: 53
-      http: 4000
+      tls: [853, "[::1]:853"]
+      http:
+        - 80
+        - 4000
       https: 443
     ```
 


### PR DESCRIPTION
:wave: Hi!

Comma separated strings are still supported for back-compat.

My goal with this is to make the NixOS module support opening the right ports in the firewall automatically, without needing to parse the comma separated strings on top of the various `addr:port` formats.
