### PR TITLE
fix(querylog): build SQLite target only on modernc-supported platforms

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -989,6 +989,9 @@ You can select one of following query log types:
 
 The `sqlite` target stores the query log in a single local file (set via `queryLog.target`, e.g. `/var/lib/blocky/querylog.db`) — no external database is required. Blocky creates the file and its parent directory automatically.
 
+!!! note
+    The `sqlite` target is not available on every platform. It relies on a pure-Go SQLite driver that does not support all CPU architectures, so it is **not** compiled into the official builds for **`linux/mips`, `linux/mipsle`, `netbsd/arm`, `netbsd/arm64` and `openbsd/arm`**. On those builds, selecting `sqlite` fails at startup with a clear error message — use the `csv`, `mysql` or `postgresql` query log target instead. All other targets (including `linux/amd64`, `linux/arm`, `linux/arm64`, `windows/amd64` and `darwin`) support `sqlite`.
+
 Set `queryLog.target` to a **plain filesystem path**. Do **not** prefix it with `file:` — for query-log targets that prefix means "read the target value from this file" (see the [Redis tip](#redis)), so `file:/var/lib/blocky/querylog.db` would be treated as a file to read the path *from*, not as the database itself.
 
 Blocky opens the database in **WAL (Write-Ahead Logging) mode** automatically; you do not need to configure this. As a result the database is written as three files next to each other: `querylog.db`, `querylog.db-wal` and `querylog.db-shm`. When running in Docker, mount the **directory** (not just the `.db` file) as a volume so all three files persist, and include all three in any backup.

--- a/querylog/database_writer.go
+++ b/querylog/database_writer.go
@@ -2,10 +2,7 @@ package querylog
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -20,7 +17,6 @@ import (
 
 	"github.com/0xERR0R/blocky/util"
 
-	"github.com/glebarez/sqlite"
 	"golang.org/x/net/publicsuffix"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
@@ -50,27 +46,6 @@ type DatabaseWriter struct {
 	dbFlushPeriod    time.Duration
 }
 
-// sqliteBusyTimeoutMs is the SQLite busy_timeout (in ms) applied to the query-log
-// connection so transient lock contention with external readers is retried, not failed.
-const sqliteBusyTimeoutMs = 5000
-
-// sqliteDirPermission is the permission used when creating the parent directory of the sqlite database file.
-const sqliteDirPermission os.FileMode = 0o750
-
-// buildSQLiteDSN turns a filesystem path into a modernc/glebarez SQLite DSN with
-// WAL journaling enabled. The "file:" prefix selects SQLite's URI filename mode,
-// the canonical form for passing connection options as query parameters. Because
-// that mode runs the path through SQLite's URI parser, the path is percent-encoded
-// first: otherwise a path containing "?" or "#" would be truncated (silently
-// opening a different file, possibly without WAL) and "%xx" would be decoded into
-// a different path. "%" is encoded first as it is the escape character itself;
-// strings.Replacer never re-scans its own output, so the inserted "%25" is safe.
-func buildSQLiteDSN(path string) string {
-	encodedPath := strings.NewReplacer("%", "%25", "?", "%3F", "#", "%23").Replace(path)
-
-	return fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(%d)", encodedPath, sqliteBusyTimeoutMs)
-}
-
 func NewDatabaseWriter(ctx context.Context, dbType config.QueryLogType, target string, logRetentionDays uint64,
 	dbFlushPeriod time.Duration,
 ) (*DatabaseWriter, error) {
@@ -80,15 +55,12 @@ func NewDatabaseWriter(ctx context.Context, dbType config.QueryLogType, target s
 	case config.QueryLogTypePostgresql, config.QueryLogTypeTimescale:
 		return newDatabaseWriter(ctx, postgres.Open(target), logRetentionDays, dbFlushPeriod, dbType)
 	case config.QueryLogTypeSqlite:
-		if target == "" {
-			return nil, errors.New("sqlite query log requires a target file path")
+		dialector, err := newSQLiteDialector(target)
+		if err != nil {
+			return nil, err
 		}
 
-		if err := os.MkdirAll(filepath.Dir(target), sqliteDirPermission); err != nil {
-			return nil, fmt.Errorf("can't create directory for sqlite database: %w", err)
-		}
-
-		return newDatabaseWriter(ctx, sqlite.Open(buildSQLiteDSN(target)), logRetentionDays, dbFlushPeriod, dbType)
+		return newDatabaseWriter(ctx, dialector, logRetentionDays, dbFlushPeriod, dbType)
 	}
 
 	return nil, fmt.Errorf("incorrect database type provided: %s", dbType)

--- a/querylog/database_writer_sqlite.go
+++ b/querylog/database_writer_sqlite.go
@@ -1,0 +1,63 @@
+//go:build !mips && !mipsle && !mips64 && !mips64le && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64)
+
+// SQLite support is compiled in only on the GOOS/GOARCH targets supported by the
+// pure-Go driver chain (github.com/glebarez/sqlite -> modernc.org/sqlite ->
+// modernc.org/libc). modernc ships no MIPS support at all and only a subset of the
+// BSD architectures (netbsd/amd64, openbsd/amd64+arm64), so the remaining release
+// targets compile the stub in database_writer_sqlite_unsupported.go instead. This
+// keeps the cross-compiled release build working (without SQLite query log there).
+// Revisit this list when the modernc.org/sqlite dependency is upgraded.
+
+package querylog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// sqliteBusyTimeoutMs is the SQLite busy_timeout (in ms) applied to the query-log
+// connection so transient lock contention with external readers is retried, not failed.
+const sqliteBusyTimeoutMs = 5000
+
+// sqliteDirPermission is the permission used when creating the parent directory of the sqlite database file.
+const sqliteDirPermission os.FileMode = 0o750
+
+// newSQLiteDialector validates the target path, ensures its parent directory exists
+// and returns a gorm dialector backed by the pure-Go (modernc) SQLite driver.
+//
+// The pure-Go driver (github.com/glebarez/sqlite -> modernc.org/sqlite ->
+// modernc.org/libc) only supports a subset of the release build targets, so this
+// implementation is compiled in everywhere except those platforms. See
+// database_writer_sqlite_unsupported.go for the stub used on the remaining targets
+// (e.g. mips/mipsle).
+func newSQLiteDialector(target string) (gorm.Dialector, error) {
+	if target == "" {
+		return nil, errors.New("sqlite query log requires a target file path")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), sqliteDirPermission); err != nil {
+		return nil, fmt.Errorf("can't create directory for sqlite database: %w", err)
+	}
+
+	return sqlite.Open(buildSQLiteDSN(target)), nil
+}
+
+// buildSQLiteDSN turns a filesystem path into a modernc/glebarez SQLite DSN with
+// WAL journaling enabled. The "file:" prefix selects SQLite's URI filename mode,
+// the canonical form for passing connection options as query parameters. Because
+// that mode runs the path through SQLite's URI parser, the path is percent-encoded
+// first: otherwise a path containing "?" or "#" would be truncated (silently
+// opening a different file, possibly without WAL) and "%xx" would be decoded into
+// a different path. "%" is encoded first as it is the escape character itself;
+// strings.Replacer never re-scans its own output, so the inserted "%25" is safe.
+func buildSQLiteDSN(path string) string {
+	encodedPath := strings.NewReplacer("%", "%25", "?", "%3F", "#", "%23").Replace(path)
+
+	return fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(%d)", encodedPath, sqliteBusyTimeoutMs)
+}

--- a/querylog/database_writer_sqlite_unsupported.go
+++ b/querylog/database_writer_sqlite_unsupported.go
@@ -22,5 +22,5 @@ import (
 // target on these platforms.
 func newSQLiteDialector(_ string) (gorm.Dialector, error) {
 	return nil, fmt.Errorf("sqlite query log is not supported on this platform (%s/%s); "+
-		"use the csv, mysql or postgresql query log target instead", runtime.GOOS, runtime.GOARCH)
+		"use the csv, mysql, postgresql or timescale query log target instead", runtime.GOOS, runtime.GOARCH)
 }

--- a/querylog/database_writer_sqlite_unsupported.go
+++ b/querylog/database_writer_sqlite_unsupported.go
@@ -1,0 +1,26 @@
+//go:build mips || mipsle || mips64 || mips64le || (netbsd && !amd64) || (openbsd && !amd64 && !arm64)
+
+// This is the exact complement of the constraint in database_writer_sqlite.go: the
+// GOOS/GOARCH targets where the pure-Go SQLite driver chain (github.com/glebarez/
+// sqlite -> modernc.org/sqlite) ships no generated code, e.g. linux/mips,
+// linux/mipsle, netbsd/arm and openbsd/arm. Keep the two constraints in sync.
+
+package querylog
+
+import (
+	"fmt"
+	"runtime"
+
+	"gorm.io/gorm"
+)
+
+// newSQLiteDialector is the stub compiled on platforms where the pure-Go SQLite
+// driver (github.com/glebarez/sqlite -> modernc.org/sqlite -> modernc.org/libc)
+// has no support, e.g. mips/mipsle. Excluding the driver keeps these release
+// targets buildable; configuring the "sqlite" query log on such a build returns a
+// clear error instead of failing to compile. Use the csv, mysql or postgresql
+// target on these platforms.
+func newSQLiteDialector(_ string) (gorm.Dialector, error) {
+	return nil, fmt.Errorf("sqlite query log is not supported on this platform (%s/%s); "+
+		"use the csv, mysql or postgresql query log target instead", runtime.GOOS, runtime.GOARCH)
+}

--- a/querylog/database_writer_test.go
+++ b/querylog/database_writer_test.go
@@ -1,3 +1,5 @@
+//go:build !mips && !mipsle && !mips64 && !mips64le && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64)
+
 package querylog
 
 import (


### PR DESCRIPTION
## Problem

The release build (`goreleaser build --clean --snapshot`, `CGO_ENABLED=0`) fails since #2080. Example failed run: https://github.com/0xERR0R/blocky/actions/runs/26934692273/job/79461568925

```
build constraints exclude all Go files in .../modernc.org/libc@v1.22.5/...
  imports github.com/glebarez/sqlite → glebarez/go-sqlite → modernc.org/libc
```

#2080 swapped the query-log SQLite driver from the CGO `mattn/go-sqlite3` to the pure-Go chain `github.com/glebarez/sqlite` → `modernc.org/sqlite` → `modernc.org/libc`. That chain ships per-architecture generated code for only a **subset** of the release matrix, so cross-compiling to the unsupported targets fails to build.

Affected release targets (modernc ships no MIPS at all, and only partial BSD support):
`linux/mips`, `linux/mipsle`, `netbsd/arm`, `netbsd/arm64`, `openbsd/arm`.

The old CGO driver compiled to a stub on every arch under `CGO_ENABLED=0` (it only errored at runtime), which is why the release built before — but it also means SQLite query log never actually worked on the official (CGO-free) release binaries prior to #2080.

## Fix

Move the SQLite dialector behind a build constraint so it is compiled in only on the GOOS/GOARCH combinations `modernc.org/sqlite` actually supports. On the remaining targets a stub `newSQLiteDialector` returns a clear runtime error and imports no sqlite/modernc code, so those binaries build again. Users on those platforms get a clear "use csv/mysql/postgresql" message instead of a broken release.

- `querylog/database_writer.go` — drop the direct `glebarez/sqlite` import; route the SQLite case through `newSQLiteDialector`.
- `querylog/database_writer_sqlite.go` *(new)* — real implementation, the only place `glebarez/sqlite` is imported.
- `querylog/database_writer_sqlite_unsupported.go` *(new)* — stub for unsupported targets.
- `querylog/database_writer_test.go` — same build constraint (imports the driver directly).

No dependency or `go.mod` changes. Note: bumping the modernc chain could later re-enable `netbsd/arm` / `openbsd/arm`, but **never MIPS**, so the gating is required regardless.

## Verification

- `go build ./...` with `CGO_ENABLED=0` across **all 17** release GOOS/GOARCH targets — pass.
- `go vet ./querylog/...` and `go test ./querylog/...` — pass.
- Full `goreleaser build --clean --snapshot` (v2.16.0, the CI version) — **build succeeded**, all 21 binaries produced including the previously-failing ones.
- Confirmed at the binary level: the `linux/mips` binary contains the stub message and no `modernc.org/sqlite`; the `linux/amd64` binary contains the real driver and not the stub.