### PR TITLE
fix: ensure HTTP response bodies are drained before closing for connection reuse

### DIFF
--- a/lists/downloader.go
+++ b/lists/downloader.go
@@ -71,6 +71,9 @@ func (d *httpDownloader) DownloadFile(ctx context.Context, link string) (io.Read
 					return nil
 				}
 
+				// Drain body before closing to allow connection reuse
+				// See: https://pkg.go.dev/net/http#Response.Body
+				_, _ = io.Copy(io.Discard, resp.Body)
 				_ = resp.Body.Close()
 
 				return fmt.Errorf("got status code %d", resp.StatusCode)

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -227,6 +227,9 @@ func (r *httpUpstreamClient) callExternal(
 	}
 
 	defer func() {
+		// Drain body before closing to allow connection reuse
+		// See: https://pkg.go.dev/net/http#Response.Body
+		_, _ = io.Copy(io.Discard, httpResponse.Body)
 		util.LogOnError(ctx, "can't close response body ", httpResponse.Body.Close())
 	}()
 


### PR DESCRIPTION


closes #1430 