### PR TITLE
feat(querylog): ignore domains (exact/wildcard/regex) in query log

### DIFF
--- a/config/query_log.go
+++ b/config/query_log.go
@@ -32,6 +32,9 @@ type QueryLog struct {
 type QueryLogIgnore struct {
 	// If true, queries resolved as Special Use Domain Names (SUDN) are not logged.
 	SUDN bool `default:"false" yaml:"sudn"`
+	// Domains whose queries are not logged. Each entry is an exact domain,
+	// a *.wildcard, or a /regex/ — same syntax as blocklists.
+	Domains []string `yaml:"domains"`
 }
 
 // SetDefaults implements `defaults.Setter`.
@@ -62,7 +65,16 @@ func (c *QueryLog) LogConfig(logger *logrus.Entry) {
 
 	logger.Infof("ignore:")
 	log.WithIndent(logger, "  ", func(e *logrus.Entry) {
-		logger.Infof("sudn: %t", c.Ignore.SUDN)
+		e.Infof("sudn: %t", c.Ignore.SUDN)
+
+		if len(c.Ignore.Domains) > 0 {
+			e.Infof("domains (%d):", len(c.Ignore.Domains))
+			log.WithIndent(e, "  ", func(e *logrus.Entry) {
+				for _, d := range c.Ignore.Domains {
+					e.Debugf("- %s", d)
+				}
+			})
+		}
 	})
 }
 

--- a/config/query_log.go
+++ b/config/query_log.go
@@ -32,8 +32,8 @@ type QueryLog struct {
 type QueryLogIgnore struct {
 	// If true, queries resolved as Special Use Domain Names (SUDN) are not logged.
 	SUDN bool `default:"false" yaml:"sudn"`
-	// Domains whose queries are not logged. Each entry is an exact domain,
-	// a *.wildcard, or a /regex/ — same syntax as blocklists.
+	// Domains whose queries are not logged. Each entry is matched against the
+	// query name as an exact domain, a *.wildcard, or a /regex/.
 	Domains []string `yaml:"domains"`
 }
 

--- a/config/query_log_test.go
+++ b/config/query_log_test.go
@@ -66,7 +66,6 @@ var _ = Describe("QueryLogConfig", func() {
 			cfg.LogConfig(logger)
 
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("domains (3):")))
-
 		})
 
 		DescribeTable("secret censoring", func(target string) {

--- a/config/query_log_test.go
+++ b/config/query_log_test.go
@@ -60,6 +60,15 @@ var _ = Describe("QueryLogConfig", func() {
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("sudn:")))
 		})
 
+		It("should log the ignored domains", func() {
+			cfg.Ignore.Domains = []string{"example.com", "*.lan", "/\\.arpa$/"}
+
+			cfg.LogConfig(logger)
+
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("domains (3):")))
+
+		})
+
 		DescribeTable("secret censoring", func(target string) {
 			cfg.Type = QueryLogTypeMysql
 			cfg.Target = Secret(target)
@@ -74,6 +83,16 @@ var _ = Describe("QueryLogConfig", func() {
 			Entry("no password", "localhost"),
 			Entry("not a URL", "invalid!://"),
 		)
+	})
+
+	Describe("ignore.domains parsing", func() {
+		It("parses the domains list", func() {
+			yamlStr := "type: console\nignore:\n  domains:\n    - example.com\n    - \"*.lan\"\n"
+
+			var qlCfg QueryLog
+			Expect(yaml.UnmarshalStrict([]byte(yamlStr), &qlCfg)).Should(Succeed())
+			Expect(qlCfg.Ignore.Domains).Should(Equal([]string{"example.com", "*.lan"}))
+		})
 	})
 
 	Describe("secret target handling", func() {

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -761,6 +761,13 @@
               "type": "boolean",
               "description": "If true, queries resolved as Special Use Domain Names (SUDN) are not logged.",
               "default": false
+            },
+            "domains": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "Domains whose queries are not logged. Each entry is matched against the\nquery name as an exact domain, a *.wildcard, or a /regex/."
             }
           },
           "additionalProperties": false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1034,6 +1034,8 @@ Configuration parameters:
 | queryLog.creationCooldown | duration format                                                                      | no        | 2s            | Time between the creation attempts                                                            |
 | queryLog.fields           | list enum (clientIP, clientName, responseReason, responseAnswer, question, duration) | no        | all           | which information should be logged                                                            |
 | queryLog.flushInterval    | duration format                                                                      | no        | 30s           | Interval to write buffered entries in bulk to the database (mysql/postgresql/timescale/sqlite)|
+| queryLog.ignore.sudn      | bool                                                                                 | no        | false         | if true, queries answered as Special Use Domain Names (SUDN) are not logged                   |
+| queryLog.ignore.domains   | list of string                                                                       | no        |               | domains excluded from the query log; each entry is an exact domain, a `*.wildcard`, or a `/regex/` (same syntax as blocklists) |
 
 !!! hint
 
@@ -1079,6 +1081,22 @@ Parsing is handled not by Blocky, but third-party libraries, therefore the full 
       type: mysql
       target: 'username:password@tcp(localhost:3306)/blocky_query_log?charset=utf8mb4&parseTime=True&loc=Local&timeout=15s'
       logRetentionDays: 7
+    ```
+
+!!! example
+    **Ignore noisy domains**
+
+    ```yaml
+    queryLog:
+      type: postgresql
+      target: postgres://user:password@db:5432/blocky_query_log
+      ignore:
+        sudn: true
+        domains:
+          - "*._dns-sd._udp.home"
+          - "db._dns-sd._udp.home"
+          - "/\\.in-addr\\.arpa$/"
+          - "apple.com"
     ```
 
 ## Hosts file

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1035,7 +1035,7 @@ Configuration parameters:
 | queryLog.fields           | list enum (clientIP, clientName, responseReason, responseAnswer, question, duration) | no        | all           | which information should be logged                                                            |
 | queryLog.flushInterval    | duration format                                                                      | no        | 30s           | Interval to write buffered entries in bulk to the database (mysql/postgresql/timescale/sqlite)|
 | queryLog.ignore.sudn      | bool                                                                                 | no        | false         | if true, queries answered as Special Use Domain Names (SUDN) are not logged                   |
-| queryLog.ignore.domains   | list of string                                                                       | no        |               | domains excluded from the query log; each entry is an exact domain, a `*.wildcard`, or a `/regex/` (same syntax as blocklists) |
+| queryLog.ignore.domains   | list of string                                                                       | no        |               | domains excluded from the query log; each entry is matched against the query name as an exact domain, a `*.wildcard`, or a `/regex/` |
 
 !!! hint
 

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/0xERR0R/blocky/cache/stringcache"
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
@@ -15,6 +17,7 @@ import (
 	"github.com/0xERR0R/blocky/util"
 	"github.com/avast/retry-go/v4"
 	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -22,6 +25,7 @@ const (
 	queryLoggingResolverType = "query_logging"
 	logChanCap               = 1000
 	defaultClientIP          = "0.0.0.0"
+	queryLogIgnoreGroup      = "ignore"
 )
 
 // QueryLoggingResolver writes query information (question, answer, duration, ...)
@@ -61,6 +65,43 @@ func GetQueryLoggingWriter(ctx context.Context, cfg config.QueryLog) (querylog.W
 	}
 
 	return writer, nil
+}
+
+// newIgnoreDomainsMatcher builds a matcher for the queryLog.ignore.domains rules.
+// Returns nil when no domains are configured, so the per-query path stays free.
+func newIgnoreDomainsMatcher(domains []string, logger *logrus.Entry) stringcache.GroupedStringCache {
+	if len(domains) == 0 {
+		return nil
+	}
+
+	cache := stringcache.NewChainedGroupedCache(
+		stringcache.NewInMemoryGroupedRegexCache(),
+		stringcache.NewInMemoryGroupedWildcardCache(), // must follow regex (regex can contain '*')
+		stringcache.NewInMemoryGroupedStringCache(),
+	)
+
+	factory := cache.Refresh(queryLogIgnoreGroup)
+
+	for _, d := range domains {
+		// Pre-validate regex entries so we can warn via the caller's logger rather
+		// than the global one (the underlying cache silently drops invalid regex).
+		if strings.HasPrefix(d, "/") && strings.HasSuffix(d, "/") {
+			inner := strings.TrimSpace(d[1 : len(d)-1])
+			if _, err := regexp.Compile(inner); err != nil {
+				logger.Warnf("ignoring invalid queryLog.ignore.domains entry: %q", d)
+
+				continue
+			}
+		}
+
+		if !factory.AddEntry(d) {
+			logger.Warnf("ignoring invalid queryLog.ignore.domains entry: %q", d)
+		}
+	}
+
+	factory.Finish()
+
+	return cache
 }
 
 // NewQueryLoggingResolver returns a new resolver instance

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -28,6 +28,10 @@ const (
 	queryLogIgnoreGroup      = "ignore"
 )
 
+// queryLogIgnoreGroups is the (single) cache group queried for ignore rules.
+// Hoisted to avoid allocating a one-element slice on every resolved query.
+var queryLogIgnoreGroups = []string{queryLogIgnoreGroup} //nolint:gochecknoglobals
+
 // QueryLoggingResolver writes query information (question, answer, duration, ...)
 type QueryLoggingResolver struct {
 	configurable[*config.QueryLog]
@@ -85,8 +89,15 @@ func newIgnoreDomainsMatcher(domains []string, logger *logrus.Entry) stringcache
 
 	for _, d := range domains {
 		// Pre-validate regex entries so we can warn via the caller's logger rather
-		// than the global one (the underlying cache silently drops invalid regex).
+		// than the global one (the underlying cache silently drops invalid regex,
+		// and a lone "/" would panic the regex cache's unguarded slice).
 		if strings.HasPrefix(d, "/") && strings.HasSuffix(d, "/") {
+			if len(d) < 2 {
+				logger.Warnf("ignoring invalid queryLog.ignore.domains entry: %q", d)
+
+				continue
+			}
+
 			inner := strings.TrimSpace(d[1 : len(d)-1])
 			if _, err := regexp.Compile(inner); err != nil {
 				logger.Warnf("ignoring invalid queryLog.ignore.domains entry: %q", d)
@@ -217,7 +228,7 @@ func (r *QueryLoggingResolver) ignore(request *model.Request, response *model.Re
 
 	if r.ignoreDomains != nil {
 		domain := util.ExtractDomain(request.Req.Question[0])
-		if len(r.ignoreDomains.Contains(domain, []string{queryLogIgnoreGroup})) > 0 {
+		if len(r.ignoreDomains.Contains(domain, queryLogIgnoreGroups)) > 0 {
 			return true
 		}
 	}

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -92,13 +92,16 @@ func newIgnoreDomainsMatcher(domains []string, logger *logrus.Entry) stringcache
 		// than the global one (the underlying cache silently drops invalid regex,
 		// and a lone "/" would panic the regex cache's unguarded slice).
 		if strings.HasPrefix(d, "/") && strings.HasSuffix(d, "/") {
-			if len(d) < 2 {
+			// Strip the surrounding slashes. Reject entries with no actual pattern
+			// (e.g. "/", "//", "/ /"): an empty regex matches every domain and would
+			// silently drop the whole query log.
+			inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(d, "/"), "/"))
+			if inner == "" {
 				logger.Warnf("ignoring invalid queryLog.ignore.domains entry: %q", d)
 
 				continue
 			}
 
-			inner := strings.TrimSpace(d[1 : len(d)-1])
 			if _, err := regexp.Compile(inner); err != nil {
 				logger.Warnf("ignoring invalid queryLog.ignore.domains entry: %q", d)
 

--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -34,9 +34,10 @@ type QueryLoggingResolver struct {
 	NextResolver
 	typed
 
-	logChan    chan *querylog.LogEntry
-	writer     querylog.Writer
-	instanceID string
+	logChan       chan *querylog.LogEntry
+	writer        querylog.Writer
+	instanceID    string
+	ignoreDomains stringcache.GroupedStringCache
 }
 
 func GetQueryLoggingWriter(ctx context.Context, cfg config.QueryLog) (querylog.Writer, error) {
@@ -74,13 +75,13 @@ func newIgnoreDomainsMatcher(domains []string, logger *logrus.Entry) stringcache
 		return nil
 	}
 
-	cache := stringcache.NewChainedGroupedCache(
+	matcher := stringcache.NewChainedGroupedCache(
 		stringcache.NewInMemoryGroupedRegexCache(),
 		stringcache.NewInMemoryGroupedWildcardCache(), // must follow regex (regex can contain '*')
 		stringcache.NewInMemoryGroupedStringCache(),
 	)
 
-	factory := cache.Refresh(queryLogIgnoreGroup)
+	factory := matcher.Refresh(queryLogIgnoreGroup)
 
 	for _, d := range domains {
 		// Pre-validate regex entries so we can warn via the caller's logger rather
@@ -94,14 +95,12 @@ func newIgnoreDomainsMatcher(domains []string, logger *logrus.Entry) stringcache
 			}
 		}
 
-		if !factory.AddEntry(d) {
-			logger.Warnf("ignoring invalid queryLog.ignore.domains entry: %q", d)
-		}
+		factory.AddEntry(d)
 	}
 
 	factory.Finish()
 
-	return cache
+	return matcher
 }
 
 // NewQueryLoggingResolver returns a new resolver instance
@@ -140,13 +139,16 @@ func NewQueryLoggingResolver(ctx context.Context, cfg config.QueryLog) (*QueryLo
 
 	logChan := make(chan *querylog.LogEntry, logChanCap)
 
+	ignoreDomains := newIgnoreDomainsMatcher(cfg.Ignore.Domains, logger)
+
 	resolver := QueryLoggingResolver{
 		configurable: withConfig(&cfg),
 		typed:        withType(queryLoggingResolverType),
 
-		logChan:    logChan,
-		writer:     writer,
-		instanceID: instanceID,
+		logChan:       logChan,
+		writer:        writer,
+		instanceID:    instanceID,
+		ignoreDomains: ignoreDomains,
 	}
 
 	go resolver.writeLog(ctx)
@@ -192,7 +194,7 @@ func (r *QueryLoggingResolver) Resolve(ctx context.Context, request *model.Reque
 
 	entry := r.createLogEntry(request, resp, start, duration)
 
-	if r.ignore(resp) {
+	if r.ignore(request, resp) {
 		// Log to the console for debugging purposes
 		logger.WithFields(querylog.LogEntryFields(entry)).Debug("ignored querylog entry")
 	} else {
@@ -206,11 +208,18 @@ func (r *QueryLoggingResolver) Resolve(ctx context.Context, request *model.Reque
 	return resp, nil
 }
 
-func (r *QueryLoggingResolver) ignore(response *model.Response) bool {
+func (r *QueryLoggingResolver) ignore(request *model.Request, response *model.Response) bool {
 	cfg := r.cfg.Ignore
 
 	if cfg.SUDN && response.RType == model.ResponseTypeSPECIAL {
 		return true
+	}
+
+	if r.ignoreDomains != nil {
+		domain := util.ExtractDomain(request.Req.Question[0])
+		if len(r.ignoreDomains.Contains(domain, []string{queryLogIgnoreGroup})) > 0 {
+			return true
+		}
 	}
 
 	// If we add more ways to ignore entries, it would be nice to log why it's ignored in the debug log

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -548,6 +548,19 @@ var _ = Describe("QueryLoggingResolver", func() {
 			Expect(matcher.Contains("example.com", []string{queryLogIgnoreGroup})).ShouldNot(BeEmpty())
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("invalid")))
 		})
+
+		It("warns and skips empty regex entries instead of matching every domain", func() {
+			logger, hook := log.NewMockEntry()
+
+			matcher := newIgnoreDomainsMatcher([]string{"//", "/ /", "example.com"}, logger)
+			Expect(matcher).ShouldNot(BeNil())
+
+			groups := []string{queryLogIgnoreGroup}
+			// an empty regex would match everything; the entries must be rejected
+			Expect(matcher.Contains("unrelated.example.net", groups)).Should(BeEmpty())
+			Expect(matcher.Contains("example.com", groups)).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("invalid")))
+		})
 	})
 })
 

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/0xERR0R/blocky/cache/stringcache"
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
@@ -532,6 +533,18 @@ var _ = Describe("QueryLoggingResolver", func() {
 				[]string{"/[invalid(/", "example.com"}, logger)
 
 			Expect(matcher).ShouldNot(BeNil())
+			Expect(matcher.Contains("example.com", []string{queryLogIgnoreGroup})).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("invalid")))
+		})
+
+		It("warns and skips a lone slash entry without panicking", func() {
+			logger, hook := log.NewMockEntry()
+
+			var matcher stringcache.GroupedStringCache
+			Expect(func() {
+				matcher = newIgnoreDomainsMatcher([]string{"/", "example.com"}, logger)
+			}).ShouldNot(Panic())
+
 			Expect(matcher.Contains("example.com", []string{queryLogIgnoreGroup})).ShouldNot(BeEmpty())
 			Expect(hook.Messages).Should(ContainElement(ContainSubstring("invalid")))
 		})

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -473,6 +473,36 @@ var _ = Describe("QueryLoggingResolver", func() {
 			Expect(readInstanceID("/var/empty/nonexistent")).Should(Equal(expected))
 		})
 	})
+
+	Describe("newIgnoreDomainsMatcher", func() {
+		It("returns nil for an empty list", func() {
+			logger, _ := log.NewMockEntry()
+			Expect(newIgnoreDomainsMatcher(nil, logger)).Should(BeNil())
+		})
+
+		It("matches exact, wildcard and regex entries", func() {
+			logger, _ := log.NewMockEntry()
+			matcher := newIgnoreDomainsMatcher(
+				[]string{"example.com", "*.lan", "/\\.arpa$/"}, logger)
+			Expect(matcher).ShouldNot(BeNil())
+
+			groups := []string{queryLogIgnoreGroup}
+			Expect(matcher.Contains("example.com", groups)).ShouldNot(BeEmpty())
+			Expect(matcher.Contains("host.lan", groups)).ShouldNot(BeEmpty())
+			Expect(matcher.Contains("1.0.0.10.in-addr.arpa", groups)).ShouldNot(BeEmpty())
+			Expect(matcher.Contains("other.com", groups)).Should(BeEmpty())
+		})
+
+		It("warns and skips an invalid entry but keeps valid ones", func() {
+			logger, hook := log.NewMockEntry()
+			matcher := newIgnoreDomainsMatcher(
+				[]string{"/[invalid(/", "example.com"}, logger)
+
+			Expect(matcher).ShouldNot(BeNil())
+			Expect(matcher.Contains("example.com", []string{queryLogIgnoreGroup})).ShouldNot(BeEmpty())
+			Expect(hook.Messages).Should(ContainElement(ContainSubstring("invalid")))
+		})
+	})
 })
 
 func readCsv(file string) ([][]string, error) {

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -170,6 +170,39 @@ var _ = Describe("QueryLoggingResolver", func() {
 					Expect(ignored.Calls).Should(BeEmpty())
 				})
 			})
+
+			Describe("Domains", func() {
+				BeforeEach(func() {
+					sutConfig.Ignore.Domains = []string{"ignored.example.com", "*.noisy.lan"}
+				})
+
+				It("should not log a matching exact domain", func() {
+					_, err := sut.Resolve(ctx,
+						newRequestWithClient("ignored.example.com.", A, "192.168.178.25", "client1"))
+					Expect(err).Should(Succeed())
+
+					Expect(sut.logChan).Should(BeEmpty())
+					Expect(ignored.Messages).Should(ContainElement(ContainSubstring("ignored querylog entry")))
+				})
+
+				It("should not log a matching wildcard domain", func() {
+					_, err := sut.Resolve(ctx,
+						newRequestWithClient("host.noisy.lan.", A, "192.168.178.25", "client1"))
+					Expect(err).Should(Succeed())
+
+					Expect(sut.logChan).Should(BeEmpty())
+					Expect(ignored.Messages).Should(ContainElement(ContainSubstring("ignored querylog entry")))
+				})
+
+				It("should log a non-matching domain", func() {
+					_, err := sut.Resolve(ctx,
+						newRequestWithClient("example.com.", A, "192.168.178.25", "client1"))
+					Expect(err).Should(Succeed())
+
+					Expect(sut.logChan).ShouldNot(BeEmpty())
+					Expect(ignored.Calls).Should(BeEmpty())
+				})
+			})
 		})
 
 		When("Configuration with logging per client", func() {


### PR DESCRIPTION
## Summary

Adds `queryLog.ignore.domains`, letting users exclude queries from the query log by domain name. Each entry is an **exact domain**, a **`*.wildcard`**, or a **`/regex/`** — the same syntax as blocklists. This complements the existing `queryLog.ignore.sudn` flag.

Motivation (closes #1390): conditional forwarding makes Apple devices flood the query log with repetitive `*._dns-sd._udp.*` and reverse-lookup `*.in-addr.arpa` queries. Pi-hole and AdGuard Home already let users suppress such domains; this brings the same capability to Blocky.

```yaml
queryLog:
  type: postgresql
  target: postgres://user:password@db:5432/blocky_query_log
  ignore:
    sudn: true
    domains:
      - "*._dns-sd._udp.home"
      - "db._dns-sd._udp.home"
      - "/\\.in-addr\\.arpa$/"
      - "apple.com"
```

## Implementation

- Reuses the existing blocklist matcher (`cache/stringcache.ChainedGroupedCache`: regex + wildcard + exact) — no new matching logic.
- The matcher is built **once** at query-logging-resolver construction from the inline list, and is `nil` when no domains are configured (zero per-query cost on the common path).
- Consulted in the existing `QueryLoggingResolver.ignore()`, matching the question name normalized via `util.ExtractDomain` (lowercase, trailing dot stripped) — consistent with how blocklist entries are stored.
- Invalid `/regex/` entries are pre-validated with `regexp.Compile` and warned+skipped at startup (the underlying cache otherwise only logs to a global logger), and a lone `"/"` entry is rejected rather than crashing.
- Scope is intentionally minimal (YAGNI): inline rules only — no file/URL sources, no refresh, no per-client rules.

## Test plan

- [x] `go build ./...`
- [x] `go test ./config/ ./resolver/` (Ginkgo) — exact/wildcard/regex matches excluded, non-matching domains still logged, SUDN unaffected, empty list = fast path, invalid-regex and lone-`/` warn+skip without panic
- [x] `go vet ./config/ ./resolver/`
- [x] `golangci-lint run ./config/... ./resolver/...` — 0 issues
- [x] Docs updated (`docs/configuration.md`: table rows + example)

## Note for reviewers

While building this I found a pre-existing latent bug in `cache/stringcache`: `regexCacheFactory.addEntry` slices `entry[1:len(entry)-1]` without a length guard, so a lone `/` entry panics. It's reachable from any list source (e.g. a stray `/` line in a blocklist). I guarded the new query-log path against it here, but did **not** touch the shared cache (out of scope for this issue) — worth a separate hardening PR.