### PR TITLE
refactor: clean up obsolete Go syntax

### DIFF
--- a/cache/stringcache/string_caches_benchmark_test.go
+++ b/cache/stringcache/string_caches_benchmark_test.go
@@ -108,7 +108,7 @@ func benchmarkFactory(b *testing.B, data []string, newFactory func() cacheFactor
 		cache   stringCache
 	)
 
-	for range b.N {
+	for b.Loop() {
 		factory = newFactory()
 
 		for _, s := range data {
@@ -173,7 +173,7 @@ func benchmarkCache(b *testing.B, data []string, newFactory func() cacheFactory)
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		// Always use the plain strings for search:
 		// - wildcards and regexes need a plain string query
 		// - all benchmarks will do the same number of queries

--- a/config/conditional_upstream.go
+++ b/config/conditional_upstream.go
@@ -32,7 +32,7 @@ func (c *ConditionalUpstream) LogConfig(logger *logrus.Entry) {
 }
 
 // UnmarshalYAML implements `yaml.Unmarshaler`.
-func (c *ConditionalUpstreamMapping) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *ConditionalUpstreamMapping) UnmarshalYAML(unmarshal func(any) error) error {
 	var input map[string]string
 	if err := unmarshal(&input); err != nil {
 		return err
@@ -43,7 +43,7 @@ func (c *ConditionalUpstreamMapping) UnmarshalYAML(unmarshal func(interface{}) e
 	for k, v := range input {
 		var upstreams []Upstream
 
-		for _, part := range strings.Split(v, ",") {
+		for part := range strings.SplitSeq(v, ",") {
 			upstream, err := ParseUpstream(strings.TrimSpace(part))
 			if err != nil {
 				return fmt.Errorf("can't convert upstream '%s': %w", strings.TrimSpace(part), err)

--- a/config/conditional_upstream_test.go
+++ b/config/conditional_upstream_test.go
@@ -62,7 +62,7 @@ var _ = Describe("ConditionalUpstreamConfig", func() {
 	Describe("UnmarshalYAML", func() {
 		It("Should parse config as map", func() {
 			c := &ConditionalUpstreamMapping{}
-			err := c.UnmarshalYAML(func(i interface{}) error {
+			err := c.UnmarshalYAML(func(i any) error {
 				*i.(*map[string]string) = map[string]string{"key": "1.2.3.4"}
 
 				return nil
@@ -77,7 +77,7 @@ var _ = Describe("ConditionalUpstreamConfig", func() {
 
 		It("should fail if wrong YAML format", func() {
 			c := &ConditionalUpstreamMapping{}
-			err := c.UnmarshalYAML(func(i interface{}) error {
+			err := c.UnmarshalYAML(func(i any) error {
 				return errors.New("some err")
 			})
 			Expect(err).Should(HaveOccurred())

--- a/config/config.go
+++ b/config/config.go
@@ -181,7 +181,7 @@ func (l *ListenConfig) UnmarshalText(data []byte) error {
 }
 
 // UnmarshalYAML creates a ListenConfig from YAML
-func (l *ListenConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (l *ListenConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	// Try parsing as a native YAML array...
 	if unmarshal((*[]string)(l)) == nil {
 		l.prefixPorts()
@@ -209,7 +209,7 @@ func (l *ListenConfig) prefixPorts() {
 }
 
 // UnmarshalYAML creates BootstrapDNS from YAML
-func (b *BootstrapDNS) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (b *BootstrapDNS) UnmarshalYAML(unmarshal func(any) error) error {
 	var single BootstrappedUpstream
 	if err := unmarshal(&single); err == nil {
 		*b = BootstrapDNS{single}
@@ -230,7 +230,7 @@ func (b *BootstrapDNS) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML creates BootstrappedUpstream from YAML
-func (b *BootstrappedUpstream) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (b *BootstrappedUpstream) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal(&b.Upstream); err == nil {
 		return nil
 	}

--- a/config/custom_dns.go
+++ b/config/custom_dns.go
@@ -29,7 +29,7 @@ type (
 	}
 )
 
-func (z *ZoneFileDNS) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (z *ZoneFileDNS) UnmarshalYAML(unmarshal func(any) error) error {
 	var input string
 	if err := unmarshal(&input); err != nil {
 		return fmt.Errorf("failed to unmarshal zone file DNS: %w", err)
@@ -66,7 +66,7 @@ func (z *ZoneFileDNS) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (c *CustomDNSEntries) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *CustomDNSEntries) UnmarshalYAML(unmarshal func(any) error) error {
 	var input string
 	if err := unmarshal(&input); err != nil {
 		return fmt.Errorf("failed to unmarshal custom DNS entries: %w", err)

--- a/config/custom_dns_test.go
+++ b/config/custom_dns_test.go
@@ -70,7 +70,7 @@ var _ = Describe("CustomDNSConfig", func() {
 	Describe("CustomDNSEntries UnmarshalYAML", func() {
 		It("Should parse config as map", func() {
 			c := CustomDNSEntries{}
-			err := c.UnmarshalYAML(func(i interface{}) error {
+			err := c.UnmarshalYAML(func(i any) error {
 				*i.(*string) = "1.2.3.4"
 
 				return nil
@@ -84,7 +84,7 @@ var _ = Describe("CustomDNSConfig", func() {
 
 		It("Should parse multiple ips as comma separated string", func() {
 			c := CustomDNSEntries{}
-			err := c.UnmarshalYAML(func(i interface{}) error {
+			err := c.UnmarshalYAML(func(i any) error {
 				*i.(*string) = "1.2.3.4,2.3.4.5"
 
 				return nil
@@ -98,7 +98,7 @@ var _ = Describe("CustomDNSConfig", func() {
 
 		It("Should parse multiple ips as comma separated string with whitespace", func() {
 			c := CustomDNSEntries{}
-			err := c.UnmarshalYAML(func(i interface{}) error {
+			err := c.UnmarshalYAML(func(i any) error {
 				*i.(*string) = "1.2.3.4, 2.3.4.5 ,   3.4.5.6"
 
 				return nil
@@ -113,7 +113,7 @@ var _ = Describe("CustomDNSConfig", func() {
 
 		It("should fail if wrong YAML format", func() {
 			c := &CustomDNSEntries{}
-			err := c.UnmarshalYAML(func(i interface{}) error {
+			err := c.UnmarshalYAML(func(i any) error {
 				return errors.New("some err")
 			})
 			Expect(err).Should(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("CustomDNSConfig", func() {
 	Describe("ZoneFileDNS UnmarshalYAML", func() {
 		It("Should parse config as map", func() {
 			z := ZoneFileDNS{}
-			err := z.UnmarshalYAML(func(i interface{}) error {
+			err := z.UnmarshalYAML(func(i any) error {
 				*i.(*string) = strings.TrimSpace(`
 $ORIGIN example.com.
 www 3600 A 1.2.3.4
@@ -175,7 +175,7 @@ cname 3600 CNAME www
 			file := folder.CreateStringFile("other.zone", "www 3600 A 1.2.3.4")
 
 			z := ZoneFileDNS{}
-			err := z.UnmarshalYAML(func(i interface{}) error {
+			err := z.UnmarshalYAML(func(i any) error {
 				*i.(*string) = strings.TrimSpace(`
 $ORIGIN example.com.
 $INCLUDE ` + file.Path)
@@ -199,7 +199,7 @@ $INCLUDE ` + file.Path)
 
 		It("Should return an error if the zone file is malformed", func() {
 			z := ZoneFileDNS{}
-			err := z.UnmarshalYAML(func(i interface{}) error {
+			err := z.UnmarshalYAML(func(i any) error {
 				*i.(*string) = strings.TrimSpace(`
 $ORIGIN example.com.
 www A 1.2.3.4
@@ -212,7 +212,7 @@ www A 1.2.3.4
 		})
 		It("Should return an error if a relative record is provided without an origin", func() {
 			z := ZoneFileDNS{}
-			err := z.UnmarshalYAML(func(i interface{}) error {
+			err := z.UnmarshalYAML(func(i any) error {
 				*i.(*string) = strings.TrimSpace(`
 $TTL 3600
 www A 1.2.3.4
@@ -225,7 +225,7 @@ www A 1.2.3.4
 		})
 		It("Should return an error if the unmarshall function returns an error", func() {
 			z := ZoneFileDNS{}
-			err := z.UnmarshalYAML(func(i interface{}) error {
+			err := z.UnmarshalYAML(func(i any) error {
 				return errors.New("Failed to unmarshal")
 			})
 			Expect(err).Should(HaveOccurred())

--- a/config/dnssec_test.go
+++ b/config/dnssec_test.go
@@ -240,7 +240,7 @@ var _ = Describe("DNSSEC config", func() {
 			cfg := &DNSSEC{}
 
 			// Document expected defaults (set by config loader)
-			expectedDefaults := map[string]interface{}{
+			expectedDefaults := map[string]any{
 				"validate":              false,
 				"maxChainDepth":         uint(10),
 				"cacheExpirationHours":  uint(1),

--- a/config/qtype_set.go
+++ b/config/qtype_set.go
@@ -35,7 +35,7 @@ func (s *QTypeSet) Insert(qType dns.Type) {
 	(*s)[QType(qType)] = struct{}{}
 }
 
-func (s *QTypeSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *QTypeSet) UnmarshalYAML(unmarshal func(any) error) error {
 	var input []QType
 	if err := unmarshal(&input); err != nil {
 		return err

--- a/e2e/caching_test.go
+++ b/e2e/caching_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Caching configuration tests", func() {
 				msg := util.NewMsgWithQuestion("prefetch.com.", A)
 
 				By("Query domain multiple times to mark it for prefetching", func() {
-					for i := 0; i < 5; i++ {
+					for range 5 {
 						Expect(doDNSRequest(ctx, blocky, msg)).
 							Should(BeDNSRecord("prefetch.com.", A, "9.8.7.6"))
 						time.Sleep(500 * time.Millisecond) // Space out queries for prefetch detection

--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 					// random strategy should retry with moka1 or moka2 and succeed
 					const attempts = 10
 
-					for i := 0; i < attempts; i++ {
+					for range attempts {
 						msg := util.NewMsgWithQuestion("random.com.", A)
 						resp, err := doDNSRequest(ctx, blocky, msg)
 						Expect(err).Should(Succeed())
@@ -222,7 +222,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 					// Query multiple times - should always get response from first server (1.1.1.1)
 					const attempts = 10
 
-					for i := 0; i < attempts; i++ {
+					for range attempts {
 						msg := util.NewMsgWithQuestion("strict.com.", A)
 						Expect(doDNSRequest(ctx, blocky, msg)).
 							Should(
@@ -301,7 +301,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 				const attempts = 20
 				successCount := 0
 
-				for i := 0; i < attempts; i++ {
+				for range attempts {
 					msg := util.NewMsgWithQuestion("parallel.com.", A)
 					resp, err := doDNSRequest(ctx, blocky, msg)
 					Expect(err).Should(Succeed())
@@ -405,7 +405,7 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 					foundStamp := false
 					foundTraditional := false
 
-					for i := 0; i < attempts; i++ {
+					for range attempts {
 						msg := util.NewMsgWithQuestion("mixed-test.com.", A)
 						resp, err := doDNSRequest(ctx, blocky, msg)
 						Expect(err).Should(Succeed())

--- a/helpertest/helper.go
+++ b/helpertest/helper.go
@@ -204,7 +204,7 @@ func HaveEdnsOption(code uint16) types.GomegaMatcher {
 }
 
 func HaveTTL(matcher types.GomegaMatcher) types.GomegaMatcher {
-	return gomega.WithTransform(func(actual interface{}) (uint32, error) {
+	return gomega.WithTransform(func(actual any) (uint32, error) {
 		// Handle different types of input
 		var records []dns.RR
 
@@ -275,7 +275,7 @@ func (matcher *dnsRecordMatcher) matchSingle(rr dns.RR) bool {
 }
 
 // Match checks the DNS record
-func (matcher *dnsRecordMatcher) Match(actual interface{}) (success bool, err error) {
+func (matcher *dnsRecordMatcher) Match(actual any) (success bool, err error) {
 	// Handle different types of input
 	var records []dns.RR
 
@@ -308,13 +308,13 @@ func (matcher *dnsRecordMatcher) Match(actual interface{}) (success bool, err er
 }
 
 // FailureMessage generates a failure message
-func (matcher *dnsRecordMatcher) FailureMessage(actual interface{}) (message string) {
+func (matcher *dnsRecordMatcher) FailureMessage(actual any) (message string) {
 	return fmt.Sprintf("Expected\n\t%s\n to contain\n\t domain '%s', type '%s', answer '%s'",
 		actual, matcher.domain, dns.TypeToString[uint16(matcher.dnsType)], matcher.answer)
 }
 
 // NegatedFailureMessage creates negated message
-func (matcher *dnsRecordMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (matcher *dnsRecordMatcher) NegatedFailureMessage(actual any) (message string) {
 	return fmt.Sprintf("Expected\n\t%s\n not to contain\n\t domain '%s', type '%s', answer '%s'",
 		actual, matcher.domain, dns.TypeToString[uint16(matcher.dnsType)], matcher.answer)
 }

--- a/lists/list_cache_benchmark_test.go
+++ b/lists/list_cache_benchmark_test.go
@@ -24,7 +24,7 @@ func BenchmarkRefresh(b *testing.B) {
 
 	b.ReportAllocs()
 
-	for range b.N {
+	for b.Loop() {
 		_ = cache.Refresh(context.Background())
 	}
 }

--- a/main_static.go
+++ b/main_static.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -191,6 +191,6 @@ func prefetchDomainCacheCount() prometheus.Gauge {
 	)
 }
 
-func subscribe(topic string, fn interface{}) {
+func subscribe(topic string, fn any) {
 	util.FatalOnError(fmt.Sprintf("can't subscribe topic '%s'", topic), evt.Bus().Subscribe(topic, fn))
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -3,6 +3,7 @@ package metrics_test
 import (
 	"context"
 	"net"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -71,19 +72,8 @@ func AssertRegistryComplete(t *testing.T, reg *prometheus.Registry) {
 		t.Errorf("Found %d / %d expected metrics", len(found), len(expected))
 	}
 
-	// helperto check if a string is in a slice
-	contains := func(slice []string, item string) bool {
-		for _, s := range slice {
-			if s == item {
-				return true
-			}
-		}
-
-		return false
-	}
-
 	for name := range found {
-		if !contains(expected, name) {
+		if !slices.Contains(expected, name) {
 			t.Errorf("found additional metric %q in registry", name)
 		}
 	}

--- a/querylog/database_writer.go
+++ b/querylog/database_writer.go
@@ -204,10 +204,7 @@ func (d *DatabaseWriter) doDBWrite() error {
 		const bulkSize = 100
 
 		for i := 0; i < len(d.pendingEntries); i += bulkSize {
-			j := i + bulkSize
-			if j > len(d.pendingEntries) {
-				j = len(d.pendingEntries)
-			}
+			j := min(i+bulkSize, len(d.pendingEntries))
 			// write bulk
 			tx := d.db.Create(d.pendingEntries[i:j])
 			err = multierror.Append(err, tx.Error)

--- a/redis/redis_suite_test.go
+++ b/redis/redis_suite_test.go
@@ -22,4 +22,4 @@ func TestRedisClient(t *testing.T) {
 
 type NoLogs struct{}
 
-func (l NoLogs) Printf(context.Context, string, ...interface{}) {}
+func (l NoLogs) Printf(context.Context, string, ...any) {}

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -50,7 +50,7 @@ func createBlockHandler(cfg config.Blocking) (blockHandler, error) {
 		// Try parsing as IP address(es)
 		var ips []net.IP
 
-		for _, part := range strings.Split(cfgBlockType, ",") {
+		for part := range strings.SplitSeq(cfgBlockType, ",") {
 			if ip := net.ParseIP(strings.TrimSpace(part)); ip != nil {
 				ips = append(ips, ip)
 			}
@@ -102,7 +102,7 @@ func clientGroupsBlock(cfg config.Blocking) map[string][]string {
 	cgb := make(map[string][]string, len(cfg.ClientGroupsBlock))
 
 	for identifier, cfgGroups := range cfg.ClientGroupsBlock {
-		for _, ipart := range strings.Split(strings.ToLower(identifier), ",") {
+		for ipart := range strings.SplitSeq(strings.ToLower(identifier), ",") {
 			existingGroups, found := cgb[ipart]
 			if found {
 				cgb[ipart] = append(existingGroups, cfgGroups...)

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -384,7 +384,7 @@ func (r *CachingResolver) adjustTTLs(answer []dns.RR) (ttl time.Duration) {
 	return time.Duration(minTTL) * time.Second
 }
 
-func (r *CachingResolver) publishMetricsIfEnabled(event string, val interface{}) {
+func (r *CachingResolver) publishMetricsIfEnabled(event string, val any) {
 	if r.emitMetricEvents {
 		evt.Bus().Publish(event, val)
 	}

--- a/resolver/dnssec/nsec.go
+++ b/resolver/dnssec/nsec.go
@@ -4,6 +4,7 @@ package dnssec
 
 import (
 	"github.com/miekg/dns"
+	"slices"
 )
 
 // validateNSECDenialOfExistence validates NSEC-based denial of existence per RFC 4035 §5.4
@@ -103,11 +104,5 @@ func (v *Validator) nsecCoversName(nsec *dns.NSEC, name string) bool {
 
 // nsecHasType checks if an NSEC record claims a given type exists
 func (v *Validator) nsecHasType(nsec *dns.NSEC, qtype uint16) bool {
-	for _, t := range nsec.TypeBitMap {
-		if t == qtype {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(nsec.TypeBitMap, qtype)
 }

--- a/resolver/dnssec/validator_test.go
+++ b/resolver/dnssec/validator_test.go
@@ -980,7 +980,7 @@ var _ = Describe("DNSSECValidator", func() {
 
 			// Run multiple validations concurrently
 			done := make(chan bool)
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				go func() {
 					defer GinkgoRecover()
 					_ = sut.walkChainOfTrust(ctx, domain)
@@ -989,7 +989,7 @@ var _ = Describe("DNSSECValidator", func() {
 			}
 
 			// Wait for all goroutines
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				<-done
 			}
 

--- a/resolver/resolver_suite_test.go
+++ b/resolver/resolver_suite_test.go
@@ -41,4 +41,4 @@ func TestResolver(t *testing.T) {
 
 type NoLogs struct{}
 
-func (l NoLogs) Printf(_ context.Context, _ string, _ ...interface{}) {}
+func (l NoLogs) Printf(_ context.Context, _ string, _ ...any) {}

--- a/server/server_config_trigger.go
+++ b/server/server_config_trigger.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package server
 

--- a/util/http.go
+++ b/util/http.go
@@ -76,9 +76,9 @@ func parseForwardedHeader(forwarded string) net.IP {
 
 	for _, element := range elements {
 		// Split by semicolon to get parameters (for, by, proto, host)
-		params := strings.Split(element, ";")
+		params := strings.SplitSeq(element, ";")
 
-		for _, param := range params {
+		for param := range params {
 			param = strings.TrimSpace(param)
 
 			// Look for "for=" parameter (case-insensitive)


### PR DESCRIPTION
During the code review, I noticed several outdated syntax patterns that can be replaced with more modern alternatives.
For example, interface{} can be replaced to any. Array/slice iteration and searching can be simplified.