### PR TITLE
feat: capability-aware image that runs under drop:ALL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG OPTS=""
 # setup go environment
 ENV GO_SKIP_GENERATE=1\
   GO_BUILD_FLAGS="-tags static -v ${OPTS}" \
+  CGO_ENABLED=0 \
   BIN_USER=100\
   BIN_AUTOCAB=1 \
   BIN_OUT_DIR="/bin" \

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ ifdef BIN_USER
 	chown $(BIN_USER) $(GO_BUILD_OUTPUT)
 endif
 ifdef BIN_AUTOCAB
-	$(info setting cap_net_bind_service to $(GO_BUILD_OUTPUT))
-	setcap 'cap_net_bind_service=+ep' $(GO_BUILD_OUTPUT)
+	$(info setting cap_net_bind_service (permitted) on $(GO_BUILD_OUTPUT))
+	setcap 'cap_net_bind_service=+p' $(GO_BUILD_OUTPUT)
 endif
 
 test: check-go ## run tests

--- a/cmd/caps_test.go
+++ b/cmd/caps_test.go
@@ -64,10 +64,20 @@ var _ = Describe("warnMissingPrivilegedPortCapability", func() {
 			raiseNetBindService = func() (bool, error) { return false, errors.New("boom") }
 		})
 
-		It("logs only the capability error, even with a privileged port", func() {
+		It("logs one combined warning naming the error and the capability", func() {
 			warnMissingPrivilegedPortCapability(config.Ports{DNS: config.ListenConfig{":53"}})
 			Expect(loggerHook.AllEntries()).Should(HaveLen(1))
+			Expect(loggerHook.LastEntry().Message).Should(SatisfyAll(
+				ContainSubstring("could not adjust process capabilities"),
+				ContainSubstring("CAP_NET_BIND_SERVICE"),
+			))
+		})
+
+		It("logs only the error when no privileged port is configured", func() {
+			warnMissingPrivilegedPortCapability(config.Ports{DNS: config.ListenConfig{":1053"}})
+			Expect(loggerHook.AllEntries()).Should(HaveLen(1))
 			Expect(loggerHook.LastEntry().Message).Should(ContainSubstring("could not adjust process capabilities"))
+			Expect(loggerHook.LastEntry().Message).ShouldNot(ContainSubstring("CAP_NET_BIND_SERVICE"))
 		})
 	})
 })

--- a/cmd/caps_test.go
+++ b/cmd/caps_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/log"
+
+	"github.com/sirupsen/logrus/hooks/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("warnMissingPrivilegedPortCapability", func() {
+	var (
+		loggerHook *test.Hook
+		origRaise  func() (bool, error)
+	)
+
+	BeforeEach(func() {
+		origRaise = raiseNetBindService
+		loggerHook = test.NewGlobal()
+		log.Log().AddHook(loggerHook)
+	})
+
+	AfterEach(func() {
+		raiseNetBindService = origRaise
+		loggerHook.Reset()
+	})
+
+	When("the capability is effective", func() {
+		BeforeEach(func() {
+			raiseNetBindService = func() (bool, error) { return true, nil }
+		})
+
+		It("does not warn even with a privileged port", func() {
+			warnMissingPrivilegedPortCapability(config.Ports{DNS: config.ListenConfig{":53"}})
+			Expect(loggerHook.AllEntries()).Should(BeEmpty())
+		})
+	})
+
+	When("the capability is not effective", func() {
+		BeforeEach(func() {
+			raiseNetBindService = func() (bool, error) { return false, nil }
+		})
+
+		It("warns when a privileged port is configured", func() {
+			warnMissingPrivilegedPortCapability(config.Ports{DNS: config.ListenConfig{":53"}})
+			Expect(loggerHook.LastEntry().Message).Should(ContainSubstring("CAP_NET_BIND_SERVICE"))
+		})
+
+		It("does not warn when only unprivileged ports are configured", func() {
+			warnMissingPrivilegedPortCapability(config.Ports{
+				DNS:  config.ListenConfig{":1053"},
+				HTTP: config.ListenConfig{":4000"},
+			})
+			Expect(loggerHook.AllEntries()).Should(BeEmpty())
+		})
+	})
+
+	When("raising the capability returns an error", func() {
+		BeforeEach(func() {
+			raiseNetBindService = func() (bool, error) { return false, errors.New("boom") }
+		})
+
+		It("logs only the capability error, even with a privileged port", func() {
+			warnMissingPrivilegedPortCapability(config.Ports{DNS: config.ListenConfig{":53"}})
+			Expect(loggerHook.AllEntries()).Should(HaveLen(1))
+			Expect(loggerHook.LastEntry().Message).Should(ContainSubstring("could not adjust process capabilities"))
+		})
+	})
+})

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -41,6 +41,12 @@ func newServeCommand() *cobra.Command {
 	}
 }
 
+// privilegedPortCapHint describes how to satisfy the CAP_NET_BIND_SERVICE
+// requirement for binding ports below 1024.
+const privilegedPortCapHint = "grant CAP_NET_BIND_SERVICE (Kubernetes " +
+	"securityContext capabilities.add, or docker run --cap-add NET_BIND_SERVICE) " +
+	"or use a port >= 1024"
+
 // warnMissingPrivilegedPortCapability raises CAP_NET_BIND_SERVICE if it is
 // available, and warns when a privileged port (< 1024) is configured but the
 // capability could not be obtained. It never fails: any real bind error
@@ -48,6 +54,14 @@ func newServeCommand() *cobra.Command {
 func warnMissingPrivilegedPortCapability(ports config.Ports) {
 	effective, err := raiseNetBindService()
 	if err != nil {
+		if privileged := ports.PrivilegedPorts(); len(privileged) > 0 {
+			log.Log().Warnf("could not adjust process capabilities (%v); binding "+
+				"privileged port(s) %s may fail — %s",
+				err, strings.Join(privileged, ", "), privilegedPortCapHint)
+
+			return
+		}
+
 		log.Log().Warnf("could not adjust process capabilities: %v", err)
 
 		return
@@ -58,10 +72,8 @@ func warnMissingPrivilegedPortCapability(ports config.Ports) {
 	}
 
 	if privileged := ports.PrivilegedPorts(); len(privileged) > 0 {
-		log.Log().Warnf("configured to listen on privileged port(s) %s but "+
-			"CAP_NET_BIND_SERVICE is not available; grant the capability "+
-			"(Kubernetes securityContext capabilities.add, or docker run "+
-			"--cap-add NET_BIND_SERVICE) or use a port >= 1024", strings.Join(privileged, ", "))
+		log.Log().Warnf("configured to listen on privileged port(s) %s without "+
+			"CAP_NET_BIND_SERVICE; %s", strings.Join(privileged, ", "), privilegedPortCapHint)
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -22,6 +23,9 @@ var (
 	done              = make(chan bool, 1)
 	isConfigMandatory = true
 	signals           = make(chan os.Signal, 1)
+
+	// raiseNetBindService is a seam so tests can stub the capability raise.
+	raiseNetBindService = util.RaiseNetBindService
 )
 
 const shutdownTimeout = 10 * time.Second
@@ -37,6 +41,30 @@ func newServeCommand() *cobra.Command {
 	}
 }
 
+// warnMissingPrivilegedPortCapability raises CAP_NET_BIND_SERVICE if it is
+// available, and warns when a privileged port (< 1024) is configured but the
+// capability could not be obtained. It never fails: any real bind error
+// surfaces later from server.NewServer.
+func warnMissingPrivilegedPortCapability(ports config.Ports) {
+	effective, err := raiseNetBindService()
+	if err != nil {
+		log.Log().Warnf("could not adjust process capabilities: %v", err)
+
+		return
+	}
+
+	if effective {
+		return
+	}
+
+	if privileged := ports.PrivilegedPorts(); len(privileged) > 0 {
+		log.Log().Warnf("configured to listen on privileged port(s) %s but "+
+			"CAP_NET_BIND_SERVICE is not available; grant the capability "+
+			"(Kubernetes securityContext capabilities.add, or docker run "+
+			"--cap-add NET_BIND_SERVICE) or use a port >= 1024", strings.Join(privileged, ", "))
+	}
+}
+
 func startServer(_ *cobra.Command, _ []string) error {
 	printBanner()
 
@@ -46,6 +74,8 @@ func startServer(_ *cobra.Command, _ []string) error {
 	}
 
 	log.Configure(&cfg.Log)
+
+	warnMissingPrivilegedPortCapability(cfg.Ports)
 
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 

--- a/config/config.go
+++ b/config/config.go
@@ -359,7 +359,8 @@ func (p *Ports) PrivilegedPorts() []string {
 
 	for _, lc := range []ListenConfig{p.DNS, p.HTTP, p.HTTPS, p.TLS} {
 		for _, addr := range lc {
-			if port, ok := extractPort(addr); ok && port < privilegedPortCeiling {
+			// Port 0 (OS-assigned ephemeral port) is never privileged.
+			if port, ok := extractPort(addr); ok && port > 0 && port < privilegedPortCeiling {
 				privileged = append(privileged, addr)
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -348,6 +348,46 @@ func (c *Ports) LogConfig(logger *logrus.Entry) {
 	logger.Infof("HTTPS = %s", c.HTTPS)
 }
 
+// privilegedPortCeiling is the first non-privileged TCP/UDP port. Ports below
+// it require CAP_NET_BIND_SERVICE (or root) to bind on Linux.
+const privilegedPortCeiling = 1024
+
+// PrivilegedPorts returns the configured listen addresses across DNS, HTTP,
+// HTTPS and TLS whose port is below privilegedPortCeiling.
+func (p *Ports) PrivilegedPorts() []string {
+	var privileged []string
+
+	for _, lc := range []ListenConfig{p.DNS, p.HTTP, p.HTTPS, p.TLS} {
+		for _, addr := range lc {
+			if port, ok := extractPort(addr); ok && port < privilegedPortCeiling {
+				privileged = append(privileged, addr)
+			}
+		}
+	}
+
+	return privileged
+}
+
+// extractPort returns the port number of a listen address. It accepts every
+// ListenConfig form: "53", ":53", "1.2.3.4:53", "[::1]:853", "host:5353".
+func extractPort(addr string) (uint16, bool) {
+	if addr == "" {
+		return 0, false
+	}
+
+	portStr := addr
+	if _, splitPort, err := net.SplitHostPort(addr); err == nil {
+		portStr = splitPort
+	}
+
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return 0, false
+	}
+
+	return uint16(port), true
+}
+
 // split in two types to avoid infinite recursion. See `BootstrapDNS.UnmarshalYAML`.
 type (
 	BootstrapDNS bootstrapDNS

--- a/config/ports_test.go
+++ b/config/ports_test.go
@@ -40,6 +40,12 @@ var _ = Describe("Ports.PrivilegedPorts", func() {
 
 		Expect(ports.PrivilegedPorts()).Should(BeEmpty())
 	})
+
+	It("does not treat port 0 (OS-assigned ephemeral) as privileged", func() {
+		ports := Ports{DNS: ListenConfig{":0"}, HTTP: ListenConfig{"127.0.0.1:0"}}
+
+		Expect(ports.PrivilegedPorts()).Should(BeEmpty())
+	})
 })
 
 var _ = Describe("extractPort", func() {

--- a/config/ports_test.go
+++ b/config/ports_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Ports.PrivilegedPorts", func() {
+	It("returns privileged listen entries across DNS, HTTP, HTTPS and TLS", func() {
+		ports := Ports{
+			DNS:   ListenConfig{":53"},
+			HTTP:  ListenConfig{":4000"},
+			HTTPS: ListenConfig{"127.0.0.1:443"},
+			TLS:   ListenConfig{"[::1]:853"},
+		}
+
+		Expect(ports.PrivilegedPorts()).Should(ConsistOf(":53", "127.0.0.1:443", "[::1]:853"))
+	})
+
+	It("returns empty when every configured port is unprivileged", func() {
+		ports := Ports{DNS: ListenConfig{":1053"}, HTTP: ListenConfig{":4000"}}
+
+		Expect(ports.PrivilegedPorts()).Should(BeEmpty())
+	})
+
+	It("treats port 1023 as privileged and 1024 as unprivileged", func() {
+		ports := Ports{DNS: ListenConfig{":1023"}, HTTP: ListenConfig{":1024"}}
+
+		Expect(ports.PrivilegedPorts()).Should(ConsistOf(":1023"))
+	})
+
+	It("handles a bare port without a colon (robustness; prefixPorts normalises these during unmarshal)", func() {
+		ports := Ports{DNS: ListenConfig{"53"}}
+
+		Expect(ports.PrivilegedPorts()).Should(ConsistOf("53"))
+	})
+
+	It("ignores empty and unparseable entries", func() {
+		ports := Ports{DNS: ListenConfig{"", "notaport"}}
+
+		Expect(ports.PrivilegedPorts()).Should(BeEmpty())
+	})
+})
+
+var _ = Describe("extractPort", func() {
+	DescribeTable("parses the port from a listen address",
+		func(addr string, expectedPort uint16, expectedOK bool) {
+			port, ok := extractPort(addr)
+			Expect(ok).Should(Equal(expectedOK))
+			if expectedOK {
+				Expect(port).Should(Equal(expectedPort))
+			}
+		},
+		Entry("bare port", "53", uint16(53), true),
+		Entry("colon-prefixed", ":53", uint16(53), true),
+		Entry("ipv4 host", "127.0.0.1:53", uint16(53), true),
+		Entry("ipv6 host", "[::1]:853", uint16(853), true),
+		Entry("hostname high port", "localhost:5353", uint16(5353), true),
+		Entry("empty string", "", uint16(0), false),
+		Entry("non-numeric", "notaport", uint16(0), false),
+	)
+})

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,6 +44,13 @@ run `./blocky --config config.yml`.
     `setcap 'cap_net_bind_service=+ep' ./blocky`, run as root (not recommended),
     or configure a port >= 1024.
 
+    If Blocky runs under a **restricted capability bounding set** (for example a
+    hardened `systemd` unit, or a container that drops capabilities), use
+    `setcap 'cap_net_bind_service=+p' ./blocky` instead. Blocky raises the
+    capability to effective itself at startup, which avoids the
+    `operation not permitted` exec error that `+ep` triggers when the capability
+    is not in the bounding set.
+
 ## Run with docker
 
 !!! note "Running under a restricted runtime"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,10 +39,26 @@ run `./blocky --config config.yml`.
 
 !!! warning
 
-    Please be aware, if you want to use port 53 or 953 on Linux you should add `CAP_NET_BIND_SERVICE` capability
-    to the binary with `setcap 'cap_net_bind_service=+ep' ./blocky`, or run as root (not recommended).
+    To bind a **privileged port (< 1024, e.g. 53 or 853)** as a non-root user on
+    Linux, the binary needs the `NET_BIND_SERVICE` capability. Add it with
+    `setcap 'cap_net_bind_service=+ep' ./blocky`, run as root (not recommended),
+    or configure a port >= 1024.
 
 ## Run with docker
+
+!!! note "Running under a restricted runtime"
+
+    The container image is capability-aware. The binary ships with
+    `cap_net_bind_service=+p` (permitted only), so the container starts even under
+    a restricted runtime that drops all capabilities (for example the Kubernetes
+    *Restricted* Pod Security Standard, `capabilities: drop: [ALL]`).
+
+    - On **ports >= 1024** no capability is required.
+    - On **privileged ports (< 1024, e.g. 53/853)** Blocky needs `NET_BIND_SERVICE`.
+      With the default runtime capability set it is already present and Blocky
+      enables it automatically. Under `drop: [ALL]`, grant it back (Kubernetes
+      `securityContext.capabilities.add: ["NET_BIND_SERVICE"]`, or
+      `docker run --cap-add NET_BIND_SERVICE`) or configure a port >= 1024.
 
 ### Alternative registry
 

--- a/e2e/capabilities_test.go
+++ b/e2e/capabilities_test.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+// capDropDNSPort is an unprivileged (>= 1024) DNS port used to prove the image
+// runs under --cap-drop ALL without needing NET_BIND_SERVICE.
+const capDropDNSPort = 1053
+
+var _ = Describe("Restricted capabilities", Label("e2e"), func() {
+	var (
+		e2eNet *testcontainers.DockerNetwork
+		blocky testcontainers.Container
+		err    error
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		e2eNet = getRandomNetwork(ctx)
+
+		_, err = createDNSMokkaContainer(ctx, "moka1", e2eNet, `A google/NOERROR("A 1.2.3.4 123")`)
+		Expect(err).Should(Succeed())
+	})
+
+	Context("with all capabilities dropped on a high port", func() {
+		BeforeEach(func(ctx context.Context) {
+			blocky, err = createBlockyContainerWithCapDrop(ctx, e2eNet, capDropDNSPort, dedent(fmt.Sprintf(`
+				upstreams:
+				  groups:
+				    default:
+				      - moka1
+				ports:
+				  dns: %d
+				`, capDropDNSPort)))
+			Expect(err).Should(Succeed())
+		})
+
+		It("execs and serves DNS without NET_BIND_SERVICE", func(ctx context.Context) {
+			Expect(blocky.IsRunning()).Should(BeTrue())
+			Expect(getContainerLogs(ctx, blocky)).
+				ShouldNot(ContainElement(ContainSubstring("operation not permitted")))
+		})
+	})
+})

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -320,6 +321,41 @@ func doHTTPRequest(ctx context.Context, container testcontainers.Container, cont
 	}
 
 	return nil
+}
+
+// createBlockyContainerWithCapDrop creates a blocky container that listens on
+// the given DNS port with ALL Linux capabilities dropped. It verifies the image
+// execs and serves DNS under a PSS-Restricted-style runtime (Kubernetes
+// Restricted profile / docker --cap-drop ALL). It builds on the standard blocky
+// container request, overriding only the exposed ports, the healthcheck target
+// port, and the dropped capabilities — so image resolution and coverage wiring
+// are inherited.
+func createBlockyContainerWithCapDrop(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+	dnsPort int, lines ...string,
+) (testcontainers.Container, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*startupTimeout)
+	defer cancel()
+
+	confFile := createTempFile(lines...)
+	portStr := strconv.Itoa(dnsPort)
+
+	req := buildBlockyContainerRequest(confFile)
+	req.ExposedPorts = []string{portStr + "/tcp", portStr + "/udp"}
+
+	baseConfigModifier := req.ConfigModifier
+	req.ConfigModifier = func(c *container.Config) {
+		baseConfigModifier(c)
+		// Point the healthcheck at the configured DNS port (the image default is 53).
+		c.Healthcheck.Test = []string{"CMD", "/app/blocky", "healthcheck", "-p", portStr}
+	}
+
+	baseHostConfigModifier := req.HostConfigModifier
+	req.HostConfigModifier = func(hc *container.HostConfig) {
+		baseHostConfigModifier(hc)
+		hc.CapDrop = []string{"ALL"}
+	}
+
+	return startContainerWithNetwork(ctx, req, "blocky", e2eNet)
 }
 
 // createTempFile creates a temporary file with the given lines which is deleted after the test

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792
 	golang.org/x/net v0.55.0
+	golang.org/x/sys v0.45.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/mysql v1.6.0
@@ -183,7 +184,6 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/util/caps_linux.go
+++ b/util/caps_linux.go
@@ -52,7 +52,7 @@ func RaiseNetBindService() (effective bool, err error) {
 
 	// Apply to all OS threads so any goroutine that calls bind() sees the
 	// capability. AllThreadsSyscall requires CGO_ENABLED=0 (it returns ENOTSUP
-	// under cgo); Blocky is always built as a pure-Go static binary.
+	// under cgo); Blocky's Docker image and release binaries are built with CGO_ENABLED=0.
 	// The unsafe.Pointer->uintptr conversions are inlined in the call as
 	// required by the unsafe.Pointer rules.
 	_, _, errno := syscall.AllThreadsSyscall(

--- a/util/caps_linux.go
+++ b/util/caps_linux.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package util
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// RaiseNetBindService promotes CAP_NET_BIND_SERVICE from the process's permitted
+// set into its effective set, across all OS threads (via syscall.AllThreadsSyscall,
+// which applies the capability change to every thread — this matters because Go's
+// net package may run bind() on any thread). It returns whether the capability is
+// effective afterwards.
+//
+// It is best-effort: if the capability is not present in the permitted set
+// (e.g. the runtime dropped all capabilities), it makes no change and returns
+// (false, nil). Promoting an already-permitted capability to effective needs no
+// privilege, so the common path does not fail.
+func RaiseNetBindService() (effective bool, err error) {
+	hdr := unix.CapUserHeader{Version: unix.LINUX_CAPABILITY_VERSION_3}
+	var data [2]unix.CapUserData
+
+	if err = unix.Capget(&hdr, &data[0]); err != nil {
+		return false, err
+	}
+
+	const (
+		capNetBindService = unix.CAP_NET_BIND_SERVICE
+		capsPerWord       = 32 // each CapUserData word holds 32 capability bits
+	)
+
+	// Capabilities 0-31 are in data[0], 32-63 in data[1].
+	// CAP_NET_BIND_SERVICE = 10, so it lives in data[0].
+	capBit := uint32(1) << (capNetBindService % capsPerWord)
+	idx := capNetBindService / capsPerWord
+
+	if data[idx].Permitted&capBit == 0 {
+		// Not in permitted set; nothing to raise.
+		return false, nil
+	}
+
+	if data[idx].Effective&capBit != 0 {
+		// Already effective.
+		return true, nil
+	}
+
+	// Add the cap to the effective set.
+	data[idx].Effective |= capBit
+
+	// Apply to all OS threads so any goroutine that calls bind() sees the
+	// capability. AllThreadsSyscall requires CGO_ENABLED=0 (it returns ENOTSUP
+	// under cgo); Blocky is always built as a pure-Go static binary.
+	// The unsafe.Pointer->uintptr conversions are inlined in the call as
+	// required by the unsafe.Pointer rules.
+	_, _, errno := syscall.AllThreadsSyscall(
+		unix.SYS_CAPSET,
+		uintptr(unsafe.Pointer(&hdr)),
+		uintptr(unsafe.Pointer(&data[0])),
+		0,
+	)
+	if errno != 0 {
+		return false, errno
+	}
+
+	return true, nil
+}

--- a/util/caps_other.go
+++ b/util/caps_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package util
+
+// RaiseNetBindService is a no-op on platforms without Linux capabilities. It
+// reports effective == true so that callers do not emit a privileged-port
+// capability warning for a concept that does not apply on this platform.
+func RaiseNetBindService() (effective bool, err error) {
+	return true, nil
+}

--- a/util/caps_test.go
+++ b/util/caps_test.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RaiseNetBindService", func() {
+	It("returns without error and is stable across calls", func() {
+		// effective depends on whether CAP_NET_BIND_SERVICE is in the process's
+		// permitted set (usually false in CI). We verify the contract that holds
+		// regardless: no error, and a stable result across calls.
+		effective, err := RaiseNetBindService()
+		Expect(err).Should(Succeed())
+
+		effectiveAgain, err := RaiseNetBindService()
+		Expect(err).Should(Succeed())
+		Expect(effectiveAgain).Should(Equal(effective))
+	})
+})


### PR DESCRIPTION
## Summary

Makes the container image runnable under a restricted runtime (`capabilities: drop: [ALL]`, e.g. the Kubernetes *Restricted* Pod Security Standard) **without** regressing the default non-root port-53 deployment.

- **Build:** bake `cap_net_bind_service=+p` (permitted-only) instead of `+ep`. Removing the effective bit means the binary is no longer "capability-dumb", so the kernel no longer blocks `execve` with `operation not permitted` when the bounding set is empty.
- **Runtime:** at startup, raise `CAP_NET_BIND_SERVICE` from the *permitted* to the *effective* set across all OS threads (`util.RaiseNetBindService`; Linux via `x/sys/unix` + `syscall.AllThreadsSyscall`, non-Linux no-op). This keeps the default non-root image binding port 53 out of the box.
- **UX:** `cmd/serve.go` warns once, with actionable remediation, when a privileged port (< 1024) is configured but the capability isn't available.
- **Docker:** pin `CGO_ENABLED=0` (required for `AllThreadsSyscall`, previously only off implicitly).
- **Docs:** explain the capability-aware image and restricted-runtime port binding.

## Why not a separate `-unprivileged` image
Neither AdGuard Home nor Pi-hole ships a second image; they handle capabilities at the default/runtime layer. This follows that approach — one image, capability-aware — rather than proliferating tags.

## Backward compatibility (never worse than today, strictly better for the restricted case)
- **Default non-root image, port 53, normal runtime:** the cap is in the default runtime's permitted set; Blocky raises it → binds 53. ✅
- **`drop:[ALL]` on a high port (the issue):** execs cleanly, no cap needed. ✅ (was a crash-loop)
- **`drop:[ALL]` + `--cap-add NET_BIND_SERVICE` (documented workaround):** still works. ✅
- **Bare binary / release users:** unaffected — releases never set file caps. ✅

## Implementation note
The design originally specified `kernel.org/pub/linux/libcap/cap`, but it was unfetchable in the dev environment; the functionally-equivalent `x/sys/unix` + `AllThreadsSyscall` path is used instead (no new external dependency; `x/sys` was already vendored).

## Test Plan
- [x] Ginkgo unit tests: `config.Ports.PrivilegedPorts` / `extractPort`; `cmd` warning paths (effective / not-effective / error, privileged vs unprivileged)
- [x] `go build ./...`, `go vet ./...` clean
- [ ] e2e (`make e2e-test`, runs in CI): container execs and serves DNS under `--cap-drop ALL` on a high port — compiles locally but was not executed here (needs Docker image build)

Closes #1461