### PR TITLE
test(e2e): smoke-test schedule-based blocking

### DIFF
--- a/e2e/blocking_test.go
+++ b/e2e/blocking_test.go
@@ -793,7 +793,12 @@ var _ = Describe("Domain blocking functionality", func() {
 
 		Context("when the schedule is active right now", func() {
 			BeforeEach(func(ctx context.Context) {
-				today := weekdayNames[time.Now().UTC().Weekday()]
+				// Cover today and tomorrow so the schedule stays active even
+				// if the container ticks past UTC midnight between BeforeEach
+				// and the DNS query.
+				wd := int(time.Now().UTC().Weekday())
+				today := weekdayNames[wd]
+				tomorrow := weekdayNames[(wd+1)%7]
 
 				blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(fmt.Sprintf(`
 					log:
@@ -808,13 +813,13 @@ var _ = Describe("Domain blocking functionality", func() {
 					      - http://httpserver:8080/list.txt
 					  schedules:
 					    now:
-					      weekdays: [%s]
+					      weekdays: [%s, %s]
 					  listSchedules:
 					    ads: [now]
 					  clientGroupsBlock:
 					    default:
 					      - ads
-				`, today)))
+				`, today, tomorrow)))
 				Expect(err).Should(Succeed())
 			})
 
@@ -827,7 +832,10 @@ var _ = Describe("Domain blocking functionality", func() {
 
 		Context("when the schedule is inactive right now", func() {
 			BeforeEach(func(ctx context.Context) {
-				tomorrow := weekdayNames[(int(time.Now().UTC().Weekday())+1)%7]
+				// Pick a weekday two days out so neither today's nor
+				// tomorrow's container weekday matches, even if UTC midnight
+				// rolls over between BeforeEach and the DNS query.
+				twoDaysOut := weekdayNames[(int(time.Now().UTC().Weekday())+2)%7]
 
 				blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(fmt.Sprintf(`
 					log:
@@ -848,7 +856,7 @@ var _ = Describe("Domain blocking functionality", func() {
 					  clientGroupsBlock:
 					    default:
 					      - ads
-				`, tomorrow)))
+				`, twoDaysOut)))
 				Expect(err).Should(Succeed())
 			})
 

--- a/e2e/blocking_test.go
+++ b/e2e/blocking_test.go
@@ -824,5 +824,39 @@ var _ = Describe("Domain blocking functionality", func() {
 					Should(BeDNSRecord("blockeddomain.com.", A, "0.0.0.0"))
 			})
 		})
+
+		Context("when the schedule is inactive right now", func() {
+			BeforeEach(func(ctx context.Context) {
+				tomorrow := weekdayNames[(int(time.Now().UTC().Weekday())+1)%7]
+
+				blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(fmt.Sprintf(`
+					log:
+					  level: warn
+					upstreams:
+					  groups:
+					    default:
+					      - moka2
+					blocking:
+					  denylists:
+					    ads:
+					      - http://httpserver:8080/list.txt
+					  schedules:
+					    not-now:
+					      weekdays: [%s]
+					  listSchedules:
+					    ads: [not-now]
+					  clientGroupsBlock:
+					    default:
+					      - ads
+				`, tomorrow)))
+				Expect(err).Should(Succeed())
+			})
+
+			It("lets the domain resolve via the upstream", func(ctx context.Context) {
+				msg := util.NewMsgWithQuestion("blockeddomain.com.", A)
+				Expect(doDNSRequest(ctx, blocky, msg)).
+					Should(BeDNSRecord("blockeddomain.com.", A, "5.6.7.8"))
+			})
+		})
 	})
 })

--- a/e2e/blocking_test.go
+++ b/e2e/blocking_test.go
@@ -2,8 +2,10 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	. "github.com/0xERR0R/blocky/helpertest"
 	"github.com/0xERR0R/blocky/util"
@@ -768,6 +770,58 @@ var _ = Describe("Domain blocking functionality", func() {
 					Expect(doDNSRequest(ctx, blocky, msg)).
 						Should(BeDNSRecord("blocked.com.", A, "0.0.0.0"))
 				})
+			})
+		})
+	})
+
+	Describe("Schedule-based blocking", func() {
+		// Container clock defaults to UTC (Alpine base image), so the
+		// schedule's weekday is computed in UTC here as well.
+		weekdayNames := []string{"sun", "mon", "tue", "wed", "thu", "fri", "sat"}
+
+		BeforeEach(func(ctx context.Context) {
+			// Upstream that resolves the test domain so the inactive
+			// case can verify the schedule lets traffic through.
+			_, err = createDNSMokkaContainer(ctx, "moka2", e2eNet,
+				`A blockeddomain.com/NOERROR("A 5.6.7.8 300")`,
+			)
+			Expect(err).Should(Succeed())
+
+			_, err = createHTTPServerContainer(ctx, "httpserver", e2eNet, "list.txt", "blockeddomain.com")
+			Expect(err).Should(Succeed())
+		})
+
+		Context("when the schedule is active right now", func() {
+			BeforeEach(func(ctx context.Context) {
+				today := weekdayNames[time.Now().UTC().Weekday()]
+
+				blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(fmt.Sprintf(`
+					log:
+					  level: warn
+					upstreams:
+					  groups:
+					    default:
+					      - moka2
+					blocking:
+					  denylists:
+					    ads:
+					      - http://httpserver:8080/list.txt
+					  schedules:
+					    now:
+					      weekdays: [%s]
+					  listSchedules:
+					    ads: [now]
+					  clientGroupsBlock:
+					    default:
+					      - ads
+				`, today)))
+				Expect(err).Should(Succeed())
+			})
+
+			It("blocks domains in the scheduled list", func(ctx context.Context) {
+				msg := util.NewMsgWithQuestion("blockeddomain.com.", A)
+				Expect(doDNSRequest(ctx, blocky, msg)).
+					Should(BeDNSRecord("blockeddomain.com.", A, "0.0.0.0"))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

- Adds two end-to-end tests for the schedule-based blocking feature introduced in #2037: one verifying a list group is blocked when its schedule is active today, one verifying it falls through to the upstream when the schedule covers tomorrow only.
- Both cases share a `BeforeEach` that provisions a moka mock upstream and an httpserver-served blocklist; the schedule weekday is computed from `time.Now().UTC().Weekday()` and relies on the Alpine container's UTC default.
- Smoke-only by design — overnight wrap, bounded windows, OR-logic across multiple schedules, and validation errors are already covered by unit tests in `config/schedule_test.go` and `resolver/blocking_resolver_test.go`.

## Test plan

- [ ] `make e2e-test` passes locally (full suite)
- [ ] `go tool ginkgo --label-filter=e2e --focus="Schedule-based blocking" e2e` reports `2 Passed | 0 Failed`
- [ ] `go tool ginkgo --label-filter=e2e --focus="Domain blocking functionality" e2e` reports `0 Failed` (no regression in the existing blocking suite)