### PR TITLE
fix(caching): sync prefetched entries to Redis

### DIFF
--- a/cache/prefetching/prefetching_cache.go
+++ b/cache/prefetching/prefetching_cache.go
@@ -70,6 +70,10 @@ func NewPrefetchingCache[T any](ctx context.Context, options PrefetchingOptions[
 	return pc
 }
 
+// Assert the prefetching cache satisfies the decorator's reload-publish hook so a
+// signature drift fails to compile instead of silently disabling Redis sync.
+var _ cache.ReloadPublishable[any] = (*PrefetchingExpiringLRUCache[any])(nil)
+
 // SetReloadPublisher registers a function invoked with each entry reloaded by
 // prefetching. A cache decorator uses it to propagate reloaded entries (which are
 // stored directly by the inner expiration cache and so bypass the decorator).
@@ -104,7 +108,8 @@ func (e *PrefetchingExpiringLRUCache[T]) onExpired(
 		e.onPrefetchEntryReloaded(cacheKey)
 	}
 
-	if p := e.reloadPublisher.Load(); p != nil {
+	// skip the publish for non-positive TTLs: the decorator would drop them anyway.
+	if p := e.reloadPublisher.Load(); p != nil && ttl > 0 {
 		(*p)(cacheKey, loadedVal, ttl)
 	}
 

--- a/cache/prefetching/prefetching_cache.go
+++ b/cache/prefetching/prefetching_cache.go
@@ -18,6 +18,12 @@ type PrefetchingExpiringLRUCache[T any] struct {
 	prefetchExpires         time.Duration
 	onPrefetchEntryReloaded OnEntryReloadedCallback
 	onPrefetchCacheHit      expirationcache.OnCacheHitCallback
+
+	// reloadPublisher, when set, is called with each entry reloaded by prefetching so
+	// a decorator (e.g. Redis write-through) can propagate the refreshed entry. It is
+	// stored atomically because it is wired during setup while the cleanup goroutine
+	// (which reads it) is already running.
+	reloadPublisher atomic.Pointer[func(key string, val *T, ttl time.Duration)]
 }
 
 type cacheValue[T any] struct {
@@ -64,6 +70,13 @@ func NewPrefetchingCache[T any](ctx context.Context, options PrefetchingOptions[
 	return pc
 }
 
+// SetReloadPublisher registers a function invoked with each entry reloaded by
+// prefetching. A cache decorator uses it to propagate reloaded entries (which are
+// stored directly by the inner expiration cache and so bypass the decorator).
+func (e *PrefetchingExpiringLRUCache[T]) SetReloadPublisher(fn func(key string, val *T, ttl time.Duration)) {
+	e.reloadPublisher.Store(&fn)
+}
+
 // check if a cache entry should be prefetched: was queried > threshold in the time window
 func (e *PrefetchingExpiringLRUCache[T]) shouldPrefetch(cacheKey string) bool {
 	if e.prefetchThreshold == 0 {
@@ -78,18 +91,24 @@ func (e *PrefetchingExpiringLRUCache[T]) shouldPrefetch(cacheKey string) bool {
 func (e *PrefetchingExpiringLRUCache[T]) onExpired(
 	ctx context.Context, cacheKey string,
 ) (val *cacheValue[T], ttl time.Duration) {
-	if e.shouldPrefetch(cacheKey) {
-		loadedVal, ttl := e.reloadFn(ctx, cacheKey)
-		if loadedVal != nil {
-			if e.onPrefetchEntryReloaded != nil {
-				e.onPrefetchEntryReloaded(cacheKey)
-			}
-
-			return &cacheValue[T]{loadedVal, true}, ttl
-		}
+	if !e.shouldPrefetch(cacheKey) {
+		return nil, 0
 	}
 
-	return nil, 0
+	loadedVal, ttl := e.reloadFn(ctx, cacheKey)
+	if loadedVal == nil {
+		return nil, 0
+	}
+
+	if e.onPrefetchEntryReloaded != nil {
+		e.onPrefetchEntryReloaded(cacheKey)
+	}
+
+	if p := e.reloadPublisher.Load(); p != nil {
+		(*p)(cacheKey, loadedVal, ttl)
+	}
+
+	return &cacheValue[T]{loadedVal, true}, ttl
 }
 
 func (e *PrefetchingExpiringLRUCache[T]) trackCacheKeyQueryCount(cacheKey string) {

--- a/cache/prefetching/prefetching_cache.go
+++ b/cache/prefetching/prefetching_cache.go
@@ -78,6 +78,14 @@ var _ cache.ReloadPublishable[any] = (*PrefetchingExpiringLRUCache[any])(nil)
 // prefetching. A cache decorator uses it to propagate reloaded entries (which are
 // stored directly by the inner expiration cache and so bypass the decorator).
 func (e *PrefetchingExpiringLRUCache[T]) SetReloadPublisher(fn func(key string, val *T, ttl time.Duration)) {
+	if fn == nil {
+		// clear the publisher: storing &fn would keep a non-nil pointer to a nil
+		// func, which onExpired would then call and panic on.
+		e.reloadPublisher.Store(nil)
+
+		return
+	}
+
 	e.reloadPublisher.Store(&fn)
 }
 

--- a/cache/prefetching/prefetching_cache_test.go
+++ b/cache/prefetching/prefetching_cache_test.go
@@ -173,6 +173,41 @@ var _ = Describe("Prefetching expiration cache", func() {
 				})
 			})
 
+			It("Should not panic when the reload publisher is cleared with nil", func() {
+				c := NewPrefetchingCache[string](ctx, PrefetchingOptions[string]{
+					Options: cache.Options{
+						CleanupInterval: 100 * time.Millisecond,
+					},
+					ReloadFn: func(ctx context.Context, cacheKey string) (*string, time.Duration) {
+						v := "v2"
+
+						return &v, 50 * time.Millisecond
+					},
+				})
+
+				// Set then clear: storing &fn for a nil fn would leave a non-nil pointer
+				// to a nil func that the cleanup goroutine would call and panic on.
+				c.SetReloadPublisher(func(key string, val *string, _ time.Duration) {})
+				c.SetReloadPublisher(nil)
+
+				By("put a value and query it (threshold 0 -> always prefetch)", func() {
+					v := "v1"
+					c.Put("key1", &v, 50*time.Millisecond)
+					c.Get("key1")
+				})
+
+				By("the entry is still reloaded without the cleared publisher panicking", func() {
+					Eventually(func() string {
+						val, _ := c.Get("key1")
+						if val == nil {
+							return ""
+						}
+
+						return *val
+					}, "5s").Should(Equal("v2"))
+				})
+			})
+
 			It("Should execute hook functions", func() {
 				onPrefetchAfterPutChannel := make(chan int, 10)
 				onPrefetchEntryReloaded := make(chan string, 10)

--- a/cache/prefetching/prefetching_cache_test.go
+++ b/cache/prefetching/prefetching_cache_test.go
@@ -134,6 +134,45 @@ var _ = Describe("Prefetching expiration cache", func() {
 					}, "5s").Should(Succeed())
 				})
 			})
+			It("Should call the reload publisher on prefetch reload", func() {
+				publishedKey := make(chan string, 1)
+				publishedVal := make(chan string, 1)
+
+				c := NewPrefetchingCache[string](ctx, PrefetchingOptions[string]{
+					Options: cache.Options{
+						CleanupInterval: 100 * time.Millisecond,
+					},
+					ReloadFn: func(ctx context.Context, cacheKey string) (*string, time.Duration) {
+						v := "v2"
+
+						return &v, 50 * time.Millisecond
+					},
+				})
+
+				c.SetReloadPublisher(func(key string, val *string, _ time.Duration) {
+					// non-blocking so the background cleanup goroutine is never blocked
+					select {
+					case publishedKey <- key:
+					default:
+					}
+					select {
+					case publishedVal <- *val:
+					default:
+					}
+				})
+
+				By("put a value and query it (threshold 0 -> always prefetch)", func() {
+					v := "v1"
+					c.Put("key1", &v, 50*time.Millisecond)
+					c.Get("key1")
+				})
+
+				By("the reload publisher receives the reloaded entry", func() {
+					Eventually(publishedKey, "5s").Should(Receive(Equal("key1")))
+					Eventually(publishedVal, "5s").Should(Receive(Equal("v2")))
+				})
+			})
+
 			It("Should execute hook functions", func() {
 				onPrefetchAfterPutChannel := make(chan int, 10)
 				onPrefetchEntryReloaded := make(chan string, 10)

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -52,6 +52,14 @@ type RedisOptions[T any] struct {
 	SendBufSize int
 }
 
+// reloadPublishable is implemented by inner caches that reload entries internally
+// (e.g. the prefetching cache). The Redis decorator wires its write-through publish
+// in so those reloaded entries are synced like any other Put, without the inner cache
+// or its callers needing to know about Redis.
+type reloadPublishable[T any] interface {
+	SetReloadPublisher(publish func(key string, val *T, ttl time.Duration))
+}
+
 type redisSyncEntry struct {
 	Key  string `json:"k"`
 	Data []byte `json:"d"`
@@ -144,6 +152,12 @@ func NewRedisExpiringCache[T any](
 	go c.runSubscriber(ctx)
 	go c.runWriter(ctx)
 
+	// If the inner cache reloads entries internally (e.g. prefetching), wire our
+	// write-through publish so reloaded entries are synced like any other Put.
+	if rp, ok := inner.(reloadPublishable[T]); ok {
+		rp.SetReloadPublisher(c.Publish)
+	}
+
 	return c, nil
 }
 
@@ -152,7 +166,21 @@ func NewRedisExpiringCache[T any](
 // and a warning is logged – the DNS path is never blocked.
 func (c *RedisExpiringCache[T]) Put(key string, val *T, expiration time.Duration) {
 	c.inner.Put(key, val, expiration)
+	c.enqueueSend(key, val, expiration)
+}
 
+// Publish enqueues a non-blocking write-through to Redis WITHOUT storing the
+// value in the inner cache. It is used when the local store is handled
+// elsewhere – e.g. the prefetch reload path, where the underlying expiration
+// cache stores the reloaded value itself. Drop-on-full semantics match Put.
+func (c *RedisExpiringCache[T]) Publish(key string, val *T, expiration time.Duration) {
+	c.enqueueSend(key, val, expiration)
+}
+
+// enqueueSend pushes an entry onto the send buffer for the background writer.
+// If the buffer is full the entry is dropped and a warning is logged so the
+// DNS path is never blocked. Entries with non-positive expiration are skipped.
+func (c *RedisExpiringCache[T]) enqueueSend(key string, val *T, expiration time.Duration) {
 	if expiration <= 0 {
 		return
 	}

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -52,11 +52,13 @@ type RedisOptions[T any] struct {
 	SendBufSize int
 }
 
-// reloadPublishable is implemented by inner caches that reload entries internally
+// ReloadPublishable is implemented by inner caches that reload entries internally
 // (e.g. the prefetching cache). The Redis decorator wires its write-through publish
 // in so those reloaded entries are synced like any other Put, without the inner cache
-// or its callers needing to know about Redis.
-type reloadPublishable[T any] interface {
+// or its callers needing to know about Redis. Implementations should add a
+// compile-time assertion against this interface so a signature drift fails to build
+// instead of silently disabling Redis sync of reloaded entries.
+type ReloadPublishable[T any] interface {
 	SetReloadPublisher(publish func(key string, val *T, ttl time.Duration))
 }
 
@@ -144,6 +146,13 @@ func NewRedisExpiringCache[T any](
 		logger:     log.PrefixedLog("redis-cache"),
 	}
 
+	// If the inner cache reloads entries internally (e.g. prefetching), wire our
+	// write-through publish BEFORE the startup scan and goroutines so reloads that
+	// fire during startup are buffered on sendBuf and synced rather than dropped.
+	if rp, ok := inner.(ReloadPublishable[T]); ok {
+		rp.SetReloadPublisher(c.publishWriteThrough)
+	}
+
 	// Blocking startup load.
 	if err := c.loadFromRedis(ctx); err != nil {
 		c.logger.WithError(err).Warn("startup Redis scan failed – starting with empty local cache")
@@ -151,12 +160,6 @@ func NewRedisExpiringCache[T any](
 
 	go c.runSubscriber(ctx)
 	go c.runWriter(ctx)
-
-	// If the inner cache reloads entries internally (e.g. prefetching), wire our
-	// write-through publish so reloaded entries are synced like any other Put.
-	if rp, ok := inner.(reloadPublishable[T]); ok {
-		rp.SetReloadPublisher(c.Publish)
-	}
 
 	return c, nil
 }
@@ -169,11 +172,14 @@ func (c *RedisExpiringCache[T]) Put(key string, val *T, expiration time.Duration
 	c.enqueueSend(key, val, expiration)
 }
 
-// Publish enqueues a non-blocking write-through to Redis WITHOUT storing the
-// value in the inner cache. It is used when the local store is handled
+// publishWriteThrough enqueues a non-blocking write-through to Redis WITHOUT
+// storing the value in the inner cache. It is used when the local store is handled
 // elsewhere – e.g. the prefetch reload path, where the underlying expiration
 // cache stores the reloaded value itself. Drop-on-full semantics match Put.
-func (c *RedisExpiringCache[T]) Publish(key string, val *T, expiration time.Duration) {
+//
+// It is named distinctly from the Redis pub/sub PUBLISH issued by flushBatch
+// (c.client.Publish) to avoid conflating the two.
+func (c *RedisExpiringCache[T]) publishWriteThrough(key string, val *T, expiration time.Duration) {
 	c.enqueueSend(key, val, expiration)
 }
 

--- a/cache/redis_test.go
+++ b/cache/redis_test.go
@@ -36,6 +36,18 @@ func newTestInner(ctx context.Context) ExpiringCache[testValue] {
 	return expirationcache.NewCache[testValue](ctx, expirationcache.Options{})
 }
 
+// reloadPublishableInner is an inner cache that reloads entries internally (like the
+// prefetching cache) and exposes SetReloadPublisher so the Redis decorator can wire in.
+type reloadPublishableInner struct {
+	ExpiringCache[testValue]
+
+	publisher func(key string, val *testValue, ttl time.Duration)
+}
+
+func (r *reloadPublishableInner) SetReloadPublisher(fn func(key string, val *testValue, ttl time.Duration)) {
+	r.publisher = fn
+}
+
 // defaultOpts returns a RedisOptions with the given prefix suitable for tests.
 func defaultOpts(prefix string) RedisOptions[testValue] {
 	return RedisOptions[testValue]{
@@ -122,6 +134,82 @@ var _ = Describe("RedisExpiringCache", func() {
 				}()
 
 				Eventually(done).WithTimeout(time.Second).Should(BeClosed())
+			})
+		})
+	})
+
+	Describe("Publish", func() {
+		When("a value is published", func() {
+			It("enqueues to Redis but does not store in the inner cache", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				DeferCleanup(cancel)
+
+				inner := newTestInner(ctx)
+				opts := defaultOpts("publish:")
+
+				c, err := NewRedisExpiringCache(ctx, inner, client, opts)
+				Expect(err).ToNot(HaveOccurred())
+
+				c.Publish("foo", &testValue{Data: "bar"}, time.Minute)
+
+				// Redis key must appear after async flush.
+				Eventually(func() bool {
+					exists, _ := client.Exists(ctx, "publish:foo").Result()
+
+					return exists > 0
+				}).WithTimeout(2 * time.Second).WithPolling(20 * time.Millisecond).Should(BeTrue())
+
+				// Inner cache must NOT have the entry: the local store is the caller's responsibility.
+				val, _ := inner.Get("foo")
+				Expect(val).To(BeNil())
+			})
+		})
+
+		When("expiration is zero", func() {
+			It("does not enqueue to Redis", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				DeferCleanup(cancel)
+
+				inner := newTestInner(ctx)
+				opts := defaultOpts("publish-zero:")
+
+				c, err := NewRedisExpiringCache(ctx, inner, client, opts)
+				Expect(err).ToNot(HaveOccurred())
+
+				c.Publish("foo", &testValue{Data: "bar"}, 0)
+
+				Consistently(func() bool {
+					exists, _ := client.Exists(ctx, "publish-zero:foo").Result()
+
+					return exists > 0
+				}).WithTimeout(300 * time.Millisecond).WithPolling(20 * time.Millisecond).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("reload publisher wiring", func() {
+		When("the inner cache reloads entries internally", func() {
+			It("wires its write-through publish into the inner cache", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				DeferCleanup(cancel)
+
+				inner := &reloadPublishableInner{ExpiringCache: newTestInner(ctx)}
+
+				c, err := NewRedisExpiringCache(ctx, inner, client, defaultOpts("reloadwire:"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c).ToNot(BeNil())
+
+				// The decorator must have wired a publisher into the inner cache.
+				Expect(inner.publisher).ToNot(BeNil())
+
+				// And the wired publisher writes through to Redis (without touching inner).
+				inner.publisher("rkey", &testValue{Data: "rv"}, time.Minute)
+
+				Eventually(func() bool {
+					exists, _ := client.Exists(ctx, "reloadwire:rkey").Result()
+
+					return exists > 0
+				}).WithTimeout(2 * time.Second).WithPolling(20 * time.Millisecond).Should(BeTrue())
 			})
 		})
 	})

--- a/cache/redis_test.go
+++ b/cache/redis_test.go
@@ -138,7 +138,7 @@ var _ = Describe("RedisExpiringCache", func() {
 		})
 	})
 
-	Describe("Publish", func() {
+	Describe("publishWriteThrough", func() {
 		When("a value is published", func() {
 			It("enqueues to Redis but does not store in the inner cache", func() {
 				ctx, cancel := context.WithCancel(context.Background())
@@ -150,7 +150,7 @@ var _ = Describe("RedisExpiringCache", func() {
 				c, err := NewRedisExpiringCache(ctx, inner, client, opts)
 				Expect(err).ToNot(HaveOccurred())
 
-				c.Publish("foo", &testValue{Data: "bar"}, time.Minute)
+				c.publishWriteThrough("foo", &testValue{Data: "bar"}, time.Minute)
 
 				// Redis key must appear after async flush.
 				Eventually(func() bool {
@@ -176,7 +176,7 @@ var _ = Describe("RedisExpiringCache", func() {
 				c, err := NewRedisExpiringCache(ctx, inner, client, opts)
 				Expect(err).ToNot(HaveOccurred())
 
-				c.Publish("foo", &testValue{Data: "bar"}, 0)
+				c.publishWriteThrough("foo", &testValue{Data: "bar"}, 0)
 
 				Consistently(func() bool {
 					exists, _ := client.Exists(ctx, "publish-zero:foo").Result()

--- a/e2e/redis_test.go
+++ b/e2e/redis_test.go
@@ -359,15 +359,19 @@ var _ = Describe("Redis configuration tests", func() {
 						Should(BeNumerically("==", 1))
 				})
 
-				By("waiting for the original Redis entry (2s TTL) to expire", func() {
-					Eventually(dbSize, "10s", "100ms").WithArguments(ctx, redisClient).
-						Should(BeNumerically("==", 0))
+				By("flushing Redis to deterministically simulate the original SET expiring", func() {
+					// Flushing (instead of racing the natural 2s TTL) removes the flaky
+					// dependency on catching the brief empty window between expiry and the
+					// next ~5s cleanup republish. The local entry is untouched.
+					Expect(redisClient.FlushDB(ctx).Err()).Should(Succeed())
+					Expect(dbSize(ctx, redisClient)).Should(BeNumerically("==", 0))
 				})
 
 				By("verifying a prefetch reload re-publishes the entry to Redis", func() {
-					// The entry can only reappear via a prefetch reload re-publish (#1422):
-					// the original SET expired and no client query refreshed it.
-					Eventually(dbSize, "10s", "100ms").WithArguments(ctx, redisClient).
+					// Nothing re-queries the domain, so the entry can only reappear via a
+					// prefetch reload re-publish (#1422): the local entry's TTL expires and
+					// the ~5s cache cleanup reloads it and writes it through to Redis.
+					Eventually(dbSize, "15s", "100ms").WithArguments(ctx, redisClient).
 						Should(BeNumerically(">=", 1))
 				})
 

--- a/e2e/redis_test.go
+++ b/e2e/redis_test.go
@@ -322,6 +322,62 @@ var _ = Describe("Redis configuration tests", func() {
 		})
 	})
 
+	Describe("Prefetch sync via Redis", func() {
+		When("Redis and a prefetching blocky instance are configured", func() {
+			BeforeEach(func(ctx context.Context) {
+				// Short upstream TTL so prefetch reloads (driven by the ~5s cache cleanup)
+				// fire within the test window.
+				_, err = createDNSMokkaContainer(ctx, "moka2", e2eNet,
+					`A google/NOERROR("A 1.2.3.4 2")`,
+				)
+				Expect(err).Should(Succeed())
+
+				blocky1, err = createBlockyContainerFromString(ctx, e2eNet, dedent(`
+					log:
+					  level: warn
+					upstreams:
+					  groups:
+					    default:
+					      - moka2
+					caching:
+					  prefetching: true
+					  prefetchThreshold: 0
+					redis:
+					  address: redis:6379
+					`))
+				Expect(err).Should(Succeed())
+			})
+
+			It("re-publishes prefetched entries to Redis after the original TTL expires", func(ctx context.Context) {
+				msg := util.NewMsgWithQuestion("google.de.", A)
+
+				By("querying once to populate the local cache and Redis", func() {
+					Eventually(doDNSRequest, "5s", "2ms").WithArguments(ctx, blocky1, msg).
+						Should(BeDNSRecord("google.de.", A, "1.2.3.4"))
+
+					Eventually(dbSize, "5s", "100ms").WithArguments(ctx, redisClient).
+						Should(BeNumerically("==", 1))
+				})
+
+				By("waiting for the original Redis entry (2s TTL) to expire", func() {
+					Eventually(dbSize, "10s", "100ms").WithArguments(ctx, redisClient).
+						Should(BeNumerically("==", 0))
+				})
+
+				By("verifying a prefetch reload re-publishes the entry to Redis", func() {
+					// The entry can only reappear via a prefetch reload re-publish (#1422):
+					// the original SET expired and no client query refreshed it.
+					Eventually(dbSize, "10s", "100ms").WithArguments(ctx, redisClient).
+						Should(BeNumerically(">=", 1))
+				})
+
+				By("No warnings/errors in log", func() {
+					Expect(getContainerLogs(ctx, blocky1)).Should(BeEmpty())
+				})
+			})
+		})
+	})
+
 	Describe("Multiple query types via Redis cache", func() {
 		When("both A and AAAA queries are cached", func() {
 			BeforeEach(func(ctx context.Context) {

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -167,7 +167,11 @@ func (r *CachingResolver) reloadCacheEntry(ctx context.Context, cacheKey string)
 		return nil, 0
 	}
 
-	packed, err := response.Res.Pack()
+	// strip EDNS0 OPT records so prefetched entries match the normal putInCache path
+	respCopy := response.Res.Copy()
+	util.RemoveEdns0Record(respCopy)
+
+	packed, err := respCopy.Pack()
 	if err != nil {
 		logger.Error("unable to pack response", err)
 

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -163,22 +163,22 @@ func (r *CachingResolver) reloadCacheEntry(ctx context.Context, cacheKey string)
 		return nil, 0
 	}
 
-	if response.Res.Rcode != dns.RcodeSuccess {
+	// only refresh entries the normal put path would cache: successful, not
+	// truncated and without the CD flag (mirrors putInCache).
+	if response.Res.Rcode != dns.RcodeSuccess || !isResponseCacheable(response.Res) {
 		return nil, 0
 	}
 
-	// strip EDNS0 OPT records so prefetched entries match the normal putInCache path
-	respCopy := response.Res.Copy()
-	util.RemoveEdns0Record(respCopy)
+	// clamp the record TTLs before packing so the stored (and Redis-synced) bytes
+	// carry the same TTLs the normal put path produces.
+	ttl := r.adjustTTLs(response.Res.Answer)
 
-	packed, err := respCopy.Pack()
+	packed, err := packForCache(ctx, response.Res)
 	if err != nil {
-		logger.Error("unable to pack response", err)
-
 		return nil, 0
 	}
 
-	return &packed, r.adjustTTLs(response.Res.Answer)
+	return &packed, ttl
 }
 
 // LogConfig implements `config.Configurable`.
@@ -309,26 +309,34 @@ func isResponseCacheable(msg *dns.Msg) bool {
 	return !msg.Truncated && !msg.CheckingDisabled
 }
 
+// packForCache copies the message, strips EDNS0 OPT records (which must never be
+// cached) and returns the packed wire bytes. Both the normal put path and the
+// prefetch reload path use it so cached and prefetched entries are byte-identical.
+func packForCache(ctx context.Context, msg *dns.Msg) ([]byte, error) {
+	msgCopy := msg.Copy()
+	util.RemoveEdns0Record(msgCopy)
+
+	packed, err := msgCopy.Pack()
+	util.LogOnError(ctx, "error on packing", err)
+
+	return packed, err
+}
+
 func (r *CachingResolver) putInCache(
 	ctx context.Context, cacheKey string, response *model.Response, ttl time.Duration,
 ) {
-	respCopy := response.Res.Copy()
+	packed, err := packForCache(ctx, response.Res)
+	if err != nil {
+		return
+	}
 
-	// don't cache any EDNS OPT records
-	util.RemoveEdns0Record(respCopy)
-
-	packed, err := respCopy.Pack()
-	util.LogOnError(ctx, "error on packing", err)
-
-	if err == nil {
-		if response.Res.Rcode == dns.RcodeSuccess && isResponseCacheable(response.Res) {
-			// put value into cache
-			r.resultCache.Put(cacheKey, &packed, ttl)
-		} else if response.Res.Rcode == dns.RcodeNameError {
-			if r.cfg.CacheTimeNegative.IsAboveZero() {
-				// put negative cache if result code is NXDOMAIN
-				r.resultCache.Put(cacheKey, &packed, r.cfg.CacheTimeNegative.ToDuration())
-			}
+	if response.Res.Rcode == dns.RcodeSuccess && isResponseCacheable(response.Res) {
+		// put value into cache
+		r.resultCache.Put(cacheKey, &packed, ttl)
+	} else if response.Res.Rcode == dns.RcodeNameError {
+		if r.cfg.CacheTimeNegative.IsAboveZero() {
+			// put negative cache if result code is NXDOMAIN
+			r.resultCache.Put(cacheKey, &packed, r.cfg.CacheTimeNegative.ToDuration())
 		}
 	}
 }

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -761,6 +761,52 @@ var _ = Describe("CachingResolver", func() {
 				Expect(msg.Answer).Should(HaveLen(1))
 			})
 		})
+
+		When("the reloaded response is truncated", func() {
+			BeforeEach(func() {
+				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 123, A, "1.2.3.4")
+				mockAnswer.Truncated = true
+			})
+
+			It("is not cached or published (matches putInCache's isResponseCacheable gate)", func() {
+				packed, ttl := sut.reloadCacheEntry(ctx, cacheKey)
+				Expect(packed).Should(BeNil())
+				Expect(ttl).Should(BeZero())
+			})
+		})
+
+		When("the reloaded response has the CD flag set", func() {
+			BeforeEach(func() {
+				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 123, A, "1.2.3.4")
+				mockAnswer.CheckingDisabled = true
+			})
+
+			It("is not cached or published (matches putInCache's isResponseCacheable gate)", func() {
+				packed, ttl := sut.reloadCacheEntry(ctx, cacheKey)
+				Expect(packed).Should(BeNil())
+				Expect(ttl).Should(BeZero())
+			})
+		})
+
+		When("a maximum caching time is configured", func() {
+			BeforeEach(func() {
+				sutConfig.MaxCachingTime = config.Duration(time.Minute)
+				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 3600, A, "1.2.3.4")
+			})
+
+			It("clamps the TTL baked into the packed value, not just the returned TTL", func() {
+				packed, ttl := sut.reloadCacheEntry(ctx, cacheKey)
+				Expect(packed).ShouldNot(BeNil())
+				Expect(ttl).Should(Equal(time.Minute))
+
+				msg := new(dns.Msg)
+				Expect(msg.Unpack(*packed)).Should(Succeed())
+				Expect(msg.Answer).Should(HaveLen(1))
+				// the clamped TTL must be packed, otherwise the stored/Redis-synced
+				// bytes would carry the raw upstream TTL (3600).
+				Expect(msg.Answer[0].Header().Ttl).Should(Equal(uint32(60)))
+			})
+		})
 	})
 
 	Context("isRequestCacheable", func() {

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -717,6 +717,52 @@ var _ = Describe("CachingResolver", func() {
 		})
 	})
 
+	Describe("reloadCacheEntry (prefetch reload)", func() {
+		var cacheKey string
+
+		BeforeEach(func() {
+			cacheKey = util.GenerateCacheKey(dns.Type(dns.TypeA), "example.com")
+		})
+
+		When("the reloaded response contains EDNS0 OPT records", func() {
+			BeforeEach(func() {
+				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 123, A, "1.2.3.4")
+				opt := new(dns.OPT)
+				opt.Hdr.Name = "."
+				opt.Hdr.Rrtype = dns.TypeOPT
+				opt.Option = append(opt.Option, &dns.EDNS0_COOKIE{Code: dns.EDNS0COOKIE, Cookie: "0102030405060708"})
+				mockAnswer.Extra = append(mockAnswer.Extra, opt)
+			})
+
+			It("strips the OPT records from the stored value", func() {
+				packed, ttl := sut.reloadCacheEntry(ctx, cacheKey)
+				Expect(packed).ShouldNot(BeNil())
+				Expect(ttl).Should(BeNumerically(">", 0))
+
+				msg := new(dns.Msg)
+				Expect(msg.Unpack(*packed)).Should(Succeed())
+				Expect(msg.Answer).Should(HaveLen(1))
+				Expect(msg.Extra).Should(BeEmpty())
+			})
+		})
+
+		When("the response is successful", func() {
+			BeforeEach(func() {
+				mockAnswer, _ = util.NewMsgWithAnswer("example.com.", 123, A, "1.2.3.4")
+			})
+
+			It("returns the packed value and TTL", func() {
+				packed, ttl := sut.reloadCacheEntry(ctx, cacheKey)
+				Expect(packed).ShouldNot(BeNil())
+				Expect(ttl).Should(BeNumerically(">", 0))
+
+				msg := new(dns.Msg)
+				Expect(msg.Unpack(*packed)).Should(Succeed())
+				Expect(msg.Answer).Should(HaveLen(1))
+			})
+		})
+	})
+
 	Context("isRequestCacheable", func() {
 		var request *Request
 		When("request is not cacheable", func() {


### PR DESCRIPTION
## What

Prefetched cache entries are now written through to Redis (and propagated to peer instances), and the prefetch reload path is aligned with the normal `putInCache` path.

Closes #1422.

## Why

The prefetching cache reloads entries internally in a background cleanup goroutine (`PrefetchingExpiringLRUCache.onExpired`), storing them directly in the inner expiration cache and thereby **bypassing** the Redis write-through decorator. Refreshed/prefetched entries were therefore never synced to Redis or to other blocky instances.

## How

**Feature (`ceac6af`)**
- Prefetching cache exposes a `reloadPublisher` hook (`atomic.Pointer`), invoked for each reloaded entry.
- The Redis decorator type-asserts the inner cache to `ReloadPublishable[T]` and wires its write-through publish in, so reloaded entries are synced like any other `Put` — without the inner cache or its callers needing to know about Redis.
- `reloadCacheEntry` strips EDNS0 OPT records so prefetched entries match cached ones.

**Review hardening (`008fad2`)**
- `reloadCacheEntry` now applies the same `isResponseCacheable` (Truncated/CD) gate as `putInCache`, so non-cacheable responses are no longer stored or synced to peers.
- Record TTLs are clamped (`adjustTTLs`) **before** packing, so the stored/synced bytes carry clamped TTLs rather than raw upstream values.
- Extracted a shared `packForCache` helper (the copy+strip+pack sequence was duplicated verbatim).
- Publisher is wired **before** the startup scan/goroutines so reloads firing during startup are buffered, not dropped.
- `ReloadPublishable` is exported with a compile-time assertion on the prefetching cache, so a signature drift fails the build instead of silently disabling sync.
- Renamed the write-through method to unexported `publishWriteThrough` to avoid conflation with the Redis pub/sub PUBLISH.
- Skip the reload publish for non-positive TTLs.

## Tests

- Unit tests for the reload publisher wiring, the `publishWriteThrough` semantics, the Truncated/CD gate, and the TTL-clamp-in-packed-bytes.
- e2e test proves a prefetched entry is re-published to Redis after the original SET expires (deterministic via `FlushDB`).

All non-e2e packages pass locally (`go test`, `go vet`, `gofmt` clean). The e2e suite needs Docker — please confirm on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)