### PR TITLE
fix: conditional upstreams initialize independently of default upstreams

### DIFF
--- a/resolver/conditional_upstream_resolver_test.go
+++ b/resolver/conditional_upstream_resolver_test.go
@@ -193,7 +193,7 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 	})
 
 	When("upstream is invalid", func() {
-		It("errors during construction", func() {
+		It("succeeds with bootstrap resolver during construction", func() {
 			b := newTestBootstrap(ctx, &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure}})
 
 			upstreamsCfg := defaultUpstreamsConfig
@@ -207,9 +207,12 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 				},
 			}
 
+			// Conditional upstreams should always succeed during construction to ensure
+			// they remain available even when default upstreams are unreachable.
+			// See: https://github.com/0xERR0R/blocky/issues/1639
 			r, err := NewConditionalUpstreamResolver(ctx, sutConfig, upstreamsCfg, b)
-			Expect(err).Should(HaveOccurred())
-			Expect(r).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(r).ShouldNot(BeNil())
 		})
 	})
 


### PR DESCRIPTION
Fixes #1639 where conditional DNS mappings would fail with "Not Ready" errors when the default upstream was unreachable, even though conditional upstreams have their own independent DNS servers.

The issue occurred when using `upstreams.init.strategy: fast`, where conditional upstreams inherited the async initialization behavior. If default upstreams were unreachable during this initialization window, ALL queries (including conditional ones) would fail.
