### PR TITLE
perf(e2e): probe blocky healthcheck at 250ms during start period

### DIFF
--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -221,6 +221,11 @@ func buildBlockyContainerRequest(confFile string) testcontainers.ContainerReques
 		ConfigModifier: func(c *container.Config) {
 			c.Healthcheck = &container.HealthConfig{
 				Interval: time.Second,
+				// During the image's start period Docker probes at the
+				// start-interval, which defaults to 5s. blocky is ready in
+				// <1s, so without this every container wastes ~5s waiting to
+				// be marked healthy.
+				StartInterval: 250 * time.Millisecond,
 			}
 			// Enable coverage collection if GOCOVERDIR is set
 			if coverDir != "" {

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -45,6 +45,10 @@ const (
 	// copied files, so it can only read them via the world-readable bit.
 	modeWorldReadable = 0o444
 	startupTimeout    = 30 * time.Second
+
+	// healthcheckStartInterval overrides Docker's 5s default start-interval so
+	// blocky (ready in <1s) is probed and marked healthy almost immediately.
+	healthcheckStartInterval = 250 * time.Millisecond
 )
 
 // createDNSMokkaContainer creates a DNS mokka container with the given rules attached to the test network
@@ -225,7 +229,7 @@ func buildBlockyContainerRequest(confFile string) testcontainers.ContainerReques
 				// start-interval, which defaults to 5s. blocky is ready in
 				// <1s, so without this every container wastes ~5s waiting to
 				// be marked healthy.
-				StartInterval: 250 * time.Millisecond,
+				StartInterval: healthcheckStartInterval,
 			}
 			// Enable coverage collection if GOCOVERDIR is set
 			if coverDir != "" {


### PR DESCRIPTION
## What

Nearly every e2e spec starts a blocky container and blocks on
`wait.ForHealthCheck()` in `BeforeEach`. At the Docker-daemon level, blocky's
DNS server is **"up and running" in <1s** and its healthcheck command returns
`OK` in ~0.1s — yet the container isn't marked `healthy` for **~5s**.

**Why:** the image's `HEALTHCHECK` sets a 60s `start_period`, and Docker (25+)
probes during the start period at the **start-interval, which defaults to 5s**.
So nothing probes blocky until ~5s even though it's been ready the whole time.

This sets `StartInterval: 250ms` on the blocky healthcheck in the e2e helper so
the first probe fires almost immediately. It only affects the e2e test
containers (DBs and the mokka upstream use log/port wait strategies, untouched).

## Measured (idle machine, daemon-event timestamps)

Per blocky container, in isolation:

| `--health-start-interval` | blocky start → healthy |
|---|---|
| default (5s) | ~5.06s |
| **250ms (this PR)** | **~0.34s** |

A single blocky+mokka spec drops from ~8.1s to ~3.7s.

At the suite level the wall-clock win is more modest than the per-container
number suggests, because the healthcheck wait is idle time that overlaps across
the parallel Ginkgo workers, and the heavy DB/redis specs are bound by other
waits. The hard 5s floor on every blocky container is removed regardless.

Suite stays fully green: **137/137 specs, 0 skips**.

Builds on #2085 (proc oversubscription).