### PR TITLE
Call idnaProfile.ToUnicode before calling idnaProfile.ToASCII

### DIFF
--- a/lists/parsers/hosts.go
+++ b/lists/parsers/hosts.go
@@ -242,6 +242,10 @@ func normalizeHostsListEntry(host string) (string, error) {
 	// that decision to it.
 	idnaProfile := idna.Punycode
 
+	// remove optional start and end markers for ABP styled lists
+	host = strings.TrimPrefix(host, "||")
+	host = strings.TrimSuffix(host, "^")
+
 	if !isRegex(host) {
 		hostUnicode, err = idnaProfile.ToUnicode(host)
 		if err != nil || hostUnicode == host {
@@ -251,10 +255,6 @@ func normalizeHostsListEntry(host string) (string, error) {
 			}
 		}
 	}
-
-	// remove optional start and end markers for ABP styled lists
-	host = strings.TrimPrefix(host, "||")
-	host = strings.TrimSuffix(host, "^")
 
 	if err := validateHostsListEntry(host); err != nil {
 		return "", err

--- a/lists/parsers/hosts.go
+++ b/lists/parsers/hosts.go
@@ -235,6 +235,7 @@ func (e WildcardEntry) forEachHost(callback func(string) error) error {
 
 func normalizeHostsListEntry(host string) (string, error) {
 	var err error
+	var hostUnicode string
 	// Lookup is the profile preferred for DNS queries, we use Punycode here as it does less validation.
 	// That avoids rejecting domains in a list for reasons that amount to "that domain should not be used"
 	// since the goal of the list is to determine whether the domain should be used or not, we leave
@@ -242,9 +243,12 @@ func normalizeHostsListEntry(host string) (string, error) {
 	idnaProfile := idna.Punycode
 
 	if !isRegex(host) {
-		host, err = idnaProfile.ToASCII(host)
-		if err != nil {
-			return "", fmt.Errorf("%w: %s", err, host)
+		hostUnicode, err = idnaProfile.ToUnicode(host)
+		if err != nil || hostUnicode == host {
+			host, err = idnaProfile.ToASCII(host)
+			if err != nil {
+				return "", fmt.Errorf("%w: %s", err, host)
+			}
 		}
 	}
 

--- a/lists/parsers/hosts_test.go
+++ b/lists/parsers/hosts_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Hosts", func() {
 				`müller.com`,
 				`*.example.com`,
 				`||0-c1j0.lat^`,
+				"xn----7sbhlqiujscje.xn--p1ai",
 			)
 		})
 
@@ -82,11 +83,16 @@ var _ = Describe("Hosts", func() {
 			Expect(iteratorToList(it.ForEach)).Should(Equal([]string{"0-c1j0.lat"}))
 			Expect(sut.Position()).Should(Equal("line 10"))
 
+			it, err = sut.Next(context.Background())
+			Expect(err).Should(Succeed())
+			Expect(iteratorToList(it.ForEach)).Should(Equal([]string{"xn----7sbhlqiujscje.xn--p1ai"}))
+			Expect(sut.Position()).Should(Equal("line 11"))
+
 			_, err = sut.Next(context.Background())
 			Expect(err).Should(HaveOccurred())
 			Expect(err).Should(MatchError(io.EOF))
 			Expect(IsNonResumableErr(err)).Should(BeTrue())
-			Expect(sut.Position()).Should(Equal("line 11"))
+			Expect(sut.Position()).Should(Equal("line 12"))
 		})
 	})
 


### PR DESCRIPTION
Some lists already have Unicode character containing domains converted to their ASCII representation which causes these entries to error out.