### PR TITLE
docs(redis): document unix socket support and add e2e test

### DIFF
--- a/config/redis.go
+++ b/config/redis.go
@@ -6,7 +6,8 @@ import (
 
 // Redis configuration for the redis connection
 type Redis struct {
-	// Server address and port, or the sentinel master name when sentinel is used.
+	// Server address and port (e.g. `localhost:6379`), a unix socket path (e.g. `/var/run/redis/redis.sock`),
+	// or the sentinel master name when sentinel is used. An address starting with `/` is treated as a unix socket.
 	Address string `yaml:"address"`
 	// Redis username (if authentication is required).
 	Username string `default:"" yaml:"username"`

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -792,7 +792,7 @@
       "properties": {
         "address": {
           "type": "string",
-          "description": "Server address and port, or the sentinel master name when sentinel is used."
+          "description": "Server address and port (e.g. `localhost:6379`), a unix socket path (e.g. `/var/run/redis/redis.sock`),\nor the sentinel master name when sentinel is used. An address starting with `/` is treated as a unix socket."
         },
         "username": {
           "type": "string",

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -257,7 +257,7 @@ queryLog:
 
 # optional: Blocky can synchronize its cache and blocking state between multiple instances through redis.
 redis:
-  # Server address and port or master name if sentinel is used
+  # Server address and port, a unix socket path (starting with /), or master name if sentinel is used
   address: redismaster
   # Username if necessary
   username: usrname

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -870,7 +870,7 @@ Synchronization is disabled if no address is configured.
 
 | Parameter                | Type            | Mandatory | Default value | Description                                                         |
 | ------------------------ | --------------- | --------- | ------------- | ------------------------------------------------------------------- |
-| redis.address            | string          | no        |               | Server address and port or master name if sentinel is used          |
+| redis.address            | string          | no        |               | Server address and port, a unix socket path (starting with `/`), or master name if sentinel is used |
 | redis.username           | string          | no        |               | Username if necessary                                               |
 | redis.password           | string          | no        |               | Password if necessary                                               |
 | redis.database           | int             | no        | 0             | Database                                                            |

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -102,6 +102,30 @@ func createRedisContainer(ctx context.Context, e2eNet *testcontainers.DockerNetw
 	))
 }
 
+// createRedisContainerWithUnixSocket creates a redis container that listens only on a unix socket
+// (no TCP) attached to the test network under the alias 'redis'. The socket is created at
+// containerSocketDir+"/redis.sock" inside a directory that is bind-mounted from hostSocketDir, so both
+// the blocky container and the host can connect to redis purely via the socket.
+// It is automatically terminated when the test is finished.
+func createRedisContainerWithUnixSocket(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+	hostSocketDir, containerSocketDir string,
+) (testcontainers.Container, error) {
+	socketPath := containerSocketDir + "/redis.sock"
+
+	req := testcontainers.ContainerRequest{
+		Image: redisImage,
+		// Disable TCP (port 0) so the socket is the only way in; 777 lets the (non-root) blocky
+		// container connect to the socket created by the (root) redis process.
+		Cmd:        []string{"redis-server", "--port", "0", "--unixsocket", socketPath, "--unixsocketperm", "777"},
+		WaitingFor: wait.ForLog("Ready to accept connections unix"),
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.Binds = append(hc.Binds, hostSocketDir+":"+containerSocketDir)
+		},
+	}
+
+	return startContainerWithNetwork(ctx, req, "redis", e2eNet)
+}
+
 // createPostgresContainer creates a postgres container attached to the test network under the alias 'postgres'.
 // It creates a database 'user' with user 'user' and password 'user'.
 // It is automatically terminated when the test is finished.
@@ -203,6 +227,15 @@ func buildBlockyContainerRequest(confFile string) testcontainers.ContainerReques
 func createBlockyContainer(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
 	lines ...string,
 ) (testcontainers.Container, error) {
+	return createBlockyContainerWithBinds(ctx, e2eNet, nil, lines...)
+}
+
+// createBlockyContainerWithBinds creates a blocky container like createBlockyContainer, but additionally
+// mounts the given Docker bind mounts (each in "hostPath:containerPath" form) into the container.
+// It is automatically terminated when the test is finished.
+func createBlockyContainerWithBinds(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+	binds []string, lines ...string,
+) (testcontainers.Container, error) {
 	// Add timeout to context
 	ctx, cancel := context.WithTimeout(ctx, 2*startupTimeout)
 	defer cancel()
@@ -215,6 +248,14 @@ func createBlockyContainer(ctx context.Context, e2eNet *testcontainers.DockerNet
 	}
 
 	req := buildBlockyContainerRequest(confFile)
+
+	if len(binds) > 0 {
+		baseHostConfigModifier := req.HostConfigModifier
+		req.HostConfigModifier = func(hc *container.HostConfig) {
+			baseHostConfigModifier(hc)
+			hc.Binds = append(hc.Binds, binds...)
+		}
+	}
 
 	container, err := startContainerWithNetwork(ctx, req, "blocky", e2eNet)
 	if err != nil {

--- a/e2e/redis_test.go
+++ b/e2e/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	. "github.com/0xERR0R/blocky/helpertest"
@@ -397,3 +398,81 @@ var _ = Describe("Redis configuration tests", func() {
 func dbSize(ctx context.Context, redisClient *redis.Client) (int64, error) {
 	return redisClient.DBSize(ctx).Result()
 }
+
+var _ = Describe("Redis unix socket configuration", func() {
+	const containerSocketDir = "/sockets"
+
+	var (
+		e2eNet        *testcontainers.DockerNetwork
+		redisClient   *redis.Client
+		hostSocketDir string
+		err           error
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		e2eNet = getRandomNetwork(ctx)
+
+		// Shared directory bind-mounted into both the redis and blocky containers so they can
+		// communicate over the unix socket living inside it.
+		hostSocketDir, err = os.MkdirTemp("", "blocky_e2e_redis_socket-")
+		Expect(err).Should(Succeed())
+		Expect(os.Chmod(hostSocketDir, 0o777)).Should(Succeed())
+		DeferCleanup(func() error {
+			return os.RemoveAll(hostSocketDir)
+		})
+
+		_, err = createRedisContainerWithUnixSocket(ctx, e2eNet, hostSocketDir, containerSocketDir)
+		Expect(err).Should(Succeed())
+
+		// Redis has no TCP listener; the host test client verifies the database over the same unix
+		// socket via the bind-mounted directory. go-redis treats a `/`-prefixed address as a unix
+		// socket, so this also exercises the behaviour under test from the client side.
+		redisClient = redis.NewClient(&redis.Options{
+			Addr: hostSocketDir + "/redis.sock",
+		})
+		Expect(dbSize(ctx, redisClient)).Should(BeNumerically("==", 0))
+
+		_, err = createDNSMokkaContainer(ctx, "moka1", e2eNet, `A google/NOERROR("A 1.2.3.4 123")`)
+		Expect(err).Should(Succeed())
+	})
+
+	When("blocky is configured with a redis unix socket address", func() {
+		var blocky testcontainers.Container
+
+		BeforeEach(func(ctx context.Context) {
+			blocky, err = createBlockyContainerWithBinds(ctx, e2eNet,
+				[]string{hostSocketDir + ":" + containerSocketDir},
+				"log:",
+				"  level: warn",
+				"upstreams:",
+				"  groups:",
+				"    default:",
+				"      - moka1",
+				"redis:",
+				"  address: "+containerSocketDir+"/redis.sock",
+			)
+			Expect(err).Should(Succeed())
+		})
+
+		It("stores cache entries in redis over the unix socket", func(ctx context.Context) {
+			msg := util.NewMsgWithQuestion("google.de.", A)
+
+			By("querying blocky, which should resolve and store the result in redis via the socket", func() {
+				Eventually(doDNSRequest, "5s", "2ms").WithArguments(ctx, blocky, msg).
+					Should(
+						SatisfyAll(
+							BeDNSRecord("google.de.", A, "1.2.3.4"),
+							HaveTTL(BeNumerically("==", 123)),
+						))
+			})
+
+			By("checking redis contains the cache entry written over the unix socket", func() {
+				Eventually(dbSize, "5s", "2ms").WithArguments(ctx, redisClient).Should(BeNumerically("==", 1))
+			})
+
+			By("No warnings/errors in log", func() {
+				Expect(getContainerLogs(ctx, blocky)).Should(BeEmpty())
+			})
+		})
+	})
+})

--- a/e2e/redis_test.go
+++ b/e2e/redis_test.go
@@ -430,6 +430,7 @@ var _ = Describe("Redis unix socket configuration", func() {
 		redisClient = redis.NewClient(&redis.Options{
 			Addr: hostSocketDir + "/redis.sock",
 		})
+		DeferCleanup(redisClient.Close)
 		Expect(dbSize(ctx, redisClient)).Should(BeNumerically("==", 0))
 
 		_, err = createDNSMokkaContainer(ctx, "moka1", e2eNet, `A google/NOERROR("A 1.2.3.4 123")`)


### PR DESCRIPTION
Resolves #1058.

## Finding

While starting on #1058, the e2e test I wrote to verify unix socket support **passed on the first run** — because [go-redis already treats a `/`-prefixed address as a unix socket](https://github.com/go-redis/redis/blob/v8.11.5/options.go#L121-L127):

```go
if opt.Network == "" {
    if strings.HasPrefix(opt.Addr, "/") {
        opt.Network = "unix"
    } else {
        opt.Network = "tcp"
    }
}
```

So blocky has **always** supported `redis.address: /path/to/redis.sock` for the standard (non-sentinel) connection — it was just undocumented and untested. This PR locks the behaviour in and documents it rather than adding redundant connection code.

## Changes

- Document unix socket support on the Redis `address` config field in `config/redis.go` (the source of truth) and regenerate `docs/config.schema.json` via `go generate`.
- Update the human-facing docs (`docs/configuration.md`, `docs/config.yml`).
- Add an e2e test (`e2e/redis_test.go`) that runs a **socket-only** redis instance (`--port 0`, unix socket in a bind-mounted dir) and proves blocky stores a cache entry through the socket. The host-side verification client also connects via the socket path, so go-redis's unix detection is exercised from both ends.
- Add test helpers `createRedisContainerWithUnixSocket` and `createBlockyContainerWithBinds` (the latter is a thin wrapper; `createBlockyContainer` now delegates to it with no behaviour change).

## Testing

- New unix-socket e2e spec: passing
- Full Redis e2e suite (6 specs): passing
- `redis` + `config` unit suites: passing
- `golangci-lint` (v2.12.2) on changed packages: 0 issues; `gofmt`/`go vet` clean

## Notes

- Sentinel mode is out of scope — its addresses are sentinel hosts, not a single connection target.