### PR TITLE
fix(api): keep /api/query response unobfuscated when log.privacy is on

### DIFF
--- a/api/api_interface_impl_test.go
+++ b/api/api_interface_impl_test.go
@@ -96,6 +96,34 @@ var _ = Describe("API implementation tests", func() {
 				Expect(resp200.ReturnCode).Should(Equal("NOERROR"))
 			})
 
+			When("log privacy is enabled", func() {
+				BeforeEach(func() {
+					util.LogPrivacy.Store(true)
+					DeferCleanup(func() { util.LogPrivacy.Store(false) })
+				})
+
+				It("should still return the unobfuscated response (issue #1950)", func() {
+					queryResponse, err := util.NewMsgWithAnswer(
+						"example.com.", 123, A, "93.184.216.34",
+					)
+					Expect(err).Should(Succeed())
+
+					querierMock.On("Query", ctx, "", net.IP(nil), "example.com.", A).Return(&model.Response{
+						Res:    queryResponse,
+						Reason: "RESOLVED (tcp+udp:1.1.1.1)",
+					}, nil)
+
+					resp, err := sut.Query(ctx, QueryRequestObject{
+						Body: &ApiQueryRequest{
+							Query: "example.com", Type: "A",
+						},
+					})
+					Expect(err).Should(Succeed())
+					resp200 := resp.(Query200JSONResponse)
+					Expect(resp200.Response).Should(Equal("A (93.184.216.34)"))
+				})
+			})
+
 			It("extracts metadata from the HTTP request", func() {
 				r, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://blocky.localhost", nil)
 				Expect(err).Should(Succeed())

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -149,7 +149,7 @@ func (r *ConditionalUpstreamResolver) internalResolve(ctx context.Context, reso 
 
 	var answer string
 	if response != nil {
-		answer = util.AnswerToString(response.Res.Answer)
+		answer = util.Obfuscate(util.AnswerToString(response.Res.Answer))
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -135,7 +135,7 @@ func (r *CustomDNSResolver) processRequest(
 			if len(answers) > 0 {
 				logger.WithFields(logrus.Fields{
 					"answer": util.Obfuscate(util.AnswerToString(answers)),
-					"domain": domain,
+					"domain": util.Obfuscate(domain),
 				}).Debugf("returning custom dns entry")
 
 				return model.NewResponseWithAnswers(request, answers, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS"), nil

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -134,7 +134,7 @@ func (r *CustomDNSResolver) processRequest(
 
 			if len(answers) > 0 {
 				logger.WithFields(logrus.Fields{
-					"answer": util.AnswerToString(answers),
+					"answer": util.Obfuscate(util.AnswerToString(answers)),
 					"domain": domain,
 				}).Debugf("returning custom dns entry")
 

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -126,7 +126,7 @@ func (r *HostsFileResolver) Resolve(ctx context.Context, request *model.Request)
 	response := r.resolve(question, domain)
 	if response != nil {
 		logger.WithFields(logrus.Fields{
-			"answer": util.AnswerToString(response),
+			"answer": util.Obfuscate(util.AnswerToString(response)),
 			"domain": util.Obfuscate(domain),
 		}).Debugf("returning hosts file entry")
 

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -192,7 +192,8 @@ func evaluateResponses(
 			continue
 		}
 
-		logger.WithField("answer", util.Obfuscate(util.AnswerToString(result.response.Res.Answer))).Debug("using response from resolver")
+		logger.WithField("answer", util.Obfuscate(util.AnswerToString(result.response.Res.Answer))).
+			Debug("using response from resolver")
 
 		return result.response, nil
 	}

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -192,7 +192,7 @@ func evaluateResponses(
 			continue
 		}
 
-		logger.WithField("answer", util.AnswerToString(result.response.Res.Answer)).Debug("using response from resolver")
+		logger.WithField("answer", util.Obfuscate(util.AnswerToString(result.response.Res.Answer))).Debug("using response from resolver")
 
 		return result.response, nil
 	}
@@ -214,7 +214,7 @@ func (r *ParallelBestResolver) retryWithDifferent(
 
 	logger.WithFields(logrus.Fields{
 		"resolver": *resolver,
-		"answer":   util.AnswerToString(resp.Res.Answer),
+		"answer":   util.Obfuscate(util.AnswerToString(resp.Res.Answer)),
 	}).Debug("using response from resolver")
 
 	return resp, nil

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -205,7 +205,7 @@ func (r *QueryLoggingResolver) createLogEntry(request *model.Request, response *
 			entry.ResponseCode = dns.RcodeToString[response.Res.Rcode]
 
 		case config.QueryLogFieldResponseAnswer:
-			entry.Answer = util.AnswerToString(response.Res.Answer)
+			entry.Answer = util.Obfuscate(util.AnswerToString(response.Res.Answer))
 
 		case config.QueryLogFieldQuestion:
 			entry.QuestionName = util.Obfuscate(request.Req.Question[0].Name)

--- a/resolver/strict_resolver.go
+++ b/resolver/strict_resolver.go
@@ -80,7 +80,7 @@ func (r *StrictResolver) Resolve(ctx context.Context, request *model.Request) (*
 
 		logger.WithFields(logrus.Fields{
 			"resolver": *resolver,
-			"answer":   util.AnswerToString(resp.Res.Answer),
+			"answer":   util.Obfuscate(util.AnswerToString(resp.Res.Answer)),
 		}).Debug("using response from resolver")
 
 		return resp, nil

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -462,7 +462,7 @@ func (r *UpstreamResolver) logResponse(
 	logger *logrus.Entry, request *model.Request, resp *dns.Msg, ip net.IP, rtt time.Duration,
 ) {
 	logger.WithFields(logrus.Fields{
-		"answer":           util.AnswerToString(resp.Answer),
+		"answer":           util.Obfuscate(util.AnswerToString(resp.Answer)),
 		"return_code":      dns.RcodeToString[resp.Rcode],
 		"upstream":         r.cfg.String(),
 		"upstream_ip":      ip.String(),

--- a/util/common.go
+++ b/util/common.go
@@ -46,7 +46,8 @@ func Obfuscate(in string) string {
 	return in
 }
 
-// AnswerToString creates a user-friendly representation of an answer
+// AnswerToString creates a user-friendly representation of an answer.
+// The result is NOT obfuscated; callers that emit it to logs must wrap with Obfuscate.
 func AnswerToString(answer []dns.RR) string {
 	answers := make([]string, len(answer))
 
@@ -65,7 +66,7 @@ func AnswerToString(answer []dns.RR) string {
 		}
 	}
 
-	return Obfuscate(strings.Join(answers, ", "))
+	return strings.Join(answers, ", ")
 }
 
 // QuestionToString creates a user-friendly representation of a question

--- a/util/common_test.go
+++ b/util/common_test.go
@@ -61,6 +61,21 @@ var _ = Describe("Common function tests", func() {
 					"AAAA (2001:db8:85a3:8d3:1319:8a2e:370:7344), CNAME (cname), PTR (ptr), \t0\tCLASS0\tNone\tns"))
 			})
 		})
+
+		When("LogPrivacy is enabled", func() {
+			BeforeEach(func() {
+				LogPrivacy.Store(true)
+			})
+
+			AfterEach(func() {
+				LogPrivacy.Store(false)
+			})
+
+			It("should still return the raw representation (obfuscation is the caller's job)", func() {
+				rr := []dns.RR{&dns.A{A: net.ParseIP("127.0.0.1")}}
+				Expect(AnswerToString(rr)).Should(Equal("A (127.0.0.1)"))
+			})
+		})
 	})
 
 	Describe("print question", func() {


### PR DESCRIPTION
## Summary
- `util.AnswerToString` unconditionally applied `Obfuscate()` to its output, coupling DNS-answer formatting to log-privacy behavior.
- The REST `/api/query` handler shared this formatter, so responses were obfuscated when `log.privacy: true` — making the endpoint useless for its stated purpose (#1950).
- Move the `Obfuscate()` call to the eight log call sites in `resolver/` and `query_logging_resolver.go`; `AnswerToString` now returns the raw representation.
- API handler is unchanged in shape but now returns truthful data regardless of `log.privacy`.

`QuestionToString` still applies obfuscation; it has no API consumer and there's no observable bug, so it was left alone to keep this PR focused.

## Test plan
- [x] Added failing test in `util/common_test.go` proving `AnswerToString` no longer obfuscates when `LogPrivacy` is enabled.
- [x] Added failing test in `api/api_interface_impl_test.go` reproducing the issue #1950 scenario end-to-end through the API handler.
- [x] `go test ./api/ ./util/ ./resolver/` — all green.
- [x] Manually verified all eight log call sites still emit obfuscated answers via `util.Obfuscate(util.AnswerToString(...))`.

Fixes #1950