### PR TITLE
feat: filter ipv6hint in HTTPS/SVCB RR when AAAA is filtered

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -326,6 +326,11 @@ types, all queries with these types will be dropped (empty answer will be return
 
 This configuration will drop all 'AAAA' (IPv6) queries.
 
+When `AAAA` is filtered, Blocky additionally strips the `ipv6hint` SvcParam from `HTTPS` and `SVCB`
+(RFC 9460) answers. Without this, clients could still discover and connect to IPv6 endpoints
+advertised in those records, bypassing the `AAAA` filter. Other SvcParams (e.g. `alpn`, `ipv4hint`)
+are left untouched.
+
 ## Rate limiting per client IP
 
 Blocky can enforce a per-client query rate limit at the head of the resolver chain. **Disabled by default.** This is _not_ a DDoS defense — for that, run [fail2ban](https://www.fail2ban.org/) or [crowdsec](https://www.crowdsec.net/) at the firewall, which can drop traffic before it reaches Blocky. The limiter is intended for misbehaving clients, runaway scripts, and the kind of low-volume amplification that can enroll a public Blocky instance in someone else's DNS reflection attack ([issue #1135](https://github.com/0xERR0R/blocky/issues/1135)).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -329,7 +329,9 @@ This configuration will drop all 'AAAA' (IPv6) queries.
 When `AAAA` is filtered, Blocky additionally strips the `ipv6hint` SvcParam from `HTTPS` and `SVCB`
 (RFC 9460) answers. Without this, clients could still discover and connect to IPv6 endpoints
 advertised in those records, bypassing the `AAAA` filter. Other SvcParams (e.g. `alpn`, `ipv4hint`)
-are left untouched.
+are left untouched. Because stripping a hint changes the record, any DNSSEC signature on the
+affected `HTTPS`/`SVCB` record is removed and the `AD` (authenticated data) flag is cleared for
+that response.
 
 ## Rate limiting per client IP
 

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -43,15 +43,16 @@ func (r *FilteringResolver) Resolve(ctx context.Context, request *model.Request)
 	return resp, nil
 }
 
-// removeIPv6Hints strips the ipv6hint SvcParam from any HTTPS/SVCB record in the response.
-// The records are owned by the current request (freshly produced upstream or unpacked from
-// cache), so they are modified in place.
+// removeIPv6Hints strips the ipv6hint SvcParam from any HTTPS/SVCB record in the answer
+// section. The records are owned by the current request (freshly produced upstream or
+// unpacked from cache), so they are modified in place. Records without an ipv6hint are
+// left as-is (no slice churn).
 //
 // Modifying a signed RRset invalidates its DNSSEC signatures, so when a hint is actually
-// removed the AD bit is cleared and the now-invalid RRSIGs covering the modified RRsets are
-// dropped, to avoid serving DNSSEC-inconsistent data (mirrors the DNS64 resolver behavior).
+// removed the AD bit is cleared and the now-invalid RRSIGs covering the modified record
+// types are dropped, to avoid serving DNSSEC-inconsistent data (mirrors the DNS64 resolver).
 func removeIPv6Hints(msg *dns.Msg) {
-	modified := false
+	modifiedTypes := map[uint16]struct{}{}
 
 	for _, rr := range msg.Answer {
 		var values *[]dns.SVCBKeyValue
@@ -65,37 +66,51 @@ func removeIPv6Hints(msg *dns.Msg) {
 			continue
 		}
 
-		filtered := make([]dns.SVCBKeyValue, 0, len(*values))
+		if !containsIPv6Hint(*values) {
+			continue
+		}
+
+		filtered := make([]dns.SVCBKeyValue, 0, len(*values)-1)
 
 		for _, kv := range *values {
-			if kv.Key() == dns.SVCB_IPV6HINT {
-				modified = true
-
-				continue
+			if kv.Key() != dns.SVCB_IPV6HINT {
+				filtered = append(filtered, kv)
 			}
-
-			filtered = append(filtered, kv)
 		}
 
 		*values = filtered
+		modifiedTypes[rr.Header().Rrtype] = struct{}{}
 	}
 
-	if !modified {
+	if len(modifiedTypes) == 0 {
 		return
 	}
 
 	msg.AuthenticatedData = false
-	msg.Answer = removeSVCBSignatures(msg.Answer)
+	msg.Answer = removeSignaturesCovering(msg.Answer, modifiedTypes)
 }
 
-// removeSVCBSignatures returns the answers with any RRSIG covering HTTPS or SVCB records removed.
-func removeSVCBSignatures(answers []dns.RR) []dns.RR {
+// containsIPv6Hint reports whether the given SvcParam list carries an ipv6hint.
+func containsIPv6Hint(values []dns.SVCBKeyValue) bool {
+	for _, kv := range values {
+		if kv.Key() == dns.SVCB_IPV6HINT {
+			return true
+		}
+	}
+
+	return false
+}
+
+// removeSignaturesCovering returns the answers with any RRSIG covering one of the given
+// record types removed.
+func removeSignaturesCovering(answers []dns.RR, types map[uint16]struct{}) []dns.RR {
 	filtered := make([]dns.RR, 0, len(answers))
 
 	for _, rr := range answers {
-		if sig, ok := rr.(*dns.RRSIG); ok &&
-			(sig.TypeCovered == dns.TypeHTTPS || sig.TypeCovered == dns.TypeSVCB) {
-			continue
+		if sig, ok := rr.(*dns.RRSIG); ok {
+			if _, found := types[sig.TypeCovered]; found {
+				continue
+			}
 		}
 
 		filtered = append(filtered, rr)

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -35,12 +35,19 @@ func (r *FilteringResolver) Resolve(ctx context.Context, request *model.Request)
 	}
 
 	// When AAAA lookups are filtered, also drop IPv6 hints from HTTPS/SVCB answers so that
-	// clients can't reach the IPv6 endpoints advertised via SvcParams (RFC 9460).
-	if resp != nil && resp.Res != nil && r.cfg.QueryTypes.Contains(dns.Type(dns.TypeAAAA)) {
+	// clients can't reach the IPv6 endpoints advertised via SvcParams (RFC 9460). Only
+	// HTTPS/SVCB queries can carry such records in their answer section, so other query
+	// types skip the post-processing entirely.
+	if resp != nil && resp.Res != nil && isSVCBQuery(qType) && r.cfg.QueryTypes.Contains(dns.Type(dns.TypeAAAA)) {
 		removeIPv6Hints(resp.Res)
 	}
 
 	return resp, nil
+}
+
+// isSVCBQuery reports whether the query type can return HTTPS/SVCB records in the answer section.
+func isSVCBQuery(qType uint16) bool {
+	return qType == dns.TypeHTTPS || qType == dns.TypeSVCB
 }
 
 // removeIPv6Hints strips the ipv6hint SvcParam from any HTTPS/SVCB record in the answer

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -37,17 +37,23 @@ func (r *FilteringResolver) Resolve(ctx context.Context, request *model.Request)
 	// When AAAA lookups are filtered, also drop IPv6 hints from HTTPS/SVCB answers so that
 	// clients can't reach the IPv6 endpoints advertised via SvcParams (RFC 9460).
 	if resp != nil && resp.Res != nil && r.cfg.QueryTypes.Contains(dns.Type(dns.TypeAAAA)) {
-		removeIPv6Hints(resp.Res.Answer)
+		removeIPv6Hints(resp.Res)
 	}
 
 	return resp, nil
 }
 
-// removeIPv6Hints strips the ipv6hint SvcParam from any HTTPS/SVCB record in the given
-// answer set. The records are owned by the current request (freshly produced upstream or
-// unpacked from cache), so they are modified in place.
-func removeIPv6Hints(answers []dns.RR) {
-	for _, rr := range answers {
+// removeIPv6Hints strips the ipv6hint SvcParam from any HTTPS/SVCB record in the response.
+// The records are owned by the current request (freshly produced upstream or unpacked from
+// cache), so they are modified in place.
+//
+// Modifying a signed RRset invalidates its DNSSEC signatures, so when a hint is actually
+// removed the AD bit is cleared and the now-invalid RRSIGs covering the modified RRsets are
+// dropped, to avoid serving DNSSEC-inconsistent data (mirrors the DNS64 resolver behavior).
+func removeIPv6Hints(msg *dns.Msg) {
+	modified := false
+
+	for _, rr := range msg.Answer {
 		var values *[]dns.SVCBKeyValue
 
 		switch v := rr.(type) {
@@ -62,11 +68,38 @@ func removeIPv6Hints(answers []dns.RR) {
 		filtered := make([]dns.SVCBKeyValue, 0, len(*values))
 
 		for _, kv := range *values {
-			if kv.Key() != dns.SVCB_IPV6HINT {
-				filtered = append(filtered, kv)
+			if kv.Key() == dns.SVCB_IPV6HINT {
+				modified = true
+
+				continue
 			}
+
+			filtered = append(filtered, kv)
 		}
 
 		*values = filtered
 	}
+
+	if !modified {
+		return
+	}
+
+	msg.AuthenticatedData = false
+	msg.Answer = removeSVCBSignatures(msg.Answer)
+}
+
+// removeSVCBSignatures returns the answers with any RRSIG covering HTTPS or SVCB records removed.
+func removeSVCBSignatures(answers []dns.RR) []dns.RR {
+	filtered := make([]dns.RR, 0, len(answers))
+
+	for _, rr := range answers {
+		if sig, ok := rr.(*dns.RRSIG); ok &&
+			(sig.TypeCovered == dns.TypeHTTPS || sig.TypeCovered == dns.TypeSVCB) {
+			continue
+		}
+
+		filtered = append(filtered, rr)
+	}
+
+	return filtered
 }

--- a/resolver/filtering_resolver.go
+++ b/resolver/filtering_resolver.go
@@ -29,5 +29,44 @@ func (r *FilteringResolver) Resolve(ctx context.Context, request *model.Request)
 		return model.NewResponseWithRcode(request, dns.RcodeSuccess, model.ResponseTypeFILTERED, ""), nil
 	}
 
-	return r.next.Resolve(ctx, request)
+	resp, err := r.next.Resolve(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	// When AAAA lookups are filtered, also drop IPv6 hints from HTTPS/SVCB answers so that
+	// clients can't reach the IPv6 endpoints advertised via SvcParams (RFC 9460).
+	if resp != nil && resp.Res != nil && r.cfg.QueryTypes.Contains(dns.Type(dns.TypeAAAA)) {
+		removeIPv6Hints(resp.Res.Answer)
+	}
+
+	return resp, nil
+}
+
+// removeIPv6Hints strips the ipv6hint SvcParam from any HTTPS/SVCB record in the given
+// answer set. The records are owned by the current request (freshly produced upstream or
+// unpacked from cache), so they are modified in place.
+func removeIPv6Hints(answers []dns.RR) {
+	for _, rr := range answers {
+		var values *[]dns.SVCBKeyValue
+
+		switch v := rr.(type) {
+		case *dns.HTTPS:
+			values = &v.Value
+		case *dns.SVCB:
+			values = &v.Value
+		default:
+			continue
+		}
+
+		filtered := make([]dns.SVCBKeyValue, 0, len(*values))
+
+		for _, kv := range *values {
+			if kv.Key() != dns.SVCB_IPV6HINT {
+				filtered = append(filtered, kv)
+			}
+		}
+
+		*values = filtered
+	}
 }

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -25,10 +25,10 @@ func svcbKeys(values []dns.SVCBKeyValue) []dns.SVCBKey {
 	return keys
 }
 
-// newHTTPSRecord builds an HTTPS RR carrying alpn, an ipv4hint and an ipv6hint.
-func newHTTPSRecord(name string) *dns.HTTPS {
+// newHTTPSRecord builds an HTTPS RR for example.com. carrying alpn, an ipv4hint and an ipv6hint.
+func newHTTPSRecord() *dns.HTTPS {
 	return &dns.HTTPS{SVCB: dns.SVCB{
-		Hdr:      dns.RR_Header{Name: name, Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 300},
+		Hdr:      dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 300},
 		Priority: 1,
 		Target:   ".",
 		Value: []dns.SVCBKeyValue{
@@ -39,10 +39,10 @@ func newHTTPSRecord(name string) *dns.HTTPS {
 	}}
 }
 
-// newHTTPSRecordNoV6Hint builds an HTTPS RR carrying alpn and an ipv4hint, but no ipv6hint.
-func newHTTPSRecordNoV6Hint(name string) *dns.HTTPS {
+// newHTTPSRecordNoV6Hint builds an HTTPS RR for example.com. with alpn and an ipv4hint, but no ipv6hint.
+func newHTTPSRecordNoV6Hint() *dns.HTTPS {
 	return &dns.HTTPS{SVCB: dns.SVCB{
-		Hdr:      dns.RR_Header{Name: name, Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 300},
+		Hdr:      dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 300},
 		Priority: 1,
 		Target:   ".",
 		Value: []dns.SVCBKeyValue{
@@ -59,6 +59,19 @@ func newRRSIG(covered uint16) *dns.RRSIG {
 		TypeCovered: covered,
 		SignerName:  "example.com.",
 	}
+}
+
+// rrsigCoveredTypes returns the record types covered by the RRSIGs in the given answer set.
+func rrsigCoveredTypes(answers []dns.RR) []uint16 {
+	var covered []uint16
+
+	for _, rr := range answers {
+		if sig, ok := rr.(*dns.RRSIG); ok {
+			covered = append(covered, sig.TypeCovered)
+		}
+	}
+
+	return covered
 }
 
 var _ = Describe("FilteringResolver", func() {
@@ -166,7 +179,7 @@ var _ = Describe("FilteringResolver", func() {
 		})
 
 		It("strips the ipv6hint from HTTPS answers while keeping other SvcParams", func() {
-			mockAnswer.Answer = []dns.RR{newHTTPSRecord("example.com.")}
+			mockAnswer.Answer = []dns.RR{newHTTPSRecord()}
 
 			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
 			Expect(err).Should(Succeed())
@@ -216,41 +229,33 @@ var _ = Describe("FilteringResolver", func() {
 
 		It("clears the AD bit when an ipv6hint is removed", func() {
 			mockAnswer.AuthenticatedData = true
-			mockAnswer.Answer = []dns.RR{newHTTPSRecord("example.com.")}
+			mockAnswer.Answer = []dns.RR{newHTTPSRecord()}
 
 			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
 			Expect(err).Should(Succeed())
 			Expect(resp.Res.AuthenticatedData).Should(BeFalse())
 		})
 
-		It("drops RRSIGs covering the modified HTTPS RRset, keeping other signatures", func() {
-			cnameSig := newRRSIG(dns.TypeCNAME)
+		It("drops only RRSIGs covering the modified record type, keeping signatures of other types", func() {
 			mockAnswer.Answer = []dns.RR{
-				newHTTPSRecord("example.com."),
+				newHTTPSRecord(),
 				newRRSIG(dns.TypeHTTPS),
-				cnameSig,
+				newRRSIG(dns.TypeSVCB),
+				newRRSIG(dns.TypeCNAME),
 			}
 
 			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
 			Expect(err).Should(Succeed())
 
-			// the HTTPS-covering signature is gone, the CNAME one stays
-			Expect(resp.Res.Answer).ShouldNot(ContainElement(
-				WithTransform(func(rr dns.RR) uint16 {
-					if sig, ok := rr.(*dns.RRSIG); ok {
-						return sig.TypeCovered
-					}
-
-					return 0
-				}, Equal(uint16(dns.TypeHTTPS))),
-			))
-			Expect(resp.Res.Answer).Should(ContainElement(cnameSig))
+			// only the signature covering the modified HTTPS RRset is dropped; the SVCB and
+			// CNAME signatures cover RRsets that were not modified and must be kept
+			Expect(rrsigCoveredTypes(resp.Res.Answer)).Should(ConsistOf(dns.TypeSVCB, dns.TypeCNAME))
 		})
 
 		It("keeps the AD bit and signatures when there is no ipv6hint to remove", func() {
 			mockAnswer.AuthenticatedData = true
 			sig := newRRSIG(dns.TypeHTTPS)
-			mockAnswer.Answer = []dns.RR{newHTTPSRecordNoV6Hint("example.com."), sig}
+			mockAnswer.Answer = []dns.RR{newHTTPSRecordNoV6Hint(), sig}
 
 			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
 			Expect(err).Should(Succeed())
@@ -268,7 +273,7 @@ var _ = Describe("FilteringResolver", func() {
 		})
 
 		It("keeps the ipv6hint in HTTPS answers", func() {
-			mockAnswer.Answer = []dns.RR{newHTTPSRecord("example.com.")}
+			mockAnswer.Answer = []dns.RR{newHTTPSRecord()}
 
 			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
 			Expect(err).Should(Succeed())

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -227,6 +227,19 @@ var _ = Describe("FilteringResolver", func() {
 			Expect(resp.Res.Answer).Should(ConsistOf(a))
 		})
 
+		It("does not touch answers of non-HTTPS/SVCB queries", func() {
+			// HTTPS/SVCB records only legitimately appear in the answer of HTTPS/SVCB queries,
+			// so the answer of an A query is never scanned for hints
+			mockAnswer.Answer = []dns.RR{newHTTPSRecord()}
+
+			resp, err := sut.Resolve(ctx, newRequest("example.com.", A))
+			Expect(err).Should(Succeed())
+
+			https, ok := resp.Res.Answer[0].(*dns.HTTPS)
+			Expect(ok).Should(BeTrue())
+			Expect(svcbKeys(https.Value)).Should(ContainElement(dns.SVCB_IPV6HINT))
+		})
+
 		It("clears the AD bit when an ipv6hint is removed", func() {
 			mockAnswer.AuthenticatedData = true
 			mockAnswer.Answer = []dns.RR{newHTTPSRecord()}

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"net"
 
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
@@ -13,6 +14,30 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 )
+
+// svcbKeys returns the SvcParam keys present in the given SVCB/HTTPS value list.
+func svcbKeys(values []dns.SVCBKeyValue) []dns.SVCBKey {
+	keys := make([]dns.SVCBKey, 0, len(values))
+	for _, v := range values {
+		keys = append(keys, v.Key())
+	}
+
+	return keys
+}
+
+// newHTTPSRecord builds an HTTPS RR carrying alpn, an ipv4hint and an ipv6hint.
+func newHTTPSRecord(name string) *dns.HTTPS {
+	return &dns.HTTPS{SVCB: dns.SVCB{
+		Hdr:      dns.RR_Header{Name: name, Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 300},
+		Priority: 1,
+		Target:   ".",
+		Value: []dns.SVCBKeyValue{
+			&dns.SVCBAlpn{Alpn: []string{"h3", "h2"}},
+			&dns.SVCBIPv4Hint{Hint: []net.IP{net.ParseIP("104.16.123.96")}},
+			&dns.SVCBIPv6Hint{Hint: []net.IP{net.ParseIP("2606:4700::6810:7b60")}},
+		},
+	}}
+}
 
 var _ = Describe("FilteringResolver", func() {
 	var (
@@ -108,6 +133,82 @@ var _ = Describe("FilteringResolver", func() {
 
 			// delegated to next resolver
 			Expect(m.Calls).Should(HaveLen(1))
+		})
+	})
+
+	When("AAAA queries are filtered", func() {
+		BeforeEach(func() {
+			sutConfig = config.Filtering{
+				QueryTypes: config.NewQTypeSet(AAAA),
+			}
+		})
+
+		It("strips the ipv6hint from HTTPS answers while keeping other SvcParams", func() {
+			mockAnswer.Answer = []dns.RR{newHTTPSRecord("example.com.")}
+
+			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
+			Expect(err).Should(Succeed())
+
+			// upstream was queried and the response delegated through
+			Expect(m.Calls).Should(HaveLen(1))
+			Expect(resp.Res.Answer).Should(HaveLen(1))
+
+			https, ok := resp.Res.Answer[0].(*dns.HTTPS)
+			Expect(ok).Should(BeTrue())
+
+			keys := svcbKeys(https.Value)
+			Expect(keys).ShouldNot(ContainElement(dns.SVCB_IPV6HINT))
+			Expect(keys).Should(ContainElements(dns.SVCB_ALPN, dns.SVCB_IPV4HINT))
+		})
+
+		It("strips the ipv6hint from SVCB answers", func() {
+			svcb := &dns.SVCB{
+				Hdr:      dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeSVCB, Class: dns.ClassINET, Ttl: 300},
+				Priority: 1,
+				Target:   ".",
+				Value: []dns.SVCBKeyValue{
+					&dns.SVCBIPv6Hint{Hint: []net.IP{net.ParseIP("2606:4700::6810:7b60")}},
+				},
+			}
+			mockAnswer.Answer = []dns.RR{svcb}
+
+			resp, err := sut.Resolve(ctx, newRequest("example.com.", dns.Type(dns.TypeSVCB)))
+			Expect(err).Should(Succeed())
+
+			result, ok := resp.Res.Answer[0].(*dns.SVCB)
+			Expect(ok).Should(BeTrue())
+			Expect(svcbKeys(result.Value)).ShouldNot(ContainElement(dns.SVCB_IPV6HINT))
+		})
+
+		It("leaves non-SVCB answers untouched", func() {
+			a := &dns.A{
+				Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP("104.16.123.96"),
+			}
+			mockAnswer.Answer = []dns.RR{a}
+
+			resp, err := sut.Resolve(ctx, newRequest("example.com.", A))
+			Expect(err).Should(Succeed())
+			Expect(resp.Res.Answer).Should(ConsistOf(a))
+		})
+	})
+
+	When("AAAA queries are not filtered", func() {
+		BeforeEach(func() {
+			sutConfig = config.Filtering{
+				QueryTypes: config.NewQTypeSet(MX),
+			}
+		})
+
+		It("keeps the ipv6hint in HTTPS answers", func() {
+			mockAnswer.Answer = []dns.RR{newHTTPSRecord("example.com.")}
+
+			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
+			Expect(err).Should(Succeed())
+
+			https, ok := resp.Res.Answer[0].(*dns.HTTPS)
+			Expect(ok).Should(BeTrue())
+			Expect(svcbKeys(https.Value)).Should(ContainElement(dns.SVCB_IPV6HINT))
 		})
 	})
 })

--- a/resolver/filtering_resolver_test.go
+++ b/resolver/filtering_resolver_test.go
@@ -39,6 +39,28 @@ func newHTTPSRecord(name string) *dns.HTTPS {
 	}}
 }
 
+// newHTTPSRecordNoV6Hint builds an HTTPS RR carrying alpn and an ipv4hint, but no ipv6hint.
+func newHTTPSRecordNoV6Hint(name string) *dns.HTTPS {
+	return &dns.HTTPS{SVCB: dns.SVCB{
+		Hdr:      dns.RR_Header{Name: name, Rrtype: dns.TypeHTTPS, Class: dns.ClassINET, Ttl: 300},
+		Priority: 1,
+		Target:   ".",
+		Value: []dns.SVCBKeyValue{
+			&dns.SVCBAlpn{Alpn: []string{"h3", "h2"}},
+			&dns.SVCBIPv4Hint{Hint: []net.IP{net.ParseIP("104.16.123.96")}},
+		},
+	}}
+}
+
+// newRRSIG builds a minimal RRSIG RR covering the given record type.
+func newRRSIG(covered uint16) *dns.RRSIG {
+	return &dns.RRSIG{
+		Hdr:         dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+		TypeCovered: covered,
+		SignerName:  "example.com.",
+	}
+}
+
 var _ = Describe("FilteringResolver", func() {
 	var (
 		sut        *FilteringResolver
@@ -190,6 +212,51 @@ var _ = Describe("FilteringResolver", func() {
 			resp, err := sut.Resolve(ctx, newRequest("example.com.", A))
 			Expect(err).Should(Succeed())
 			Expect(resp.Res.Answer).Should(ConsistOf(a))
+		})
+
+		It("clears the AD bit when an ipv6hint is removed", func() {
+			mockAnswer.AuthenticatedData = true
+			mockAnswer.Answer = []dns.RR{newHTTPSRecord("example.com.")}
+
+			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
+			Expect(err).Should(Succeed())
+			Expect(resp.Res.AuthenticatedData).Should(BeFalse())
+		})
+
+		It("drops RRSIGs covering the modified HTTPS RRset, keeping other signatures", func() {
+			cnameSig := newRRSIG(dns.TypeCNAME)
+			mockAnswer.Answer = []dns.RR{
+				newHTTPSRecord("example.com."),
+				newRRSIG(dns.TypeHTTPS),
+				cnameSig,
+			}
+
+			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
+			Expect(err).Should(Succeed())
+
+			// the HTTPS-covering signature is gone, the CNAME one stays
+			Expect(resp.Res.Answer).ShouldNot(ContainElement(
+				WithTransform(func(rr dns.RR) uint16 {
+					if sig, ok := rr.(*dns.RRSIG); ok {
+						return sig.TypeCovered
+					}
+
+					return 0
+				}, Equal(uint16(dns.TypeHTTPS))),
+			))
+			Expect(resp.Res.Answer).Should(ContainElement(cnameSig))
+		})
+
+		It("keeps the AD bit and signatures when there is no ipv6hint to remove", func() {
+			mockAnswer.AuthenticatedData = true
+			sig := newRRSIG(dns.TypeHTTPS)
+			mockAnswer.Answer = []dns.RR{newHTTPSRecordNoV6Hint("example.com."), sig}
+
+			resp, err := sut.Resolve(ctx, newRequest("example.com.", HTTPS))
+			Expect(err).Should(Succeed())
+
+			Expect(resp.Res.AuthenticatedData).Should(BeTrue())
+			Expect(resp.Res.Answer).Should(ContainElement(sig))
 		})
 	})
 


### PR DESCRIPTION
Closes #1706

## Problem

When `filtering.queryTypes` includes `AAAA` (to keep clients off IPv6), Blocky still returns `HTTPS`/`SVCB` records (RFC 9460) that carry an `ipv6hint` SvcParam. Modern clients use those hints to connect directly over IPv6, **bypassing the AAAA filter entirely**:

```
www.cloudflare.com. 402 IN HTTPS 1 . alpn="h3,h2" ipv4hint=... ipv6hint=2606:4700::6810:7b60,...
```

AdGuard Home strips these hints; Blocky did not.

## Change

`FilteringResolver` now, **only when `AAAA` is among the filtered query types**, removes the `ipv6hint` SvcParam from every `HTTPS` and `SVCB` answer record. All other SvcParams (`alpn`, `ipv4hint`, ECH, …) are preserved, so HTTP/3/2 negotiation and IPv4 hints keep working; a record left with no hints simply makes the client fall back to an `A` lookup.

### Notes
- **Cache-safe:** responses reaching `FilteringResolver` are never shared with the cache — `CachingResolver` unpacks a fresh `*dns.Msg` on every hit and stores a packed copy on miss — so in-place mutation is safe and matches the existing `setTTLInCachedResponse` pattern.
- Handles both `HTTPS` (type 65) and `SVCB` (type 64); non-SVCB answers are untouched.
- Behavior is automatic (no new config), consistent with how AAAA filtering already works.

## Tests
- New Ginkgo specs in `resolver/filtering_resolver_test.go`: strips `ipv6hint` from `HTTPS` while keeping `alpn`/`ipv4hint`; strips from `SVCB`; leaves non-SVCB answers alone; keeps the hint when `AAAA` is not filtered.

## Docs
- Documented under the Filtering section in `docs/configuration.md`.