### PR TITLE
feat: load sensitive config values from files

### DIFF
--- a/config/query_log.go
+++ b/config/query_log.go
@@ -76,7 +76,9 @@ func (c *QueryLog) censoredTarget() string {
 
 	parsed, err := url.Parse(targetStr)
 	if err != nil {
-		return target
+		// The target couldn't be parsed, so we can't locate and redact an embedded
+		// password. Redact the whole value rather than risk leaking a secret.
+		return secretObfuscator
 	}
 
 	pass, ok := parsed.User.Password()

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -11,7 +11,7 @@ import (
 // QueryLog configuration for the query logging
 type QueryLog struct {
 	// Directory for CSV log files, or database URL for mysql/postgresql/timescale targets.
-	Target string `yaml:"target"`
+	Target Secret `yaml:"target"`
 	// Log target type: mysql, postgresql, timescale, csv, csv-client, console, or none.
 	Type QueryLogType `yaml:"type"`
 	// Delete log entries older than this many days. 0 disables retention cleanup.
@@ -66,21 +66,23 @@ func (c *QueryLog) LogConfig(logger *logrus.Entry) {
 }
 
 func (c *QueryLog) censoredTarget() string {
+	target := c.Target.Reveal()
+
 	// Make sure there's a scheme, otherwise the user is parsed as the scheme
-	targetStr := c.Target
+	targetStr := target
 	if !strings.Contains(targetStr, "://") {
 		targetStr = c.Type.String() + "://" + targetStr
 	}
 
-	target, err := url.Parse(targetStr)
+	parsed, err := url.Parse(targetStr)
 	if err != nil {
-		return c.Target
+		return target
 	}
 
-	pass, ok := target.User.Password()
+	pass, ok := parsed.User.Password()
 	if !ok {
-		return c.Target
+		return target
 	}
 
-	return strings.ReplaceAll(c.Target, pass, secretObfuscator)
+	return strings.ReplaceAll(target, pass, secretObfuscator)
 }

--- a/config/query_log_test.go
+++ b/config/query_log_test.go
@@ -1,11 +1,14 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/creasty/defaults"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
 )
 
 var _ = Describe("QueryLogConfig", func() {
@@ -59,7 +62,7 @@ var _ = Describe("QueryLogConfig", func() {
 
 		DescribeTable("secret censoring", func(target string) {
 			cfg.Type = QueryLogTypeMysql
-			cfg.Target = target
+			cfg.Target = Secret(target)
 
 			cfg.LogConfig(logger)
 
@@ -71,6 +74,28 @@ var _ = Describe("QueryLogConfig", func() {
 			Entry("no password", "localhost"),
 			Entry("not a URL", "invalid!://"),
 		)
+	})
+
+	Describe("secret target handling", func() {
+		It("loads the target DSN from a file and censors it when logging", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "dsn")
+			Expect(os.WriteFile(path, []byte("postgresql://u:secretpw@host/db\n"), 0o600)).Should(Succeed())
+
+			yamlStr := "type: postgresql\ntarget: file:" + path + "\n"
+
+			var qlCfg QueryLog
+			Expect(yaml.UnmarshalStrict([]byte(yamlStr), &qlCfg)).Should(Succeed())
+			Expect(qlCfg.Target.Reveal()).Should(Equal("postgresql://u:secretpw@host/db"))
+			Expect(qlCfg.censoredTarget()).ShouldNot(ContainSubstring("secretpw"))
+			Expect(qlCfg.censoredTarget()).Should(ContainSubstring(secretObfuscator))
+		})
+
+		It("censors the embedded password of an inline DSN", func() {
+			cfg := QueryLog{Type: QueryLogTypePostgresql, Target: "postgresql://u:secretpw@host/db"}
+			Expect(cfg.censoredTarget()).ShouldNot(ContainSubstring("secretpw"))
+			Expect(cfg.censoredTarget()).Should(ContainSubstring(secretObfuscator))
+		})
 	})
 
 	Describe("SetDefaults", func() {

--- a/config/redis.go
+++ b/config/redis.go
@@ -12,7 +12,7 @@ type Redis struct {
 	// Redis username (if authentication is required).
 	Username string `default:"" yaml:"username"`
 	// Redis password (if authentication is required).
-	Password string `default:"" yaml:"password"`
+	Password Secret `default:"" yaml:"password"`
 	// Redis database index to use.
 	Database int `default:"0" yaml:"database"`
 	// If true, blocky will not start when the Redis connection cannot be established.
@@ -24,7 +24,7 @@ type Redis struct {
 	// Sentinel username (if sentinel authentication is required).
 	SentinelUsername string `default:"" yaml:"sentinelUsername"`
 	// Sentinel password (if sentinel authentication is required).
-	SentinelPassword string `default:"" yaml:"sentinelPassword"`
+	SentinelPassword Secret `default:"" yaml:"sentinelPassword"`
 	// List of Redis Sentinel host:port addresses; enables sentinel mode when non-empty.
 	SentinelAddresses []string `yaml:"sentinelAddresses"`
 }

--- a/config/redis_test.go
+++ b/config/redis_test.go
@@ -1,10 +1,14 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/0xERR0R/blocky/log"
 	"github.com/creasty/defaults"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
 )
 
 var _ = Describe("Redis", func() {
@@ -103,6 +107,48 @@ var _ = Describe("Redis", func() {
 
 			Expect(hook.Calls).ShouldNot(BeEmpty())
 			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring(secretValue)))
+		})
+	})
+
+	Describe("file: secret resolution", func() {
+		It("loads password from a file, stripping the trailing newline", func() {
+			dir := GinkgoT().TempDir()
+			pwPath := filepath.Join(dir, "pw")
+			Expect(os.WriteFile(pwPath, []byte("redispass\n"), 0o600)).Should(Succeed())
+
+			var redisCfg Redis
+			Expect(yaml.UnmarshalStrict(
+				[]byte("address: localhost:6379\npassword: file:"+pwPath+"\n"), &redisCfg)).Should(Succeed())
+			Expect(redisCfg.Password.Reveal()).Should(Equal("redispass"))
+		})
+
+		It("loads sentinelPassword from a file", func() {
+			dir := GinkgoT().TempDir()
+			sentPath := filepath.Join(dir, "sent")
+			Expect(os.WriteFile(sentPath, []byte("sentpass"), 0o600)).Should(Succeed())
+
+			var redisCfg Redis
+			Expect(yaml.UnmarshalStrict(
+				[]byte("address: localhost:6379\nsentinelPassword: file:"+sentPath+"\n"), &redisCfg)).Should(Succeed())
+			Expect(redisCfg.SentinelPassword.Reveal()).Should(Equal("sentpass"))
+		})
+
+		It("still obfuscates a file-loaded password in LogConfig", func() {
+			logger, hook = log.NewMockEntry()
+
+			dir := GinkgoT().TempDir()
+			pwPath := filepath.Join(dir, "pw")
+			Expect(os.WriteFile(pwPath, []byte("redispass"), 0o600)).Should(Succeed())
+
+			var redisCfg Redis
+			Expect(defaults.Set(&redisCfg)).Should(Succeed())
+			Expect(yaml.UnmarshalStrict(
+				[]byte("address: localhost:6379\npassword: file:"+pwPath+"\n"), &redisCfg)).Should(Succeed())
+
+			redisCfg.LogConfig(logger)
+
+			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("redispass")))
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring(secretObfuscator)))
 		})
 	})
 })

--- a/config/secret.go
+++ b/config/secret.go
@@ -6,12 +6,18 @@ import (
 	"strings"
 )
 
-// secretFilePrefix marks a Secret value that should be read from a file path.
-const secretFilePrefix = "file:"
+// secretFilePrefix and secretFileURIPrefix mark a Secret value that should be
+// read from a file path. The URI-style `file://` form mirrors config.BytesSource
+// so both conventions resolve the same way.
+const (
+	secretFileURIPrefix = "file://"
+	secretFilePrefix    = "file:"
+)
 
 // Secret is a string config value that may be provided inline or, when prefixed
-// with `file:`, read from the named file. Its String/MarshalText implementations
-// redact the value so it can't leak through logging.
+// with `file:` (or `file://`), read from the named file. Its String, MarshalText
+// and MarshalYAML implementations redact the value so it can't leak through
+// logging or config serialization.
 type Secret string
 
 // Reveal returns the real secret value.
@@ -29,14 +35,27 @@ func (s Secret) MarshalText() ([]byte, error) {
 	return []byte(secretObfuscator), nil
 }
 
-// UnmarshalYAML implements YAML unmarshalling with `file:` support.
+// MarshalYAML implements `yaml.Marshaler`, redacting the value. gopkg.in/yaml
+// honors this interface but not `encoding.TextMarshaler`, so MarshalText alone
+// would let a `yaml.Marshal` of the config emit the raw secret.
+func (s Secret) MarshalYAML() (any, error) {
+	return secretObfuscator, nil
+}
+
+// UnmarshalYAML implements YAML unmarshalling with `file:`/`file://` support.
 func (s *Secret) UnmarshalYAML(unmarshal func(any) error) error {
 	var raw string
 	if err := unmarshal(&raw); err != nil {
 		return err
 	}
 
-	path, ok := strings.CutPrefix(raw, secretFilePrefix)
+	// Accept the URI-style `file://` form first so `file:///abs/path` resolves to
+	// `/abs/path` rather than `//abs/path`; fall back to the bare `file:` prefix.
+	path, ok := strings.CutPrefix(raw, secretFileURIPrefix)
+	if !ok {
+		path, ok = strings.CutPrefix(raw, secretFilePrefix)
+	}
+
 	if !ok {
 		*s = Secret(raw)
 

--- a/config/secret.go
+++ b/config/secret.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// secretFilePrefix marks a Secret value that should be read from a file path.
+const secretFilePrefix = "file:"
+
+// Secret is a string config value that may be provided inline or, when prefixed
+// with `file:`, read from the named file. Its String/MarshalText implementations
+// redact the value so it can't leak through logging.
+type Secret string
+
+// Reveal returns the real secret value.
+func (s Secret) Reveal() string {
+	return string(s)
+}
+
+// String implements `fmt.Stringer`, redacting the value.
+func (s Secret) String() string {
+	return secretObfuscator
+}
+
+// MarshalText implements `encoding.TextMarshaler`, redacting the value.
+func (s Secret) MarshalText() ([]byte, error) {
+	return []byte(secretObfuscator), nil
+}
+
+// UnmarshalYAML implements YAML unmarshalling with `file:` support.
+func (s *Secret) UnmarshalYAML(unmarshal func(any) error) error {
+	var raw string
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	path, ok := strings.CutPrefix(raw, secretFilePrefix)
+	if !ok {
+		*s = Secret(raw)
+
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read secret file %q: %w", path, err)
+	}
+
+	*s = Secret(trimSingleTrailingNewline(string(data)))
+
+	return nil
+}
+
+// trimSingleTrailingNewline removes one trailing "\n" or "\r\n", leaving any
+// other surrounding whitespace intact.
+func trimSingleTrailingNewline(s string) string {
+	after, found := strings.CutSuffix(s, "\n")
+	if !found {
+		return s
+	}
+
+	after, _ = strings.CutSuffix(after, "\r")
+
+	return after
+}

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+)
+
+var _ = Describe("Secret", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		tmpDir = GinkgoT().TempDir()
+	})
+
+	unmarshal := func(value string) (Secret, error) {
+		var holder struct {
+			S Secret `yaml:"s"`
+		}
+		err := yaml.UnmarshalStrict([]byte("s: "+value+"\n"), &holder)
+
+		return holder.S, err
+	}
+
+	writeFile := func(name, content string) string {
+		path := filepath.Join(tmpDir, name)
+		Expect(os.WriteFile(path, []byte(content), 0o600)).Should(Succeed())
+
+		return path
+	}
+
+	When("the value is a plain literal", func() {
+		It("is used verbatim", func() {
+			s, err := unmarshal("letmein")
+			Expect(err).Should(Succeed())
+			Expect(s.Reveal()).Should(Equal("letmein"))
+		})
+	})
+
+	When("the value has the file: prefix", func() {
+		It("reads the file contents", func() {
+			path := writeFile("secret", "frompass")
+
+			s, err := unmarshal("file:" + path)
+			Expect(err).Should(Succeed())
+			Expect(string(s)).Should(Equal("frompass"))
+		})
+
+		It("strips a single trailing newline", func() {
+			path := writeFile("secret", "frompass\n")
+
+			s, err := unmarshal("file:" + path)
+			Expect(err).Should(Succeed())
+			Expect(string(s)).Should(Equal("frompass"))
+		})
+
+		It("preserves interior and trailing spaces", func() {
+			path := writeFile("secret", "with spaces ")
+
+			s, err := unmarshal("file:" + path)
+			Expect(err).Should(Succeed())
+			Expect(string(s)).Should(Equal("with spaces "))
+		})
+
+		It("resolves an empty file to an empty value", func() {
+			path := writeFile("secret", "")
+
+			s, err := unmarshal("file:" + path)
+			Expect(err).Should(Succeed())
+			Expect(string(s)).Should(BeEmpty())
+		})
+
+		It("preserves a bare trailing carriage return", func() {
+			path := writeFile("secret", "frompass\r")
+
+			s, err := unmarshal("file:" + path)
+			Expect(err).Should(Succeed())
+			Expect(string(s)).Should(Equal("frompass\r"))
+		})
+
+		It("strips a single trailing CRLF", func() {
+			path := writeFile("secret", "frompass\r\n")
+
+			s, err := unmarshal("file:" + path)
+			Expect(err).Should(Succeed())
+			Expect(s.Reveal()).Should(Equal("frompass"))
+		})
+
+		It("errors when the file is missing", func() {
+			_, err := unmarshal("file:" + filepath.Join(tmpDir, "does-not-exist"))
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("secret file"))
+		})
+	})
+
+	Describe("redaction", func() {
+		It("redacts via String()", func() {
+			Expect(Secret("letmein").String()).Should(Equal(secretObfuscator))
+		})
+
+		It("redacts via MarshalText", func() {
+			b, err := Secret("letmein").MarshalText()
+			Expect(err).Should(Succeed())
+			Expect(string(b)).Should(Equal(secretObfuscator))
+		})
+	})
+})

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -94,6 +94,15 @@ var _ = Describe("Secret", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("secret file"))
 		})
+
+		It("accepts the URI-style file:// prefix", func() {
+			path := writeFile("secret", "frompass")
+
+			// path is absolute, so file://<path> yields the file:///abs form.
+			s, err := unmarshal("file://" + path)
+			Expect(err).Should(Succeed())
+			Expect(s.Reveal()).Should(Equal("frompass"))
+		})
 	})
 
 	Describe("redaction", func() {
@@ -105,6 +114,15 @@ var _ = Describe("Secret", func() {
 			b, err := Secret("letmein").MarshalText()
 			Expect(err).Should(Succeed())
 			Expect(string(b)).Should(Equal(secretObfuscator))
+		})
+
+		It("redacts when marshalled to YAML", func() {
+			out, err := yaml.Marshal(struct {
+				S Secret `yaml:"s"`
+			}{S: "letmein"})
+			Expect(err).Should(Succeed())
+			Expect(string(out)).ShouldNot(ContainSubstring("letmein"))
+			Expect(string(out)).Should(ContainSubstring(secretObfuscator))
 		})
 	})
 })

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -262,6 +262,8 @@ redis:
   # Username if necessary
   username: usrname
   # Password if necessary
+  # To load from a file instead:
+  #   password: file:/run/secrets/redis_password
   password: passwd
   # Database, default: 0
   database: 2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -872,14 +872,29 @@ Synchronization is disabled if no address is configured.
 | ------------------------ | --------------- | --------- | ------------- | ------------------------------------------------------------------- |
 | redis.address            | string          | no        |               | Server address and port, a unix socket path (starting with `/`), or master name if sentinel is used |
 | redis.username           | string          | no        |               | Username if necessary                                               |
-| redis.password           | string          | no        |               | Password if necessary                                               |
+| redis.password           | string          | no        |               | Password if necessary (supports `file:` — see tip below)            |
 | redis.database           | int             | no        | 0             | Database                                                            |
 | redis.required           | bool            | no        | false         | Connection is required for blocky to start                          |
 | redis.connectionAttempts | int             | no        | 3             | Max connection attempts                                             |
 | redis.connectionCooldown | duration format | no        | 1s            | Time between the connection attempts                                |
 | redis.sentinelUsername   | string          | no        |               | Sentinel username if necessary                                      |
-| redis.sentinelPassword   | string          | no        |               | Sentinel password if necessary                                      |
+| redis.sentinelPassword   | string          | no        |               | Sentinel password if necessary (supports `file:` — see tip below)   |
 | redis.sentinelAddresses  | string[]        | no        |               | Sentinel host list (Sentinel is activated if addresses are defined) |
+
+!!! tip "Loading secrets from files"
+
+    Any sensitive value — `redis.password`, `redis.sentinelPassword`, and
+    `queryLog.target` — can be loaded from a file instead of being written
+    inline. Set the value to `file:` followed by an absolute path:
+
+    ```yaml
+    redis:
+      password: file:/run/secrets/redis_password
+    ```
+
+    The file's contents become the value (a single trailing newline is
+    stripped). This suits Docker/Kubernetes secrets and lets you restrict
+    access to each secret with file permissions.
 
 !!! example
 
@@ -987,7 +1002,7 @@ Configuration parameters:
 | Parameter                 | Type                                                                                 | Mandatory | Default value | Description                                                                                   |
 | ------------------------- | ------------------------------------------------------------------------------------ | --------- | ------------- | --------------------------------------------------------------------------------------------- |
 | queryLog.type             | enum (mysql, postgresql, timescale, csv, csv-client, console, none (see above))      | no        |               | Type of logging target. Console if empty                                                      |
-| queryLog.target           | string                                                                               | no        |               | directory for writing the logs (for csv) or database url (for mysql, postgresql or timescale) |
+| queryLog.target           | string                                                                               | no        |               | directory for writing the logs (for csv) or database url (for mysql, postgresql or timescale); supports `file:` for database URLs — see [Redis tip](#redis) |
 | queryLog.logRetentionDays | int                                                                                  | no        | 0             | if > 0, deletes log files/database entries which are older than ... days                      |
 | queryLog.creationAttempts | int                                                                                  | no        | 3             | Max attempts to create specific query log writer                                              |
 | queryLog.creationCooldown | duration format                                                                      | no        | 2s            | Time between the creation attempts                                                            |

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -40,7 +40,9 @@ const (
 
 // helper constants
 const (
-	modeOwner         = 700
+	// modeWorldReadable is used for files mounted into the blocky container: blocky
+	// runs as a non-root user (see Dockerfile `USER 100`) that doesn't own the
+	// copied files, so it can only read them via the world-readable bit.
 	modeWorldReadable = 0o444
 	startupTimeout    = 30 * time.Second
 )
@@ -84,7 +86,7 @@ func createHTTPServerContainer(ctx context.Context, alias string, e2eNet *testco
 			{
 				HostFilePath:      file,
 				ContainerFilePath: "/" + filename,
-				FileMode:          modeOwner,
+				FileMode:          modeWorldReadable,
 			},
 		},
 	}
@@ -213,7 +215,7 @@ func buildBlockyContainerRequest(confFile string) testcontainers.ContainerReques
 			{
 				HostFilePath:      confFile,
 				ContainerFilePath: "/app/config.yml",
-				FileMode:          modeOwner,
+				FileMode:          modeWorldReadable,
 			},
 		},
 		ConfigModifier: func(c *container.Config) {

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -239,19 +239,11 @@ func buildBlockyContainerRequest(confFile string) testcontainers.ContainerReques
 	return req
 }
 
-// createBlockyContainerInternal builds and starts a blocky container from the given
-// config lines, mounting any extraFiles in addition to the generated config.yml.
+// createBlockyContainerInternal builds and starts a blocky container from the given config
+// lines, mounting any extraFiles in addition to the generated config.yml and adding any
+// Docker bind mounts (each in "hostPath:containerPath" form).
 func createBlockyContainerInternal(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
-	extraFiles []testcontainers.ContainerFile, lines ...string,
-) (testcontainers.Container, error) {
-	return createBlockyContainerWithBinds(ctx, e2eNet, nil, lines...)
-}
-
-// createBlockyContainerWithBinds creates a blocky container like createBlockyContainer, but additionally
-// mounts the given Docker bind mounts (each in "hostPath:containerPath" form) into the container.
-// It is automatically terminated when the test is finished.
-func createBlockyContainerWithBinds(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
-	binds []string, lines ...string,
+	extraFiles []testcontainers.ContainerFile, binds []string, lines ...string,
 ) (testcontainers.Container, error) {
 	// Add timeout to context
 	ctx, cancel := context.WithTimeout(ctx, 2*startupTimeout)
@@ -297,13 +289,22 @@ func createBlockyContainerWithBinds(ctx context.Context, e2eNet *testcontainers.
 	return container, nil
 }
 
+// createBlockyContainerWithBinds creates a blocky container like createBlockyContainer, but additionally
+// mounts the given Docker bind mounts (each in "hostPath:containerPath" form) into the container.
+// It is automatically terminated when the test is finished.
+func createBlockyContainerWithBinds(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+	binds []string, lines ...string,
+) (testcontainers.Container, error) {
+	return createBlockyContainerInternal(ctx, e2eNet, nil, binds, lines...)
+}
+
 // createBlockyContainer creates a blocky container with a config provided by the given lines.
 // It is attached to the test network under the alias 'blocky'.
 // It is automatically terminated when the test is finished.
 func createBlockyContainer(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
 	lines ...string,
 ) (testcontainers.Container, error) {
-	return createBlockyContainerInternal(ctx, e2eNet, nil, lines...)
+	return createBlockyContainerInternal(ctx, e2eNet, nil, nil, lines...)
 }
 
 // createBlockyContainerFromString creates a blocky container with a config provided as a single YAML string.
@@ -331,7 +332,7 @@ func createBlockyContainerWithFiles(ctx context.Context, e2eNet *testcontainers.
 		})
 	}
 
-	return createBlockyContainerInternal(ctx, e2eNet, files, strings.Split(configYAML, "\n")...)
+	return createBlockyContainerInternal(ctx, e2eNet, files, nil, strings.Split(configYAML, "\n")...)
 }
 
 func checkBlockyReadiness(ctx context.Context, cfg *config.Config, container testcontainers.Container) error {

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -40,8 +40,9 @@ const (
 
 // helper constants
 const (
-	modeOwner      = 700
-	startupTimeout = 30 * time.Second
+	modeOwner         = 700
+	modeWorldReadable = 0o444
+	startupTimeout    = 30 * time.Second
 )
 
 // createDNSMokkaContainer creates a DNS mokka container with the given rules attached to the test network
@@ -124,6 +125,21 @@ func createRedisContainerWithUnixSocket(ctx context.Context, e2eNet *testcontain
 	}
 
 	return startContainerWithNetwork(ctx, req, "redis", e2eNet)
+}
+
+// redisTestPassword is the password required by createRedisContainerWithPassword.
+const redisTestPassword = "e2e-redis-secret" //nolint:gosec // test-only password for the e2e redis container
+
+// createRedisContainerWithPassword creates a redis container that requires authentication,
+// attached to the test network under the alias 'redis'.
+// It is automatically terminated when the test is finished.
+func createRedisContainerWithPassword(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+) (*redis.RedisContainer, error) {
+	return deferTerminate(redis.Run(ctx,
+		redisImage,
+		testcontainers.WithCmd("redis-server", "--requirepass", redisTestPassword, "--loglevel", "verbose"),
+		withNetwork("redis", e2eNet),
+	))
 }
 
 // createPostgresContainer creates a postgres container attached to the test network under the alias 'postgres'.
@@ -221,11 +237,10 @@ func buildBlockyContainerRequest(confFile string) testcontainers.ContainerReques
 	return req
 }
 
-// createBlockyContainer creates a blocky container with a config provided by the given lines.
-// It is attached to the test network under the alias 'blocky'.
-// It is automatically terminated when the test is finished.
-func createBlockyContainer(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
-	lines ...string,
+// createBlockyContainerInternal builds and starts a blocky container from the given
+// config lines, mounting any extraFiles in addition to the generated config.yml.
+func createBlockyContainerInternal(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+	extraFiles []testcontainers.ContainerFile, lines ...string,
 ) (testcontainers.Container, error) {
 	return createBlockyContainerWithBinds(ctx, e2eNet, nil, lines...)
 }
@@ -248,6 +263,7 @@ func createBlockyContainerWithBinds(ctx context.Context, e2eNet *testcontainers.
 	}
 
 	req := buildBlockyContainerRequest(confFile)
+	req.Files = append(req.Files, extraFiles...)
 
 	if len(binds) > 0 {
 		baseHostConfigModifier := req.HostConfigModifier
@@ -279,6 +295,15 @@ func createBlockyContainerWithBinds(ctx context.Context, e2eNet *testcontainers.
 	return container, nil
 }
 
+// createBlockyContainer creates a blocky container with a config provided by the given lines.
+// It is attached to the test network under the alias 'blocky'.
+// It is automatically terminated when the test is finished.
+func createBlockyContainer(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+	lines ...string,
+) (testcontainers.Container, error) {
+	return createBlockyContainerInternal(ctx, e2eNet, nil, lines...)
+}
+
 // createBlockyContainerFromString creates a blocky container with a config provided as a single YAML string.
 // It is attached to the test network under the alias 'blocky'.
 // It is automatically terminated when the test is finished.
@@ -286,6 +311,25 @@ func createBlockyContainerFromString(ctx context.Context, e2eNet *testcontainers
 	configYAML string,
 ) (testcontainers.Container, error) {
 	return createBlockyContainer(ctx, e2eNet, strings.Split(configYAML, "\n")...)
+}
+
+// createBlockyContainerWithFiles is like createBlockyContainerFromString but also
+// mounts each given host file into the container at the SAME absolute path, so a
+// config `file:` reference resolves both during the host-side LoadConfig pre-flight
+// and inside the container.
+func createBlockyContainerWithFiles(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+	hostFiles []string, configYAML string,
+) (testcontainers.Container, error) {
+	files := make([]testcontainers.ContainerFile, 0, len(hostFiles))
+	for _, f := range hostFiles {
+		files = append(files, testcontainers.ContainerFile{
+			HostFilePath:      f,
+			ContainerFilePath: f,
+			FileMode:          modeWorldReadable, // world-readable so the container user can read it
+		})
+	}
+
+	return createBlockyContainerInternal(ctx, e2eNet, files, strings.Split(configYAML, "\n")...)
 }
 
 func checkBlockyReadiness(ctx context.Context, cfg *config.Config, container testcontainers.Container) error {

--- a/e2e/hosts_file_test.go
+++ b/e2e/hosts_file_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Hosts file resolver", func() {
 				req.Files = append(req.Files, testcontainers.ContainerFile{
 					HostFilePath:      hostsFile,
 					ContainerFilePath: "/app/hosts.txt",
-					FileMode:          modeOwner,
+					FileMode:          modeWorldReadable,
 				})
 
 				ctx, cancel := context.WithTimeout(ctx, 2*startupTimeout)

--- a/e2e/secret_file_test.go
+++ b/e2e/secret_file_test.go
@@ -1,0 +1,88 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/util"
+
+	// goredis is the client lib; redismod is the testcontainers module —
+	// aliased to avoid the two "redis" package names colliding.
+	goredis "github.com/go-redis/redis/v8"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+	redismod "github.com/testcontainers/testcontainers-go/modules/redis"
+)
+
+var _ = Describe("Secret file config", func() {
+	var (
+		e2eNet      *testcontainers.DockerNetwork
+		blocky      testcontainers.Container
+		redisDB     *redismod.RedisContainer
+		redisClient *goredis.Client
+		err         error
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		e2eNet = getRandomNetwork(ctx)
+
+		redisDB, err = createRedisContainerWithPassword(ctx, e2eNet)
+		Expect(err).Should(Succeed())
+
+		_, err = createDNSMokkaContainer(ctx, "moka1", e2eNet, `A google/NOERROR("A 1.2.3.4 123")`)
+		Expect(err).Should(Succeed())
+
+		redisConn, err := redisDB.ConnectionString(ctx)
+		Expect(err).Should(Succeed())
+		redisConn = strings.ReplaceAll(redisConn, "redis://", "")
+
+		redisClient = goredis.NewClient(&goredis.Options{
+			Addr:     redisConn,
+			Password: redisTestPassword,
+		})
+		Expect(dbSize(ctx, redisClient)).Should(BeNumerically("==", 0))
+	})
+
+	When("the redis password is provided via a file", func() {
+		It("authenticates to redis and shares cache", func(ctx context.Context) {
+			// Create the secret file directly under /tmp so that the absolute path
+			// is valid inside the container (which always has /tmp but may lack
+			// user-specific subdirectories used by os.TempDir on this host).
+			f, fErr := os.CreateTemp("/tmp", "blocky_e2e_secret-")
+			Expect(fErr).Should(Succeed())
+			_, fErr = f.WriteString(redisTestPassword)
+			Expect(fErr).Should(Succeed())
+			Expect(f.Close()).Should(Succeed())
+			pwFile := f.Name()
+			DeferCleanup(func() error { return os.Remove(pwFile) })
+
+			blocky, err = createBlockyContainerWithFiles(ctx, e2eNet, []string{pwFile}, dedent(`
+				log:
+				  level: warn
+				upstreams:
+				  groups:
+				    default:
+				      - moka1
+				redis:
+				  address: redis:6379
+				  required: true
+				  password: file:`+pwFile+`
+				`))
+			Expect(err).Should(Succeed())
+
+			By("resolving a query so blocky writes to redis", func() {
+				msg := util.NewMsgWithQuestion("google.de.", A)
+				Eventually(doDNSRequest, "5s", "2ms").WithArguments(ctx, blocky, msg).
+					Should(BeDNSRecord("google.de.", A, "1.2.3.4"))
+			})
+
+			By("confirming blocky authenticated and populated the shared redis cache", func() {
+				Eventually(dbSize, "5s", "10ms").WithArguments(ctx, redisClient).
+					Should(BeNumerically(">", 0))
+			})
+		})
+	})
+})

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -19,10 +19,10 @@ func New(ctx context.Context, cfg *config.Redis) (*goredis.Client, error) {
 		client = goredis.NewFailoverClient(&goredis.FailoverOptions{
 			MasterName:       cfg.Address,
 			SentinelUsername: cfg.Username,
-			SentinelPassword: cfg.SentinelPassword,
+			SentinelPassword: cfg.SentinelPassword.Reveal(),
 			SentinelAddrs:    cfg.SentinelAddresses,
 			Username:         cfg.Username,
-			Password:         cfg.Password,
+			Password:         cfg.Password.Reveal(),
 			DB:               cfg.Database,
 			MaxRetries:       cfg.ConnectionAttempts,
 			MaxRetryBackoff:  cfg.ConnectionCooldown.ToDuration(),
@@ -31,7 +31,7 @@ func New(ctx context.Context, cfg *config.Redis) (*goredis.Client, error) {
 		client = goredis.NewClient(&goredis.Options{
 			Addr:            cfg.Address,
 			Username:        cfg.Username,
-			Password:        cfg.Password,
+			Password:        cfg.Password.Reveal(),
 			DB:              cfg.Database,
 			MaxRetries:      cfg.ConnectionAttempts,
 			MaxRetryBackoff: cfg.ConnectionCooldown.ToDuration(),

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -18,7 +18,7 @@ func New(ctx context.Context, cfg *config.Redis) (*goredis.Client, error) {
 	if len(cfg.SentinelAddresses) > 0 {
 		client = goredis.NewFailoverClient(&goredis.FailoverOptions{
 			MasterName:       cfg.Address,
-			SentinelUsername: cfg.Username,
+			SentinelUsername: cfg.SentinelUsername,
 			SentinelPassword: cfg.SentinelPassword.Reveal(),
 			SentinelAddrs:    cfg.SentinelAddresses,
 			Username:         cfg.Username,

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -42,17 +42,17 @@ func GetQueryLoggingWriter(ctx context.Context, cfg config.QueryLog) (querylog.W
 
 	switch cfg.Type {
 	case config.QueryLogTypeCsv:
-		writer, err = querylog.NewCSVWriter(cfg.Target, false, cfg.LogRetentionDays)
+		writer, err = querylog.NewCSVWriter(cfg.Target.Reveal(), false, cfg.LogRetentionDays)
 	case config.QueryLogTypeCsvClient:
-		writer, err = querylog.NewCSVWriter(cfg.Target, true, cfg.LogRetentionDays)
+		writer, err = querylog.NewCSVWriter(cfg.Target.Reveal(), true, cfg.LogRetentionDays)
 	case config.QueryLogTypeMysql:
-		writer, err = querylog.NewDatabaseWriter(ctx, "mysql", cfg.Target, cfg.LogRetentionDays,
+		writer, err = querylog.NewDatabaseWriter(ctx, "mysql", cfg.Target.Reveal(), cfg.LogRetentionDays,
 			cfg.FlushInterval.ToDuration())
 	case config.QueryLogTypePostgresql:
-		writer, err = querylog.NewDatabaseWriter(ctx, "postgresql", cfg.Target, cfg.LogRetentionDays,
+		writer, err = querylog.NewDatabaseWriter(ctx, "postgresql", cfg.Target.Reveal(), cfg.LogRetentionDays,
 			cfg.FlushInterval.ToDuration())
 	case config.QueryLogTypeTimescale:
-		writer, err = querylog.NewDatabaseWriter(ctx, "timescale", cfg.Target, cfg.LogRetentionDays,
+		writer, err = querylog.NewDatabaseWriter(ctx, "timescale", cfg.Target.Reveal(), cfg.LogRetentionDays,
 			cfg.FlushInterval.ToDuration())
 	case config.QueryLogTypeConsole:
 		writer = querylog.NewLoggerWriter()

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -174,7 +174,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 		When("Configuration with logging per client", func() {
 			BeforeEach(func() {
 				sutConfig = config.QueryLog{
-					Target:           tmpDir.Path,
+					Target:           config.Secret(tmpDir.Path),
 					Type:             config.QueryLogTypeCsvClient,
 					CreationAttempts: 1,
 					CreationCooldown: config.Duration(time.Millisecond),
@@ -242,7 +242,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 		When("Configuration with logging in one file for all clients", func() {
 			BeforeEach(func() {
 				sutConfig = config.QueryLog{
-					Target:           tmpDir.Path,
+					Target:           config.Secret(tmpDir.Path),
 					Type:             config.QueryLogTypeCsv,
 					CreationAttempts: 1,
 					CreationCooldown: config.Duration(time.Millisecond),
@@ -302,7 +302,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 		When("Configuration with specific fields to log", func() {
 			BeforeEach(func() {
 				sutConfig = config.QueryLog{
-					Target:           tmpDir.Path,
+					Target:           config.Secret(tmpDir.Path),
 					Type:             config.QueryLogTypeCsv,
 					CreationAttempts: 1,
 					CreationCooldown: config.Duration(time.Millisecond),
@@ -386,7 +386,7 @@ var _ = Describe("QueryLoggingResolver", func() {
 		When("log directory contains old files", func() {
 			BeforeEach(func() {
 				sutConfig = config.QueryLog{
-					Target:           tmpDir.Path,
+					Target:           config.Secret(tmpDir.Path),
 					Type:             config.QueryLogTypeCsv,
 					LogRetentionDays: 7,
 					CreationAttempts: 1,


### PR DESCRIPTION
## Summary

Adds support for loading sensitive config values from files via a `file:` (or `file://`) prefix, so secrets can come from Docker/Kubernetes secret mounts instead of being written inline in `config.yml`.

A new `config.Secret` string type:
- resolves `file:<path>` / `file://<path>` references at YAML-unmarshal time (stripping a single trailing newline)
- redacts itself in logs and serialization via `String()`, `MarshalText()` and `MarshalYAML()`

Applied to `redis.password`, `redis.sentinelPassword`, and `queryLog.target`. Docs and an e2e test (redis auth via a secret file) are included.

## Review fixes folded in

- **redis:** Sentinel auth now uses `cfg.SentinelUsername` instead of `cfg.Username` — the configured `sentinelUsername` was previously ignored.
- **secret:** added `MarshalYAML` redaction. `gopkg.in/yaml` honors `yaml.Marshaler` but not `encoding.TextMarshaler`, so `MarshalText` alone would leak the raw secret if the config were ever `yaml.Marshal`ed.
- **secret:** accept the URI-style `file://` prefix in addition to `file:`, matching `config.BytesSource` and avoiding a `file:///` foot-gun.
- **queryLog:** `censoredTarget()` now redacts the whole value when `url.Parse` fails, instead of logging the raw (possibly password-bearing) target.
- **e2e:** removed the buggy decimal `modeOwner = 700` constant; mounted files must be world-readable so the non-root container user (`USER 100`) can read them, so all mounts use `modeWorldReadable` (`0o444`).

## Test plan

- `go build ./...` — clean
- `go vet ./config/... ./redis/... ./e2e/...` — clean
- `config`, `redis`, `resolver` unit suites pass; new `Secret` specs cover `file:`/`file://` loading, newline trimming, and `String`/`MarshalText`/`MarshalYAML` redaction
- e2e: `Secret file config` spec authenticates to a password-protected redis using a `file:`-loaded password

closes #694