### PR TITLE
feat(sudn): handle resolver.arpa zone per RFC 9462 (DDR)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -970,6 +970,11 @@ Some RFCs have optional recommendations, which are configurable as described bel
 However, you can completely deactivate the blocking of SUDN by setting enable to false.
 Warning! You should only disable this if your upstream DNS server is local, as it shouldn't be disabled for remote upstreams.
 
+This also covers [RFC 9462 (Discovery of Designated Resolvers)](https://www.rfc-editor.org/rfc/rfc9462): queries
+for any name in `resolver.arpa.` (e.g. `_dns.resolver.arpa.`) are answered locally with NODATA and never
+forwarded upstream. Without this, stub resolvers (notably recent iOS/Android) can pick up a DDR answer from the
+upstream and silently upgrade to that upstream, bypassing blocky.
+
 Configuration parameters:
 
 | Parameter                           | Type | Mandatory | Default value | Description                                                                                   |

--- a/resolver/sudn_resolver.go
+++ b/resolver/sudn_resolver.go
@@ -85,6 +85,15 @@ var (
 		//
 		// Section 4
 		"home.arpa.": sudnHomeArpa,
+
+		// RFC 9462 (Discovery of Designated Resolvers)
+		// https://www.rfc-editor.org/rfc/rfc9462
+		//
+		// Sections 4, 6.1 and 6.4: blocky advertises no Designated Resolvers,
+		// so reply NODATA across the whole zone and never forward upstream
+		// (forwarded answers would fail the client's cert SAN check anyway
+		// and let stub resolvers bypass blocky).
+		"resolver.arpa.": sudnNoData,
 	}
 )
 
@@ -142,6 +151,10 @@ func newSUDNResponse(response *model.Request, rcode int) *model.Response {
 
 func sudnNXDomain(request *model.Request, _ *config.SUDN) *model.Response {
 	return newSUDNResponse(request, dns.RcodeNameError)
+}
+
+func sudnNoData(request *model.Request, _ *config.SUDN) *model.Response {
+	return newSUDNResponse(request, dns.RcodeSuccess)
 }
 
 func sudnLocalhost(request *model.Request, cfg *config.SUDN) *model.Response {

--- a/resolver/sudn_resolver_test.go
+++ b/resolver/sudn_resolver_test.go
@@ -203,5 +203,28 @@ var _ = Describe("SudnResolver", Label("sudnResolver"), func() {
 			Expect(err).Should(Succeed())
 			Expect(resp).ShouldNot(HaveResponseType(ResponseTypeSPECIAL))
 		})
+
+		// RFC 9462: Discovery of Designated Resolvers (DDR).
+		// Section 4 + 6.1 + 6.4: blocky has no Designated Resolvers to announce
+		// and MUST NOT forward queries for `resolver.arpa.` upstream. Reply
+		// NODATA (NOERROR + empty Answer) for every QTYPE across the zone.
+		DescribeTable("RFC 9462 resolver.arpa zone (NODATA)",
+			func(qType dns.Type, qName string) {
+				resp, err := sut.Resolve(ctx, newRequest(qName, qType))
+				Expect(err).Should(Succeed())
+				Expect(resp).Should(SatisfyAll(
+					HaveResponseType(ResponseTypeSPECIAL),
+					HaveReason("Special-Use Domain Name"),
+					HaveReturnCode(dns.RcodeSuccess),
+					HaveNoAnswer(),
+				))
+			},
+			Entry("SVCB for _dns.resolver.arpa.", dns.Type(dns.TypeSVCB), "_dns.resolver.arpa."),
+			Entry("A for _dns.resolver.arpa.", A, "_dns.resolver.arpa."),
+			Entry("AAAA for _dns.resolver.arpa.", AAAA, "_dns.resolver.arpa."),
+			Entry("A for the zone apex resolver.arpa.", A, "resolver.arpa."),
+			Entry("HTTPS for an arbitrary subdomain", HTTPS, "foo.bar.resolver.arpa."),
+			Entry("DS for the zone apex (no forwarding)", DS, "resolver.arpa."),
+		)
 	})
 })


### PR DESCRIPTION
## Summary

- Add `resolver.arpa.` handler to the SUDN resolver. Any QTYPE on any name in the zone (apex, subdomains, `_dns.resolver.arpa.`, etc.) is answered locally with NODATA (NOERROR + empty Answer) and never forwarded upstream.
- Closes the iOS/Android DDR-bypass demonstrated in #1537: today blocky forwards `_dns.resolver.arpa.` SVCB queries, the upstream responds with its own DDR record, and the stub silently upgrades to that upstream — bypassing blocky.
- Documented in the SUDN section of `docs/configuration.md`.

Per RFC 9462:

- §4: *"If the recursive resolver that receives this query has no Designated Resolvers, it SHOULD return NODATA for queries to the 'resolver.arpa' zone."*
- §6.1: *"A DNS forwarder SHOULD NOT forward queries for 'resolver.arpa' (or any subdomains) upstream."*
- §6.4: *"DNS resolvers that support DDR ... MUST treat resolver.arpa as a locally served zone."*

This is the no-DDR-config baseline. Full SVCB synthesis advertising blocky's own DoT/DoH endpoints (the rest of RFC 9462) would be a follow-up; it depends on TLS cert SAN constraints (§4.2) and per-interface address selection that don't apply to the safe NODATA default.

Refs #1537

## Test plan

- [x] New Ginkgo specs (SVCB, A, AAAA, HTTPS, DS) covering apex + subdomains of `resolver.arpa.`
- [x] Red-green verified (revert handler → 6 specs fail with upstream-forward behavior; restore → all pass)
- [x] `go test ./... -race` clean on touched packages
- [x] `golangci-lint --new-from-rev=origin/main`: 0 new issues
- [ ] Reviewer sanity check: confirm a real iPhone on the LAN stops upgrading away from blocky once this is deployed