### PR TITLE
ci: cross-compile multi-arch docker image instead of QEMU emulation

### DIFF
--- a/.github/workflows/development-docker.yml
+++ b/.github/workflows/development-docker.yml
@@ -63,11 +63,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: arm,arm64
-
+      # No QEMU needed: the image is built by cross-compiling on the native
+      # build platform (see Dockerfile), nothing runs in the target arch.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,8 @@ jobs:
         with:
           images: spx01/blocky,ghcr.io/0xerr0r/blocky
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: arm,arm64
-
+      # No QEMU needed: the image is built by cross-compiling on the native
+      # build platform (see Dockerfile), nothing runs in the target arch.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # syntax=docker/dockerfile:1
 
 # ----------- stage: build
-FROM golang:alpine AS build
+# Pin the build stage to the native build platform and cross-compile to the
+# target platform. The build is CGO-free and the final stage is `scratch`, so
+# nothing ever runs in the target arch at build time - this avoids compiling the
+# Go toolchain under slow QEMU emulation for the arm targets.
+FROM --platform=$BUILDPLATFORM golang:alpine AS build
 RUN apk add --no-cache make coreutils libcap
 
 # Arguments needed for dependency download
@@ -30,7 +34,12 @@ COPY . .
 ARG VERSION
 ARG BUILD_TIME
 
-RUN make build
+# Target platform args populated automatically by BuildKit; cross-compile to them
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} make build
 
 # ----------- stage: final
 FROM scratch


### PR DESCRIPTION
## Problem

The **Development docker build** workflow takes 30+ minutes. The `Build and push` step builds a 4-platform image (`linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64`) and compiles the Go toolchain *inside each target platform's image*. The three arm targets therefore run the entire compile **under QEMU emulation**, which is ~5–15× slower than native and dominates the runtime.

This emulation is unnecessary: the build is CGO-free (`CGO_ENABLED=0`, pure static binary) and the final stage is `FROM scratch` + `COPY`, so nothing ever *executes* in the target architecture at build time.

## Change

- Pin the build stage to `--platform=$BUILDPLATFORM` (the native amd64 runner) and let Go **cross-compile** to the target via the BuildKit-provided `$TARGETOS`/`$TARGETARCH`/`$TARGETVARIANT` args (`${TARGETVARIANT#v}` → `GOARM`). All four architectures now compile natively.
- Drop the now-redundant `Set up QEMU` step from the **build** job (no longer needed to build). The `image-test` job keeps its own QEMU setup, since it runs the arm binaries.

No change to the published images: same 4 platforms, same contents — only *how* they're compiled.

## Result

Cold build drops from **30+ min → ~2 min**.

## Testing

Reproduced CI's pipeline locally: built the full 4-platform manifest list, pushed it to a throwaway local registry, then pulled and ran `blocky version` on each architecture via QEMU.

- Manifest list contains exactly the 4 expected platforms.
- Each binary runs on its target arch and self-reports the correct architecture (the `Architecture` string is `GOARCH`+`GOARM`):

  | Platform | Reported architecture |
  |----------|----------------------|
  | linux/amd64 | `amd64` |
  | linux/arm/v6 | `arm6` |
  | linux/arm/v7 | `arm7` |
  | linux/arm64 | `arm64` |

This confirms each platform was cross-compiled correctly (not accidentally all-amd64) and the `v6`→`6` / `v7`→`7` `GOARM` mapping is right.