### PR TITLE
feat: read bootstrap nameservers from a resolv.conf file (resolvFile)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -370,6 +370,8 @@ type (
 	bootstrappedUpstream struct {
 		Upstream Upstream `yaml:"upstream"`
 		IPs      []net.IP `yaml:"ips"`
+		// Optional: read bootstrap nameservers from a resolv.conf(5) file at this path instead of listing them inline.
+		ResolvFile string `yaml:"resolvFile"`
 	}
 )
 

--- a/config/config_schema_test.go
+++ b/config/config_schema_test.go
@@ -30,6 +30,16 @@ var _ = Describe("schema-enriched config loading", func() {
 		})
 	})
 
+	When("bootstrapDns uses the resolvFile object form", func() {
+		It("is accepted by both the parser and the schema", func() {
+			data := []byte("bootstrapDns:\n  - resolvFile: /etc/resolv.conf\n")
+
+			err := unmarshalConfig(logger, data, &Config{})
+			Expect(err).Should(Succeed())
+			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")))
+		})
+	})
+
 	When("a config exercises flexible/edge value forms not covered by docs/config.yml", func() {
 		It("is accepted by both the parser and the schema (permissive-superset)", func() {
 			// testdata/superset_config.yml uses the alternative forms blocky

--- a/config/testdata/superset_config.yml
+++ b/config/testdata/superset_config.yml
@@ -56,10 +56,8 @@ ports:
   # single comma-separated string form (ListenConfig.UnmarshalText)
   dns: "53,5353"
 
-# single-string bootstrap form plus the resolvFile object form
-bootstrapDns:
-  - tcp+udp:1.1.1.1
-  - resolvFile: /etc/resolv.conf
+# single-string bootstrap form (docs uses the list/object forms)
+bootstrapDns: tcp+udp:1.1.1.1
 
 queryLog:
   type: console

--- a/config/testdata/superset_config.yml
+++ b/config/testdata/superset_config.yml
@@ -56,8 +56,10 @@ ports:
   # single comma-separated string form (ListenConfig.UnmarshalText)
   dns: "53,5353"
 
-# single-string bootstrap form (docs uses the list/object forms)
-bootstrapDns: tcp+udp:1.1.1.1
+# single-string bootstrap form plus the resolvFile object form
+bootstrapDns:
+  - tcp+udp:1.1.1.1
+  - resolvFile: /etc/resolv.conf
 
 queryLog:
   type: console

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1041,6 +1041,9 @@
                     "type": "string"
                   },
                   "type": "array"
+                },
+                "resolvFile": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false,
@@ -1064,6 +1067,9 @@
                       "type": "string"
                     },
                     "type": "array"
+                  },
+                  "resolvFile": {
+                    "type": "string"
                   }
                 },
                 "additionalProperties": false,

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -289,12 +289,16 @@ minTlsServeVersion: 1.3
 #keyFile: server.key
 
 # optional: use these DNS servers to resolve denylist urls and upstream DNS servers. It is useful if no system DNS resolver is configured, and/or to encrypt the bootstrap queries.
+# If not set, the operating system resolver (/etc/resolv.conf on Linux) is used.
 bootstrapDns:
   - tcp+udp:1.1.1.1
   - https://1.1.1.1/dns-query
   - upstream: https://dns.digitale-gesellschaft.ch/dns-query
     ips:
       - 185.95.218.42
+  # optional: read nameservers from a resolv.conf file instead of listing them inline.
+  # Useful where DHCP-provided resolvers live outside /etc/resolv.conf (e.g. OpenWrt's /tmp/resolv.conf.auto).
+  # - resolvFile: /tmp/resolv.conf.auto
 
 # optional: drop all queries with following query types. Default: empty
 filtering:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,7 +287,7 @@ It is useful if no system DNS resolver is configured, and/or to encrypt the boot
 | ---------- | -------------------- | --------------------------- | ------------- | ---------------------------------------------------------------------------- |
 | upstream   | Upstream (see above) | no                          |               |                                                                              |
 | ips        | List of IPs          | yes, if upstream is DoT/DoH |               | Only valid if upstream is DoH or DoT                                         |
-| resolvFile | string (file path)   | no                          |               | Read nameservers from a `resolv.conf`(5) file and use them as bootstrap DNS  |
+| resolvFile | string (file path)   | no                          |               | Read nameservers from a `resolv.conf`(5) file and use them as bootstrap DNS. Cannot be combined with `upstream`/`ips` in the same entry |
 
 When using an upstream specified by IP, and not by hostname, you can write only the upstream and skip `ips`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,12 +283,17 @@ Currently available strategies:
 These DNS servers are used to resolve upstream DoH and DoT servers that are specified as host names, and list domains.
 It is useful if no system DNS resolver is configured, and/or to encrypt the bootstrap queries.
 
-| Parameter | Type                 | Mandatory                   | Default value | Description                          |
-| --------- | -------------------- | --------------------------- | ------------- | ------------------------------------ |
-| upstream  | Upstream (see above) | no                          |               |                                      |
-| ips       | List of IPs          | yes, if upstream is DoT/DoH |               | Only valid if upstream is DoH or DoT |
+| Parameter  | Type                 | Mandatory                   | Default value | Description                                                                  |
+| ---------- | -------------------- | --------------------------- | ------------- | ---------------------------------------------------------------------------- |
+| upstream   | Upstream (see above) | no                          |               |                                                                              |
+| ips        | List of IPs          | yes, if upstream is DoT/DoH |               | Only valid if upstream is DoH or DoT                                         |
+| resolvFile | string (file path)   | no                          |               | Read nameservers from a `resolv.conf`(5) file and use them as bootstrap DNS  |
 
 When using an upstream specified by IP, and not by hostname, you can write only the upstream and skip `ips`.
+
+If `bootstrapDns` is not set, blocky uses the operating system's resolver (`/etc/resolv.conf` on Linux). On systems where the
+DHCP-provided resolvers live elsewhere (for example OpenWrt writes them to `/tmp/resolv.conf.auto`), use a `resolvFile` entry to
+point blocky at the right file. The file is parsed once at startup; its `nameserver` entries are used as plain-DNS bootstrap servers.
 
 !!! note
 
@@ -302,6 +307,8 @@ When using an upstream specified by IP, and not by hostname, you can write only 
             ips:
             - 123.123.123.123
           - upstream: https://234.234.234.234/dns-query
+          # read the DHCP-provided resolvers from a file (e.g. OpenWrt)
+          - resolvFile: /tmp/resolv.conf.auto
     ```
 
 ## Filtering

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -305,6 +306,14 @@ func newBootstrapedResolvers(
 	for i, upstreamCfg := range cfg {
 		i := i + 1 // user visible index should start at 1
 
+		if upstreamCfg.ResolvFile != "" {
+			if err := b.addResolvFileUpstreams(upstreamIPs, upstreamCfg.ResolvFile, upstreamsCfg); err != nil {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("item %d: %w", i, err))
+			}
+
+			continue
+		}
+
 		upstream := upstreamCfg.Upstream
 
 		if upstream.IsDefault() {
@@ -347,6 +356,47 @@ func newBootstrapedResolvers(
 	}
 
 	return upstreamIPs, nil
+}
+
+// defaultDNSPort is used for resolvFile nameservers when the file omits a port.
+const defaultDNSPort uint16 = 53
+
+// addResolvFileUpstreams reads nameservers from a resolv.conf(5) file and adds
+// one plain-DNS bootstrap upstream per nameserver to upstreamIPs. This lets
+// systems whose DHCP-provided resolvers live outside /etc/resolv.conf (e.g.
+// OpenWrt's /tmp/resolv.conf.auto) point blocky at the right file.
+func (b *Bootstrap) addResolvFileUpstreams(
+	upstreamIPs bootstrapedResolvers, path string, upstreamsCfg config.Upstreams,
+) error {
+	cc, err := dns.ClientConfigFromFile(path)
+	if err != nil {
+		return fmt.Errorf("resolvFile '%s': %w", path, err)
+	}
+
+	port := defaultDNSPort
+	if p, err := strconv.ParseUint(cc.Port, 10, 16); err == nil {
+		port = uint16(p)
+	}
+
+	var added int
+
+	for _, server := range cc.Servers {
+		ip := net.ParseIP(server)
+		if ip == nil {
+			continue
+		}
+
+		upstream := config.Upstream{Net: config.NetProtocolTcpUdp, Host: server, Port: port}
+		resolver := newUpstreamResolverUnchecked(newUpstreamConfig(upstream, upstreamsCfg), b)
+		upstreamIPs[resolver] = []net.IP{ip}
+		added++
+	}
+
+	if added == 0 {
+		return fmt.Errorf("resolvFile '%s': no usable nameservers", path)
+	}
+
+	return nil
 }
 
 func (br bootstrapedResolvers) Resolvers() []Resolver {

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -72,7 +72,7 @@ func NewBootstrap(ctx context.Context, cfg *config.Config) (b *Bootstrap, err er
 
 	ctx, logger := b.log(ctx)
 
-	bootstraped, err := newBootstrapedResolvers(b, cfg.BootstrapDNS, cfg.Upstreams)
+	bootstraped, err := newBootstrapedResolvers(b, cfg.BootstrapDNS, cfg.Upstreams, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create bootstrap resolvers: %w", err)
 	}
@@ -297,7 +297,7 @@ func (b *Bootstrap) resolveType(ctx context.Context, hostname string, qType dns.
 type bootstrapedResolvers map[Resolver][]net.IP
 
 func newBootstrapedResolvers(
-	b *Bootstrap, cfg config.BootstrapDNS, upstreamsCfg config.Upstreams,
+	b *Bootstrap, cfg config.BootstrapDNS, upstreamsCfg config.Upstreams, logger *logrus.Entry,
 ) (bootstrapedResolvers, error) {
 	upstreamIPs := make(bootstrapedResolvers, len(cfg))
 
@@ -307,7 +307,7 @@ func newBootstrapedResolvers(
 		i := i + 1 // user visible index should start at 1
 
 		if upstreamCfg.ResolvFile != "" {
-			if err := b.addResolvFileUpstreams(upstreamIPs, upstreamCfg.ResolvFile, upstreamsCfg); err != nil {
+			if err := b.addResolvFileUpstreams(upstreamIPs, upstreamCfg, upstreamsCfg, logger); err != nil {
 				multiErr = multierror.Append(multiErr, fmt.Errorf("item %d: %w", i, err))
 			}
 
@@ -358,7 +358,9 @@ func newBootstrapedResolvers(
 	return upstreamIPs, nil
 }
 
-// defaultDNSPort is used for resolvFile nameservers when the file omits a port.
+// defaultDNSPort is the fallback bootstrap port. resolv.conf(5) carries no
+// per-nameserver port, so dns.ClientConfigFromFile always reports "53"; we
+// still parse cc.Port defensively in case that ever changes.
 const defaultDNSPort uint16 = 53
 
 // addResolvFileUpstreams reads nameservers from a resolv.conf(5) file and adds
@@ -366,8 +368,15 @@ const defaultDNSPort uint16 = 53
 // systems whose DHCP-provided resolvers live outside /etc/resolv.conf (e.g.
 // OpenWrt's /tmp/resolv.conf.auto) point blocky at the right file.
 func (b *Bootstrap) addResolvFileUpstreams(
-	upstreamIPs bootstrapedResolvers, path string, upstreamsCfg config.Upstreams,
+	upstreamIPs bootstrapedResolvers, upstreamCfg config.BootstrappedUpstream,
+	upstreamsCfg config.Upstreams, logger *logrus.Entry,
 ) error {
+	if !upstreamCfg.Upstream.IsDefault() || len(upstreamCfg.IPs) > 0 {
+		return errors.New("resolvFile cannot be combined with upstream/ips in the same entry")
+	}
+
+	path := upstreamCfg.ResolvFile
+
 	cc, err := dns.ClientConfigFromFile(path)
 	if err != nil {
 		return fmt.Errorf("resolvFile '%s': %w", path, err)
@@ -395,6 +404,8 @@ func (b *Bootstrap) addResolvFileUpstreams(
 	if added == 0 {
 		return fmt.Errorf("resolvFile '%s': no usable nameservers", path)
 	}
+
+	logger.Infof("loaded %d bootstrap nameserver(s) from resolvFile '%s'", added, path)
 
 	return nil
 }

--- a/resolver/bootstrap_test.go
+++ b/resolver/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"sync/atomic"
 
@@ -177,6 +178,49 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 					for _, ips := range sut.bootstraped {
 						Expect(ips).Should(ContainElements(net.IPv4zero, net.IPv4allrouter))
 					}
+				})
+			})
+		})
+
+		Context("using a resolvFile", func() {
+			When("the file lists nameservers", func() {
+				var resolvFile *os.File
+
+				BeforeEach(func() {
+					resolvFile = TempFile("nameserver 9.9.9.9\nnameserver 1.0.0.1\n")
+					DeferCleanup(func() { _ = os.Remove(resolvFile.Name()) })
+
+					sutConfig = config.Config{
+						BootstrapDNS: []config.BootstrappedUpstream{
+							{ResolvFile: resolvFile.Name()},
+						},
+					}
+				})
+
+				It("uses the file's nameservers as bootstrap upstreams", func() {
+					Expect(sut).ShouldNot(BeNil())
+					Expect(sut.bootstraped).Should(HaveLen(2))
+
+					var ips []net.IP
+					for _, serverIPs := range sut.bootstraped {
+						ips = append(ips, serverIPs...)
+					}
+
+					Expect(ips).Should(ConsistOf(net.ParseIP("9.9.9.9"), net.ParseIP("1.0.0.1")))
+				})
+			})
+
+			When("the file does not exist", func() {
+				It("errors", func() {
+					cfg := config.Config{
+						BootstrapDNS: []config.BootstrappedUpstream{
+							{ResolvFile: "/does/not/exist/resolv.conf"},
+						},
+					}
+
+					_, err := NewBootstrap(ctx, &cfg)
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("resolvFile"))
 				})
 			})
 		})

--- a/resolver/bootstrap_test.go
+++ b/resolver/bootstrap_test.go
@@ -188,7 +188,10 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 
 				BeforeEach(func() {
 					resolvFile = TempFile("nameserver 9.9.9.9\nnameserver 1.0.0.1\n")
-					DeferCleanup(func() { _ = os.Remove(resolvFile.Name()) })
+					DeferCleanup(func() {
+						_ = resolvFile.Close()
+						_ = os.Remove(resolvFile.Name())
+					})
 
 					sutConfig = config.Config{
 						BootstrapDNS: []config.BootstrappedUpstream{
@@ -210,6 +213,36 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 				})
 			})
 
+			When("the file lists an IPv6 nameserver", func() {
+				var resolvFile *os.File
+
+				BeforeEach(func() {
+					resolvFile = TempFile("nameserver 2606:4700:4700::1111\n")
+					DeferCleanup(func() {
+						_ = resolvFile.Close()
+						_ = os.Remove(resolvFile.Name())
+					})
+
+					sutConfig = config.Config{
+						BootstrapDNS: []config.BootstrappedUpstream{
+							{ResolvFile: resolvFile.Name()},
+						},
+					}
+				})
+
+				It("uses the IPv6 nameserver as a bootstrap upstream", func() {
+					Expect(sut).ShouldNot(BeNil())
+					Expect(sut.bootstraped).Should(HaveLen(1))
+
+					var ips []net.IP
+					for _, serverIPs := range sut.bootstraped {
+						ips = append(ips, serverIPs...)
+					}
+
+					Expect(ips).Should(ConsistOf(Equal(net.ParseIP("2606:4700:4700::1111"))))
+				})
+			})
+
 			When("the file does not exist", func() {
 				It("errors", func() {
 					cfg := config.Config{
@@ -221,6 +254,49 @@ var _ = Describe("Bootstrap", Label("bootstrap"), func() {
 					_, err := NewBootstrap(ctx, &cfg)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).Should(ContainSubstring("resolvFile"))
+				})
+			})
+
+			When("the file has no usable nameservers", func() {
+				It("errors", func() {
+					resolvFile := TempFile("# only comments and a search domain\nsearch example.com\n")
+					DeferCleanup(func() {
+						_ = resolvFile.Close()
+						_ = os.Remove(resolvFile.Name())
+					})
+
+					cfg := config.Config{
+						BootstrapDNS: []config.BootstrappedUpstream{
+							{ResolvFile: resolvFile.Name()},
+						},
+					}
+
+					_, err := NewBootstrap(ctx, &cfg)
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("no usable nameservers"))
+				})
+			})
+
+			When("combined with an inline upstream or ips in the same entry", func() {
+				It("errors instead of silently ignoring them", func() {
+					resolvFile := TempFile("nameserver 9.9.9.9\n")
+					DeferCleanup(func() {
+						_ = resolvFile.Close()
+						_ = os.Remove(resolvFile.Name())
+					})
+
+					cfg := config.Config{
+						BootstrapDNS: []config.BootstrappedUpstream{
+							{
+								ResolvFile: resolvFile.Name(),
+								Upstream:   config.Upstream{Net: config.NetProtocolTcpUdp, Host: "1.1.1.1", Port: 53},
+							},
+						},
+					}
+
+					_, err := NewBootstrap(ctx, &cfg)
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring("cannot be combined"))
 				})
 			})
 		})

--- a/tools/schemagen/overrides.go
+++ b/tools/schemagen/overrides.go
@@ -66,11 +66,12 @@ func enumStringSchema(names []string) *jsonschema.Schema {
 }
 
 // bootstrappedUpstreamSchema accepts either a plain upstream string or the
-// {upstream, ips} object form (see BootstrappedUpstream.UnmarshalYAML).
+// {upstream, ips} / {resolvFile} object forms (see BootstrappedUpstream.UnmarshalYAML).
 func bootstrappedUpstreamSchema() *jsonschema.Schema {
 	props := jsonschema.NewProperties()
 	props.Set("upstream", plain("string"))
 	props.Set("ips", arrayOf(plain("string")))
+	props.Set("resolvFile", plain("string"))
 
 	obj := &jsonschema.Schema{
 		Type:                 "object",


### PR DESCRIPTION
## Summary

Adds an optional `resolvFile` form to `bootstrapDns` entries. blocky parses the given resolv.conf(5) file (via `dns.ClientConfigFromFile`, already a dependency) and uses its `nameserver` entries as plain-DNS bootstrap upstreams.

This lets systems whose DHCP-provided resolvers live **outside** `/etc/resolv.conf` — e.g. OpenWrt writes them to `/tmp/resolv.conf.auto` — point blocky at the right file:

```yaml
bootstrapDns:
  - resolvFile: /tmp/resolv.conf.auto
```

### Background

blocky never reads `resolv.conf` itself; the Go standard-library resolver (`net.DefaultResolver`) does, at the fixed path `/etc/resolv.conf`, and only as the bootstrap fallback when `bootstrapDns` is unset. So honoring a custom path means blocky must parse the file itself and feed the nameservers into the existing bootstrap resolver — which is what this does. (dnsmasq's `resolv-file=` is the equivalent feature; AdGuard Home, like blocky, otherwise relies on explicit bootstrap servers.)

### Behavior

- **Optional & backward compatible:** if no entry sets `resolvFile`, behavior is unchanged (OS resolver when `bootstrapDns` is empty, explicit entries otherwise).
- The file is read **once at startup**; each `nameserver` becomes a plain UDP/TCP bootstrap upstream (port from the file, default 53).
- Errors clearly if the file is missing/unreadable or has no usable nameservers.

### Changes

- `config`: optional `ResolvFile` field on the bootstrapped-upstream struct.
- `resolver/bootstrap`: `newBootstrapedResolvers` expands `resolvFile` entries into one upstream per nameserver.
- schema: `resolvFile` allowed in the `bootstrappedUpstream` override (regenerated `docs/config.schema.json`).
- docs: `configuration.md` (parameter row, note, example incl. OpenWrt) and `docs/config.yml`.

### Out of scope

Reads once at startup; live re-reading on file change (dnsmasq-style polling) can be a follow-up if needed.

## Test Plan

- [x] `resolver/bootstrap_test.go`: resolv.conf with nameservers → expected bootstrap upstreams; missing file → error
- [x] schema superset fixture exercises the `resolvFile` form (parser + schema agree)
- [x] `go build ./...`, `go test ./config/... ./resolver/...`, golangci-lint, gofmt all pass; schema generation deterministic

Closes #2027