### PR TITLE
build: upgrade Go to 1.26.2 and golangci-lint to v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ linters:
     - gocyclo
     - gosmopolitan
     - godox
-    - gomodguard
+    - gomodguard_v2
     - grouper
     - importas
     - iface

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GO_BUILD_LD_FLAGS:=\
 GO_BUILD_OUTPUT:=$(BIN_OUT_DIR)/$(BINARY_NAME)$(BINARY_SUFFIX)
 
 # define version of golangci-lint here. If defined in tools.go, go mod perfoms automatically downgrade to older version which doesn't work with golang >=1.18
-GOLANG_LINT_VERSION=v2.11.3
+GOLANG_LINT_VERSION=v2.12.2
 
 GINKGO_PROCS?=
 

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const refreshCmdName = "refresh"
+
 // NewListsCommand creates new command instance
 func NewListsCommand() *cobra.Command {
 	c := &cobra.Command{
@@ -21,7 +23,7 @@ func NewListsCommand() *cobra.Command {
 
 func newRefreshCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "refresh",
+		Use:   refreshCmdName,
 		Short: "refreshes all lists",
 		RunE:  refreshList,
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -9,10 +9,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const validateCmdName = "validate"
+
 // NewValidateCommand creates new command instance
 func NewValidateCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "validate",
+		Use:   validateCmdName,
 		Args:  cobra.NoArgs,
 		Short: "Validates the configuration",
 		RunE:  validateConfiguration,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xERR0R/blocky
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/0xERR0R/expiration-cache v0.1.0

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -391,7 +391,7 @@ func (r *BlockingResolver) handleDenylist(ctx context.Context, groupsToCheck []s
 
 	for _, question := range request.Req.Question {
 		domain := util.ExtractDomain(question)
-		logger := logger.WithField("domain", domain)
+		logger := logger.WithField(logFieldDomain, domain)
 
 		if groups := r.matches(groupsToCheck, r.allowlistMatcher, domain); len(groups) > 0 {
 			logger.WithField("groups", groups).Debugf("domain is allowlisted")

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -872,7 +872,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 					Denylists: map[string][]config.BytesSource{
 						"defaultGroup": config.NewBytesSources(defaultGroupFile.Path),
 					},
-					Schedules:         map[string]config.Schedule{},
+					Schedules: map[string]config.Schedule{},
 					ClientGroupsBlock: map[string][]string{
 						"default": {"defaultGroup"},
 					},

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -198,7 +198,7 @@ func (r *CachingResolver) Resolve(ctx context.Context, request *model.Request) (
 	for _, question := range request.Req.Question {
 		domain := util.ExtractDomain(question)
 		cacheKey := util.GenerateCacheKey(dns.Type(question.Qtype), domain)
-		logger := logger.WithField("domain", util.Obfuscate(domain))
+		logger := logger.WithField(logFieldDomain, util.Obfuscate(domain))
 
 		val, ttl := r.getFromCache(logger, cacheKey)
 

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -153,9 +153,9 @@ func (r *ConditionalUpstreamResolver) internalResolve(ctx context.Context, reso 
 	}
 
 	logger.WithFields(logrus.Fields{
-		"answer":   answer,
-		"domain":   util.Obfuscate(do),
-		"upstream": reso,
+		logFieldAnswer:   answer,
+		logFieldDomain:   util.Obfuscate(do),
+		logFieldUpstream: reso,
 	}).Debugf("received response from conditional upstream")
 
 	return response, nil

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -134,8 +134,8 @@ func (r *CustomDNSResolver) processRequest(
 
 			if len(answers) > 0 {
 				logger.WithFields(logrus.Fields{
-					"answer": util.Obfuscate(util.AnswerToString(answers)),
-					"domain": util.Obfuscate(domain),
+					logFieldAnswer: util.Obfuscate(util.AnswerToString(answers)),
+					logFieldDomain: util.Obfuscate(domain),
 				}).Debugf("returning custom dns entry")
 
 				return model.NewResponseWithAnswers(request, answers, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS"), nil

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -126,8 +126,8 @@ func (r *HostsFileResolver) Resolve(ctx context.Context, request *model.Request)
 	response := r.resolve(question, domain)
 	if response != nil {
 		logger.WithFields(logrus.Fields{
-			"answer": util.Obfuscate(util.AnswerToString(response)),
-			"domain": util.Obfuscate(domain),
+			logFieldAnswer: util.Obfuscate(util.AnswerToString(response)),
+			logFieldDomain: util.Obfuscate(domain),
 		}).Debugf("returning hosts file entry")
 
 		return model.NewResponseWithAnswers(request, response, model.ResponseTypeHOSTSFILE, "HOSTS FILE"), nil
@@ -230,7 +230,7 @@ func (r *HostsFileResolver) parseFile(
 		}
 
 		// Ignore loopback, if so configured
-		if r.cfg.FilterLoopback && (entry.IP.IsLoopback() || entry.Name == "localhost") {
+		if r.cfg.FilterLoopback && (entry.IP.IsLoopback() || entry.Name == localhostName) {
 			return nil
 		}
 

--- a/resolver/metrics_resolver.go
+++ b/resolver/metrics_resolver.go
@@ -21,6 +21,7 @@ const (
 	labelClient       = "client"
 	labelType         = "type"
 	labelReason       = "reason"
+	labelResponseCode = "response_code"
 	labelResponseType = "response_type"
 )
 
@@ -60,7 +61,7 @@ func (r *MetricsResolver) Resolve(ctx context.Context, request *model.Request) (
 		} else {
 			r.totalResponse.With(prometheus.Labels{
 				labelReason:       response.Reason,
-				"response_code":   dns.RcodeToString[response.Res.Rcode],
+				labelResponseCode: dns.RcodeToString[response.Res.Rcode],
 				labelResponseType: response.RType.String(),
 			}).Inc()
 		}
@@ -128,6 +129,6 @@ func totalResponseMetric() *prometheus.CounterVec {
 		prometheus.CounterOpts{
 			Name: "blocky_response_total",
 			Help: "Number of total responses",
-		}, []string{labelReason, "response_code", labelResponseType},
+		}, []string{labelReason, labelResponseCode, labelResponseType},
 	)
 }

--- a/resolver/metrics_resolver.go
+++ b/resolver/metrics_resolver.go
@@ -15,7 +15,14 @@ import (
 
 // nativeHistogramBucketFactor controls the resolution of native histograms.
 // The value of 1.05 is slightly higher accuracy than the default of 1.1.
-const nativeHistogramBucketFactor = 1.05
+const (
+	nativeHistogramBucketFactor = 1.05
+
+	labelClient       = "client"
+	labelType         = "type"
+	labelReason       = "reason"
+	labelResponseType = "response_type"
+)
 
 // MetricsResolver resolver that records metrics about requests/response
 type MetricsResolver struct {
@@ -35,8 +42,8 @@ func (r *MetricsResolver) Resolve(ctx context.Context, request *model.Request) (
 
 	if r.cfg.Enable {
 		r.totalQueries.With(prometheus.Labels{
-			"client": strings.Join(request.ClientNames, ","),
-			"type":   dns.TypeToString[request.Req.Question[0].Qtype],
+			labelClient: strings.Join(request.ClientNames, ","),
+			labelType:   dns.TypeToString[request.Req.Question[0].Qtype],
 		}).Inc()
 
 		reqDuration := time.Since(request.RequestTS)
@@ -52,9 +59,9 @@ func (r *MetricsResolver) Resolve(ctx context.Context, request *model.Request) (
 			r.totalErrors.Inc()
 		} else {
 			r.totalResponse.With(prometheus.Labels{
-				"reason":        response.Reason,
-				"response_code": dns.RcodeToString[response.Res.Rcode],
-				"response_type": response.RType.String(),
+				labelReason:       response.Reason,
+				"response_code":   dns.RcodeToString[response.Res.Rcode],
+				labelResponseType: response.RType.String(),
 			}).Inc()
 		}
 	}
@@ -91,7 +98,7 @@ func totalQueriesMetric() *prometheus.CounterVec {
 		prometheus.CounterOpts{
 			Name: "blocky_query_total",
 			Help: "Number of total queries",
-		}, []string{"client", "type"},
+		}, []string{labelClient, labelType},
 	)
 }
 
@@ -112,7 +119,7 @@ func durationHistogram() *prometheus.HistogramVec {
 			Buckets:                     []float64{0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.2, 0.5, 1.0, 2.0},
 			NativeHistogramBucketFactor: nativeHistogramBucketFactor,
 		},
-		[]string{"response_type"},
+		[]string{labelResponseType},
 	)
 }
 
@@ -121,6 +128,6 @@ func totalResponseMetric() *prometheus.CounterVec {
 		prometheus.CounterOpts{
 			Name: "blocky_response_total",
 			Help: "Number of total responses",
-		}, []string{"reason", "response_code", "response_type"},
+		}, []string{labelReason, "response_code", labelResponseType},
 	)
 }

--- a/resolver/mock_doq_upstream_server.go
+++ b/resolver/mock_doq_upstream_server.go
@@ -94,7 +94,7 @@ func generateSelfSignedCert() tls.Certificate {
 
 	template := x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		DNSNames:     []string{"localhost"},
+		DNSNames:     []string{localhostName},
 	}
 
 	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
@@ -136,7 +136,7 @@ func (t *MockDoQUpstreamServer) Start() config.Upstream {
 	port, err := config.ConvertPort(strconv.Itoa(addr.Port))
 	util.FatalOnError("can't convert port", err)
 
-	return config.Upstream{Net: config.NetProtocolQuic, Host: "127.0.0.1", Port: port}
+	return config.Upstream{Net: config.NetProtocolQuic, Host: loopbackIPv4Str, Port: port}
 }
 
 func (t *MockDoQUpstreamServer) serve() {

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -192,7 +192,7 @@ func evaluateResponses(
 			continue
 		}
 
-		logger.WithField("answer", util.Obfuscate(util.AnswerToString(result.response.Res.Answer))).
+		logger.WithField(logFieldAnswer, util.Obfuscate(util.AnswerToString(result.response.Res.Answer))).
 			Debug("using response from resolver")
 
 		return result.response, nil
@@ -214,8 +214,8 @@ func (r *ParallelBestResolver) retryWithDifferent(
 	}
 
 	logger.WithFields(logrus.Fields{
-		"resolver": *resolver,
-		"answer":   util.Obfuscate(util.AnswerToString(resp.Res.Answer)),
+		"resolver":     *resolver,
+		logFieldAnswer: util.Obfuscate(util.AnswerToString(resp.Res.Answer)),
 	}).Debug("using response from resolver")
 
 	return resp, nil

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -21,6 +21,7 @@ const (
 	cleanUpRunPeriod         = 12 * time.Hour
 	queryLoggingResolverType = "query_logging"
 	logChanCap               = 1000
+	defaultClientIP          = "0.0.0.0"
 )
 
 // QueryLoggingResolver writes query information (question, answer, duration, ...)
@@ -186,7 +187,7 @@ func (r *QueryLoggingResolver) createLogEntry(request *model.Request, response *
 ) *querylog.LogEntry {
 	entry := querylog.LogEntry{
 		Start:          start,
-		ClientIP:       "0.0.0.0",
+		ClientIP:       defaultClientIP,
 		ClientNames:    []string{"none"},
 		BlockyInstance: r.instanceID,
 	}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -17,6 +17,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	logFieldDomain   = "domain"
+	logFieldAnswer   = "answer"
+	logFieldUpstream = "upstream"
+	localhostName    = "localhost"
+	loopbackIPv4Str  = "127.0.0.1"
+)
+
 func newRequest(question string, rType dns.Type) *model.Request {
 	return &model.Request{
 		Req:      util.NewMsgWithQuestion(question, rType),

--- a/resolver/strict_resolver.go
+++ b/resolver/strict_resolver.go
@@ -79,8 +79,8 @@ func (r *StrictResolver) Resolve(ctx context.Context, request *model.Request) (*
 		}
 
 		logger.WithFields(logrus.Fields{
-			"resolver": *resolver,
-			"answer":   util.Obfuscate(util.AnswerToString(resp.Res.Answer)),
+			"resolver":     *resolver,
+			logFieldAnswer: util.Obfuscate(util.AnswerToString(resp.Res.Answer)),
 		}).Debug("using response from resolver")
 
 		return resp, nil

--- a/resolver/sudn_resolver.go
+++ b/resolver/sudn_resolver.go
@@ -11,11 +11,13 @@ import (
 	"github.com/miekg/dns"
 )
 
+const exampleDomain = "example.com."
+
 type sudnHandler = func(request *model.Request, cfg *config.SUDN) *model.Response
 
 //nolint:gochecknoglobals
 var (
-	loopbackV4 = net.ParseIP("127.0.0.1")
+	loopbackV4 = net.ParseIP(loopbackIPv4Str)
 	loopbackV6 = net.IPv6loopback
 
 	// See Wikipedia for an up-to-date reference:
@@ -51,7 +53,7 @@ var (
 		"invalid.": sudnNXDomain,
 		// Section 6.5
 		"example.":     nil,
-		"example.com.": nil,
+		exampleDomain:  nil,
 		"example.net.": nil,
 		"example.org.": nil,
 

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -368,7 +368,7 @@ func newUpstreamResolverUnchecked(cfg upstreamConfig, bootstrap *Bootstrap) *Ups
 	upstreamClient := createUpstreamClient(cfg)
 
 	return &UpstreamResolver{
-		typed:        withType("upstream"),
+		typed:        withType(logFieldUpstream),
 		configurable: withConfig(cfg),
 
 		upstreamClient: upstreamClient,
@@ -386,14 +386,14 @@ func (r UpstreamResolver) Upstream() config.Upstream {
 
 func (r *UpstreamResolver) log(ctx context.Context) (context.Context, *logrus.Entry) {
 	return r.logWithFields(ctx, logrus.Fields{
-		"upstream": r.cfg.String(),
+		logFieldUpstream: r.cfg.String(),
 	})
 }
 
 // testResolve sends a test query to verify the upstream is reachable and working
 func (r *UpstreamResolver) testResolve(ctx context.Context) error {
 	// example.com MUST always resolve. See SUDN resolver
-	request := newRequest("example.com.", dns.Type(dns.TypeA))
+	request := newRequest(exampleDomain, dns.Type(dns.TypeA))
 
 	_, err := r.Resolve(ctx, request)
 	if err != nil {
@@ -443,10 +443,10 @@ func (r *UpstreamResolver) Resolve(ctx context.Context, request *model.Request) 
 		retry.RetryIf(isTimeout),
 		retry.OnRetry(func(n uint, err error) {
 			logger.WithFields(logrus.Fields{
-				"upstream":    r.cfg.String(),
-				"upstream_ip": ip.String(),
-				"question":    util.QuestionToString(request.Req.Question),
-				"attempt":     fmt.Sprintf("%d/%d", n+1, retryAttempts),
+				logFieldUpstream: r.cfg.String(),
+				"upstream_ip":    ip.String(),
+				"question":       util.QuestionToString(request.Req.Question),
+				"attempt":        fmt.Sprintf("%d/%d", n+1, retryAttempts),
 			}).Debugf("%s, retrying...", err)
 
 			ips.Next()
@@ -462,9 +462,9 @@ func (r *UpstreamResolver) logResponse(
 	logger *logrus.Entry, request *model.Request, resp *dns.Msg, ip net.IP, rtt time.Duration,
 ) {
 	logger.WithFields(logrus.Fields{
-		"answer":           util.Obfuscate(util.AnswerToString(resp.Answer)),
+		logFieldAnswer:     util.Obfuscate(util.AnswerToString(resp.Answer)),
 		"return_code":      dns.RcodeToString[resp.Rcode],
-		"upstream":         r.cfg.String(),
+		logFieldUpstream:   r.cfg.String(),
 		"upstream_ip":      ip.String(),
 		"protocol":         request.Protocol,
 		"net":              r.cfg.Net,

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	dnsContentType   = "application/dns-message"
-	retryAttempts    = 3
-	sha256HashLength = 32
+	dnsContentType       = "application/dns-message"
+	upstreamResolverType = "upstream"
+	retryAttempts        = 3
+	sha256HashLength     = 32
 )
 
 // UpstreamServerError wraps a response with RCode ServFail so no other resolver tries to use it.
@@ -368,7 +369,7 @@ func newUpstreamResolverUnchecked(cfg upstreamConfig, bootstrap *Bootstrap) *Ups
 	upstreamClient := createUpstreamClient(cfg)
 
 	return &UpstreamResolver{
-		typed:        withType(logFieldUpstream),
+		typed:        withType(upstreamResolverType),
 		configurable: withConfig(cfg),
 
 		upstreamClient: upstreamClient,


### PR DESCRIPTION
## Summary

- Bump Go from 1.25.0 → 1.26.2 in `go.mod`
- Bump golangci-lint from v2.11.3 → v2.12.2 in `Makefile`
- Rename `gomodguard` → `gomodguard_v2` in `.golangci.yml` (linter was renamed in v2)
- Fix 19 `goconst` violations introduced by the stricter new linter version: extract repeated string literals (`"domain"`, `"answer"`, `"upstream"`, `"example.com."`, `"localhost"`, `"127.0.0.1"`, `"0.0.0.0"`, and Prometheus label names) into named constants

## Test plan

- [x] `make lint` reports 0 issues
- [x] `make test` passes