### PR TITLE
ci(e2e): speed up e2e job via Ginkgo proc oversubscription

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -21,9 +21,6 @@ env:
   # e2e specs are container/health-check-wait bound, not CPU bound, so we
   # oversubscribe the runner's cores for better wall-clock time.
   GINKGO_E2E_PROCS: --procs=8
-  # Reuse the e2e build layers (deps, base image) across runs via the GitHub
-  # Actions cache. scope=e2e keeps it separate from the docker-build job.
-  DOCKER_E2E_CACHE_FLAGS: --cache-from type=gha,scope=e2e --cache-to type=gha,mode=max,scope=e2e
 
 jobs:
   make:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,6 +18,12 @@ permissions:
 
 env:
   GINKGO_PROCS: --procs=1
+  # e2e specs are container/health-check-wait bound, not CPU bound, so we
+  # oversubscribe the runner's cores for better wall-clock time.
+  GINKGO_E2E_PROCS: --procs=8
+  # Reuse the e2e build layers (deps, base image) across runs via the GitHub
+  # Actions cache. scope=e2e keeps it separate from the docker-build job.
+  DOCKER_E2E_CACHE_FLAGS: --cache-from type=gha,scope=e2e --cache-to type=gha,mode=max,scope=e2e
 
 jobs:
   make:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,17 @@ GOLANG_LINT_VERSION=v2.12.2
 
 GINKGO_PROCS?=
 
+# Parallelism for e2e tests. e2e specs are dominated by container startup and
+# health-check waits rather than CPU, so oversubscribing beyond the core count
+# improves wall-clock time. Defaults to -p (one process per core) for local
+# runs; CI overrides this to oversubscribe the runner.
+GINKGO_E2E_PROCS?=-p
+
+# Extra flags for the e2e image build. CI sets these to enable the GitHub
+# Actions build cache (type=gha); empty by default so local builds are
+# unaffected.
+DOCKER_E2E_CACHE_FLAGS?=
+
 export PATH=$(shell go env GOPATH)/bin:$(shell echo $$PATH)
 
 # Tool check functions
@@ -83,6 +94,7 @@ test: check-go ## run tests
 
 e2e-test: check-go check-docker ## run e2e tests
 	docker buildx build \
+		${DOCKER_E2E_CACHE_FLAGS} \
 		--build-arg VERSION=blocky-e2e \
 		--build-arg BUILD_TIME=${BUILD_TIME} \
 		--build-arg GOPROXY \
@@ -90,7 +102,7 @@ e2e-test: check-go check-docker ## run e2e tests
 		-o type=docker \
 		-t blocky-e2e \
 		.
-	go tool ginkgo -p --label-filter="e2e" --timeout 15m --flake-attempts 1 e2e
+	go tool ginkgo ${GINKGO_E2E_PROCS} --label-filter="e2e" --timeout 15m --flake-attempts 1 e2e
 
 e2e-test-coverage: check-go check-docker ## run e2e tests with code coverage
 	@echo "Building coverage-instrumented Docker image..."
@@ -108,7 +120,7 @@ e2e-test-coverage: check-go check-docker ## run e2e tests with code coverage
 	@rm -rf coverage/e2e/*
 	@chmod 777 coverage/e2e
 	BLOCKY_IMAGE=blocky-e2e-coverage GOCOVERDIR=$(PWD)/coverage/e2e \
-		go tool ginkgo -p --label-filter="e2e" --timeout 15m --flake-attempts 1 e2e
+		go tool ginkgo ${GINKGO_E2E_PROCS} --label-filter="e2e" --timeout 15m --flake-attempts 1 e2e
 	@echo "Converting coverage data..."
 	go tool covdata textfmt -i=./coverage/e2e -o=coverage/e2e-coverage.out
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,6 @@ GINKGO_PROCS?=
 # runs; CI overrides this to oversubscribe the runner.
 GINKGO_E2E_PROCS?=-p
 
-# Extra flags for the e2e image build. CI sets these to enable the GitHub
-# Actions build cache (type=gha); empty by default so local builds are
-# unaffected.
-DOCKER_E2E_CACHE_FLAGS?=
-
 export PATH=$(shell go env GOPATH)/bin:$(shell echo $$PATH)
 
 # Tool check functions
@@ -94,7 +89,6 @@ test: check-go ## run tests
 
 e2e-test: check-go check-docker ## run e2e tests
 	docker buildx build \
-		${DOCKER_E2E_CACHE_FLAGS} \
 		--build-arg VERSION=blocky-e2e \
 		--build-arg BUILD_TIME=${BUILD_TIME} \
 		--build-arg GOPROXY \


### PR DESCRIPTION
## What

The `e2e-test` target runs Ginkgo with `-p` (one process per core). e2e specs
are dominated by **container startup and health-check waits, not CPU** — across
the suite, ~1663s of summed spec runtime compresses to ~244s wall-clock, and
even trivial specs cost 15–30s because each one spins up a fresh Docker network
+ blocky (+ upstream) container via `BeforeEach`. That means we can safely run
**more Ginkgo processes than the runner has cores**.

This adds a `GINKGO_E2E_PROCS` knob (default `-p`, so local runs are unchanged)
and sets `--procs=8` in CI to oversubscribe the 4-core `ubuntu-latest` runner.

## Measured impact (CI `make (e2e-test)` job)

| | duration |
|---|---|
| Baseline (`-p`) | ~6m45s |
| `--procs=8` | **4m27s** (−34%, ~2m18s) |

Verified across 3 CI runs: **137/137 specs pass, 0 skips, 0 flakes** — the higher
parallelism does not trigger any IPv6 fixed-subnet / network-collision skips.

Local reference (8-core): 244s (`-p`) → 185s (`--procs=16`).

## Notes

- Local behaviour is unchanged (`GINKGO_E2E_PROCS` defaults to `-p`); only CI
  overrides it.
- `GINKGO_PROCS: --procs=1` in CI only ever applied to the `test`/`race`
  targets, never to e2e — so this is not a regression of any prior serialization.
- I also trialed a `type=gha` Docker build cache but **dropped it**: it silently
  no-ops with a raw `docker buildx build` in a plain `run:` step (the backend
  needs `ACTIONS_RUNTIME_TOKEN`, which only `docker/build-push-action` injects),
  and the e2e image build is mostly per-commit recompile + image load anyway.

Please **squash-merge** (the branch has an extra throwaway commit from
measuring warm-cache build times).