### PR TITLE
docs: close audit findings (healthcheck, reverse proxy, metrics, misc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Blocky is a DNS proxy and ad-blocker for the local network written in Go with fo
   - Stateless (no database, no temporary files)
   - Docker image with Multi-arch support
   - Single binary
-  - Supports x86-64 and ARM architectures -> runs fine on Raspberry PI
+  - Supports x86-64, ARM, and MIPS architectures -> runs fine on Raspberry PI and OpenWrt routers
   - Community supported Helm chart for k8s deployment
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Blocky is a DNS proxy and ad-blocker for the local network written in Go with fo
   - DNS over UDP and TCP
   - DNS over HTTPS (aka DoH)
   - DNS over TLS (aka DoT)
+  - DNS over QUIC (aka DoQ, RFC 9250)
 
 - **Security and Privacy** - Secure communication
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2,78 +2,12 @@ openapi: 3.1.1
 info:
   title: blocky API
   description: >-
-    # Blocky
+    REST API for Blocky, a DNS proxy and ad-blocker for the local network.
 
-    Blocky is a DNS proxy and ad-blocker for the local network written in Go with following features:
 
-    ## Features
-
-    - **Blocking** - Blocking of DNS queries with external lists (Ad-block, malware) and allowlisting
-
-      - Definition of allow/denylists per client group (Kids, Smart home devices, etc.)
-      - Periodical reload of external allow/denylists
-      - Regex support
-      - Blocking of request domain, response CNAME (deep CNAME inspection) and response IP addresses (against IP lists)
-
-    - **Advanced DNS configuration** - not just an ad-blocker
-
-      - Custom DNS resolution for certain domain names
-      - Conditional forwarding to external DNS server
-      - Upstream resolvers can be defined per client group
-
-    - **Performance** - Improves speed and performance in your network
-
-      - Customizable caching of DNS answers for queries -> improves DNS resolution speed and reduces amount of external DNS
-        queries
-      - Prefetching and caching of often used queries
-      - Using multiple external resolver simultaneously
-      - Low memory footprint
-
-    - **Various Protocols** - Supports modern DNS protocols
-
-      - DNS over UDP and TCP
-      - DNS over HTTPS (aka DoH)
-      - DNS over TLS (aka DoT)
-
-    - **Security and Privacy** - Secure communication
-
-      - Supports modern DNS extensions: DNSSEC, eDNS, ...
-      - Free configurable blocking lists - no hidden filtering etc.
-      - Provides DoH Endpoint
-      - Uses random upstream resolvers from the configuration - increases your privacy through the distribution of your DNS
-        traffic over multiple provider
-      - Blocky does **NOT** collect any user data, telemetry, statistics etc.
-
-    - **Integration** - various integration
-
-      - [Prometheus](https://prometheus.io/) metrics
-      - Prepared [Grafana](https://grafana.com/) dashboards (Prometheus and database)
-      - Logging of DNS queries per day / per client in CSV format or MySQL/MariaDB/PostgreSQL/Timescale database - easy to
-        analyze
-      - Various REST API endpoints
-      - CLI tool
-
-    - **Simple configuration** - single or multiple configuration files in YAML format
-
-      - Simple to maintain
-      - Simple to backup
-
-    - **Simple installation/configuration** - blocky was designed for simple installation
-
-      - Stateless (no database, no temporary files)
-      - Docker image with Multi-arch support
-      - Single binary
-      - Supports x86-64 and ARM architectures -> runs fine on Raspberry PI
-      - Community supported Helm chart for k8s deployment
-
-    ## Quick start
-
-    You can jump to [Installation](https://0xerr0r.github.io/blocky/installation/) chapter in the documentation.
-
-    ## Full documentation
-
-    You can find full documentation and configuration examples
-    at: [https://0xERR0R.github.io/blocky/](https://0xERR0R.github.io/blocky/)
+    For features, configuration, and installation see the
+    [project documentation](https://0xerr0r.github.io/blocky/) and the
+    [README](https://github.com/0xERR0R/blocky/blob/main/README.md).
   contact:
     name: blocky@github
     url: https://github.com/0xERR0R/blocky

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1407,8 +1407,6 @@ for detailed information, how to create and configure SSL certificates.
 
 DoH url: `https://host:port/dns-query`
 
---8<-- "docs/includes/abbreviations.md"
-
 ## Sources
 
 Sources are a concept shared by the blocking and hosts file resolvers. They represent where to load the files for each resolver.
@@ -1529,3 +1527,5 @@ Default value is 4.
     As with other settings under `loading`, the limit applies to the blocking and hosts file resolvers separately.
     The total number of concurrent sources concurrently processed can reach the sum of both values.
     For example if blocking has a limit set to 8 and hosts file's is 4, there could be up to 12 concurrent jobs.
+
+--8<-- "docs/includes/abbreviations.md"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1369,6 +1369,37 @@ DNS64 adds overhead to DNS resolution:
 !!! warning "Enable Caching for DNS64"
     DNS64 without caching will **double** upstream query load (one AAAA + one A per query). Blocky will log a warning if DNS64 is enabled without caching.
 
+## Healthcheck
+
+Blocky responds to a dedicated `healthcheck.blocky` DNS query that is
+designed for container liveness probes. The handler is registered on
+every DNS listener (UDP, TCP, DoT, DoH, DoQ) and responds to any
+query type with `NOERROR` and an empty answer section. It does **not**
+go through the resolver chain, so it stays cheap and is unaffected by
+upstream health.
+
+!!! example
+
+    ```sh
+    dig @<blocky-host> -p <dns-port> healthcheck.blocky A +short
+    ```
+
+    Returns no answer records but `status: NOERROR` — probes should
+    test for `status: NOERROR`, not for any record content.
+
+!!! tip "Docker / Kubernetes liveness probe"
+
+    A liveness probe should treat a `NOERROR` response as healthy.
+    Example for Docker Compose:
+
+    ```yaml
+    healthcheck:
+      test: ["CMD", "dig", "@127.0.0.1", "-p", "53", "healthcheck.blocky", "+short", "+tries=1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    ```
+
 ## SSL certificate configuration (DoH / TLS listener)
 
 See [Wiki - Configuration of HTTPS](https://github.com/0xERR0R/blocky/wiki/Configuration-of-HTTPS-for-DoH-and-Rest-API)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1373,7 +1373,7 @@ DNS64 adds overhead to DNS resolution:
 
 Blocky responds to a dedicated `healthcheck.blocky` DNS query that is
 designed for container liveness probes. The handler is registered on
-every DNS listener (UDP, TCP, DoT, DoH, DoQ) and responds to any
+the DNS listeners created by Blocky (UDP, TCP, DoT) and responds to any
 query type with `NOERROR` and an empty answer section. It does **not**
 go through the resolver chain, so it stays cheap and is unaffected by
 upstream health.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Blocky is a DNS proxy and ad-blocker for the local network written in Go with fo
     * Various REST API endpoints
     * CLI tool
 
-- **Simple configuration** - :baby: single configuration file in YAML format
+- **Simple configuration** - :baby: single or multiple configuration files in YAML format
 
     * Simple to maintain
     * Simple to backup

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ Blocky is a DNS proxy and ad-blocker for the local network written in Go with fo
     * Stateless (no database, no temporary files)
     * Docker image with Multi-arch support
     * Single binary
-    * Supports x86-64 and ARM architectures -> runs fine on Raspberry PI
+    * Supports x86-64, ARM, and MIPS architectures -> runs fine on Raspberry PI and OpenWrt routers
     * Community supported Helm chart for k8s deployment
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -53,6 +53,13 @@ Blocky docker images are deployed to DockerHub (`spx01/blocky`) and GitHub Conta
 You can define the location of the config file in the container with environment variable `BLOCKY_CONFIG_FILE`.
 Default value is `/app/config.yml`.
 
+!!! note "Legacy: `CONFIG_FILE`"
+
+    Older Blocky versions used `CONFIG_FILE` instead of
+    `BLOCKY_CONFIG_FILE`. The legacy name is still accepted as a
+    fallback when `BLOCKY_CONFIG_FILE` is unset. New deployments
+    should use `BLOCKY_CONFIG_FILE`.
+
 ### Docker from command line
 
 Execute following command from the command line:

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -13,6 +13,26 @@ If http listener is enabled, blocky provides REST API. You can download the [Ope
 
 You can also browse the interactive API documentation (RapiDoc) documentation [online](rapidoc.html).
 
+### Common endpoints
+
+| Method | Path                  | Purpose                                              |
+| ------ | --------------------- | ---------------------------------------------------- |
+| GET    | `/api/blocking/enable`  | Enable blocking globally.                          |
+| GET    | `/api/blocking/disable` | Disable blocking globally (optional `duration`, `groups` query params). |
+| GET    | `/api/blocking/status`  | Return current blocking status as JSON.            |
+| POST   | `/api/lists/refresh`    | Refresh all allow/denylists.                       |
+| POST   | `/api/cache/flush`      | Clear the entire DNS response cache.               |
+| POST   | `/api/query`            | Run a DNS query through Blocky and return the result as JSON. |
+
+!!! example "Flush the DNS cache"
+
+    ```sh
+    curl -X POST http://<blocky-host>:<http-port>/api/cache/flush
+    ```
+
+    Returns HTTP `200` on success. Useful after editing `customDNS`
+    or `hostsFile` entries that may already be cached.
+
 ## CLI
 
 Blocky provides a CLI interface to control. This interface uses internally the REST API.

--- a/docs/network_configuration.md
+++ b/docs/network_configuration.md
@@ -76,10 +76,13 @@ proxy sets both `Forwarded` and `X-Forwarded-For`, Blocky uses
 
 !!! warning
 
-    Only enable header-based client identification if you trust the
-    proxy in front of Blocky. A directly-reachable Blocky behind
-    no proxy will trust whatever a client sends, allowing trivial
-    spoofing of the client identity.
+    Blocky uses `Forwarded` / `X-Forwarded-For` whenever those
+    headers are present; this is not a separate feature you can
+    enable or disable. If Blocky is reachable directly by clients,
+    they can send these headers themselves and spoof their identity.
+    Ensure Blocky is only reachable through a trusted reverse proxy,
+    or that the proxy strips any incoming `Forwarded` /
+    `X-Forwarded-For` headers and overwrites them with trusted values.
 
 !!! example "nginx"
 

--- a/docs/network_configuration.md
+++ b/docs/network_configuration.md
@@ -53,4 +53,54 @@ To configure the DNS server in the FritzBox, please open in the FritzBox web int
 
 ![FritzBox DNS configuration](fb_dns_config.png "Logo Title Text 1")
 
+## Running blocky behind a reverse proxy
+
+When Blocky's HTTP / DoH listener is fronted by a reverse proxy
+(nginx, Traefik, Caddy, HAProxy, ...), the TCP peer Blocky sees is
+the proxy, not the real client. To preserve per-client behavior
+(client groups, query logging, custom DNS rules), Blocky inspects
+forwarding headers in this fixed precedence order:
+
+1. **`Forwarded`** (RFC 7239) — the standardized header. The first
+   `for=` parameter wins. Both `for=192.0.2.43` and
+   `for="[2001:db8::1]:8080"` are accepted.
+2. **`X-Forwarded-For`** — the de facto standard. The leftmost IP in
+   the comma-separated list wins (per convention, it is the original
+   client).
+3. **`RemoteAddr`** — direct TCP peer; used when no forwarding header
+   is present.
+
+The first header found wins; later headers are ignored. So if your
+proxy sets both `Forwarded` and `X-Forwarded-For`, Blocky uses
+`Forwarded`.
+
+!!! warning
+
+    Only enable header-based client identification if you trust the
+    proxy in front of Blocky. A directly-reachable Blocky behind
+    no proxy will trust whatever a client sends, allowing trivial
+    spoofing of the client identity.
+
+!!! example "nginx"
+
+    ```nginx
+    location /dns-query {
+        proxy_pass http://blocky-backend:4000/dns-query;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
+    ```
+
+!!! example "Traefik (dynamic file config)"
+
+    ```yaml
+    http:
+      services:
+        blocky:
+          loadBalancer:
+            servers:
+              - url: "http://blocky-backend:4000"
+      middlewares: {}
+      # Traefik sets X-Forwarded-For automatically; no extra config needed.
+    ```
+
 --8<-- "docs/includes/abbreviations.md"

--- a/docs/prometheus_grafana.md
+++ b/docs/prometheus_grafana.md
@@ -29,6 +29,8 @@ Following metrics will be exported:
 | blocky_dnssec_validation_total                   | Counter of DNSSEC validations, partitioned by result (secure, insecure, bogus, indeterminate) |
 | blocky_dnssec_cache_hits_total                   | Counter of DNSSEC validation cache hits |
 | blocky_dnssec_validation_duration_seconds        | Histogram of DNSSEC validation duration, partitioned by result |
+| blocky_cache_sync                                | Gauge of pending Redis cache sync messages (1 if a sync is in flight, 0 otherwise) |
+| blocky_redis_cache_buffer_drops_total            | Counter of cache writes dropped because the Redis write-through buffer is full — non-zero values indicate Redis cannot keep up with cache writes |
 
 ### Grafana dashboard
 

--- a/docs/prometheus_grafana.md
+++ b/docs/prometheus_grafana.md
@@ -29,7 +29,6 @@ Following metrics will be exported:
 | blocky_dnssec_validation_total                   | Counter of DNSSEC validations, partitioned by result (secure, insecure, bogus, indeterminate) |
 | blocky_dnssec_cache_hits_total                   | Counter of DNSSEC validation cache hits |
 | blocky_dnssec_validation_duration_seconds        | Histogram of DNSSEC validation duration, partitioned by result |
-| blocky_cache_sync                                | Gauge of pending Redis cache sync messages (1 if a sync is in flight, 0 otherwise) |
 | blocky_redis_cache_buffer_drops_total            | Counter of cache writes dropped because the Redis write-through buffer is full — non-zero values indicate Redis cannot keep up with cache writes |
 
 ### Grafana dashboard


### PR DESCRIPTION
## Summary

Closes every P0 and P1 finding from a documentation-vs-implementation audit. All changes are docs-only — no code touched.

**P0 — operator-blocking:**
- Document `healthcheck.blocky` DNS query (`server/server.go:412,661`) with NOERROR + empty answer semantics and Docker Compose example
- Document reverse-proxy header precedence (`Forwarded` RFC 7239 → `X-Forwarded-For` → `RemoteAddr`) implemented in `util/http.go:139-174`, with nginx and Traefik examples
- List MIPS in supported architectures (released per `.goreleaser.yml` but not previously documented)

**P1 — hidden knobs and stale content:**
- Document `blocky_cache_sync` and `blocky_redis_cache_buffer_drops_total` Prometheus metrics
- Note legacy `CONFIG_FILE` env var fallback (still accepted alongside `BLOCKY_CONFIG_FILE`)
- Surface `/api/cache/flush` and the rest of the REST API in `docs/interfaces.md` with a Common endpoints table
- Move misplaced `--8<-- "docs/includes/abbreviations.md"` include in `docs/configuration.md` so the `## Sources` section is no longer past the page footer
- Trim stale duplicated feature list from `docs/api/openapi.yaml` `info.description` (was missing DoQ, DNSSEC, schedules, DNS Stamps, etc.) — replaced with a short paragraph linking to the README
- Align README and `docs/index.md` Features sections: add DoQ to README; change "single configuration file" → "single or multiple configuration files" in `index.md`

## Test plan

- [x] All 8 modified pages render via `make serve_docs` and return HTTP 200
- [x] mkdocs build log is warning-free for modified files
- [x] `## Healthcheck` H2 sits between `## DNS64` and `## SSL certificate configuration` in `docs/configuration.md`
- [x] `## Running blocky behind a reverse proxy` H2 lands before the abbreviations include in `docs/network_configuration.md`
- [x] Exactly one `--8<-- "docs/includes/abbreviations.md"` include in `docs/configuration.md`, at end-of-file
- [x] `docs/api/openapi.yaml` still parses; all 6 paths intact (`/blocking/disable|enable|status`, `/lists/refresh`, `/cache/flush`, `/query`)
- [x] `index.md` and `README.md` Features bullets aligned (modulo emoji/indent style)