### PR TITLE
feat(evt): typed event bus on maniartech/signals

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -129,7 +129,7 @@ func startServer(_ *cobra.Command, _ []string) error {
 		}
 	}()
 
-	evt.LegacyBus().Publish(evt.ApplicationStarted, util.Version, util.BuildTime)
+	evt.Emit(bus, ctx, evt.AppStartedEvent{Version: util.Version, BuildTime: util.BuildTime})
 	<-done
 
 	return terminationErr

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -128,7 +128,7 @@ func startServer(_ *cobra.Command, _ []string) error {
 		}
 	}()
 
-	evt.Bus().Publish(evt.ApplicationStarted, util.Version, util.BuildTime)
+	evt.LegacyBus().Publish(evt.ApplicationStarted, util.Version, util.BuildTime)
 	<-done
 
 	return terminationErr

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -94,7 +94,8 @@ func startServer(_ *cobra.Command, _ []string) error {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
-	srv, err := server.NewServer(ctx, cfg)
+	bus := evt.NewBus()
+	srv, err := server.NewServer(ctx, cfg, bus)
 	if err != nil {
 		return fmt.Errorf("can't start server: %w", err)
 	}

--- a/evt/bus.go
+++ b/evt/bus.go
@@ -1,0 +1,78 @@
+// Package evt provides a typed event bus on top of github.com/maniartech/signals.
+//
+// A *Bus is a registry that lazily creates one signals.Signal[T] per event type.
+// Producers and consumers use the package-level generic functions Emit, Subscribe,
+// and Unsubscribe; the bus itself never grows public fields per event.
+//
+// All operations are nil-safe: passing a nil bus makes Emit / Subscribe /
+// Unsubscribe no-ops. This is used by resolver.Bootstrap to silence its
+// internal CachingResolver.
+package evt
+
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"github.com/maniartech/signals"
+)
+
+// Bus holds typed signals keyed by event type.
+type Bus struct {
+	mu      sync.RWMutex
+	signals map[reflect.Type]any // value is signals.Signal[T] for the key's element type
+}
+
+// NewBus creates an empty Bus.
+func NewBus() *Bus {
+	return &Bus{signals: make(map[reflect.Type]any)}
+}
+
+// Emit publishes an event of type T to all subscribers. A nil bus is a no-op.
+func Emit[T any](b *Bus, ctx context.Context, event T) {
+	if b == nil {
+		return
+	}
+	signalFor[T](b).Emit(ctx, event)
+}
+
+// Subscribe registers a listener for events of type T under the given key. A
+// nil bus is a no-op. The key may later be passed to Unsubscribe to remove
+// the listener.
+func Subscribe[T any](b *Bus, key string, listener func(context.Context, T)) {
+	if b == nil {
+		return
+	}
+	signalFor[T](b).AddListener(listener, key)
+}
+
+// Unsubscribe removes a listener for events of type T identified by key. A
+// nil bus is a no-op.
+func Unsubscribe[T any](b *Bus, key string) {
+	if b == nil {
+		return
+	}
+	signalFor[T](b).RemoveListener(key)
+}
+
+// signalFor returns the lazily-initialized signal for type T.
+func signalFor[T any](b *Bus) signals.Signal[T] {
+	typ := reflect.TypeOf((*T)(nil)).Elem()
+
+	b.mu.RLock()
+	if s, ok := b.signals[typ]; ok {
+		b.mu.RUnlock()
+		return s.(signals.Signal[T])
+	}
+	b.mu.RUnlock()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Double-checked: another goroutine may have created it while we waited.
+	if s, ok := b.signals[typ]; ok {
+		return s.(signals.Signal[T])
+	}
+	s := signals.Signal[T](signals.New[T]())
+	b.signals[typ] = s
+	return s
+}

--- a/evt/bus.go
+++ b/evt/bus.go
@@ -4,9 +4,13 @@
 // Producers and consumers use the package-level generic functions Emit, Subscribe,
 // and Unsubscribe; the bus itself never grows public fields per event.
 //
-// All operations are nil-safe: passing a nil bus makes Emit / Subscribe /
-// Unsubscribe no-ops. This is used by resolver.Bootstrap to silence its
-// internal CachingResolver.
+// All operations are nil-safe: passing a nil bus makes Emit / EmitAsync /
+// Subscribe / Unsubscribe no-ops. This is used by resolver.Bootstrap to silence
+// its internal CachingResolver.
+//
+// Emit blocks the caller until every listener returns (listeners run
+// concurrently with each other, but not with the caller). Use EmitAsync when
+// the producer must not wait on listener latency.
 package evt
 
 import (
@@ -28,12 +32,33 @@ func NewBus() *Bus {
 	return &Bus{signals: make(map[reflect.Type]any)}
 }
 
-// Emit publishes an event of type T to all subscribers. A nil bus is a no-op.
+// Emit publishes an event of type T to all subscribers and blocks until every
+// listener returns. Listeners run concurrently with each other but not with the
+// caller. A nil bus is a no-op.
 func Emit[T any](b *Bus, ctx context.Context, event T) {
 	if b == nil {
 		return
 	}
 	signalFor[T](b).Emit(ctx, event)
+}
+
+// EmitAsync publishes an event of type T without blocking the caller: dispatch
+// to listeners happens in a detached background goroutine and EmitAsync returns
+// immediately. Use it when the producer must not wait on listener latency (e.g.
+// an emit whose listener performs network I/O). A nil bus is a no-op.
+//
+// Because dispatch is detached, the caller cannot observe when listeners finish,
+// and ordering relative to later Emit/EmitAsync calls is not guaranteed. The
+// supplied ctx is captured by the goroutine; if the caller cancels it right
+// after the call, listeners observe a cancelled context.
+func EmitAsync[T any](b *Bus, ctx context.Context, event T) {
+	if b == nil {
+		return
+	}
+
+	signal := signalFor[T](b)
+
+	go signal.Emit(ctx, event)
 }
 
 // Subscribe registers a listener for events of type T under the given key. A

--- a/evt/bus_test.go
+++ b/evt/bus_test.go
@@ -97,6 +97,51 @@ var _ = Describe("Bus", func() {
 		})
 	})
 
+	Describe("EmitAsync", func() {
+		When("the bus is nil", func() {
+			It("is a no-op", func() {
+				Expect(func() {
+					evt.EmitAsync[fooEvent](nil, context.Background(), fooEvent{N: 1})
+				}).ShouldNot(Panic())
+			})
+		})
+
+		When("a listener is registered", func() {
+			It("delivers the event eventually", func(specCtx context.Context) {
+				received := make(chan fooEvent, 1)
+				evt.Subscribe(bus, "k", func(_ context.Context, e fooEvent) {
+					received <- e
+				})
+
+				evt.EmitAsync(bus, specCtx, fooEvent{N: 99})
+
+				Eventually(received).WithTimeout(time.Second).Should(Receive(Equal(fooEvent{N: 99})))
+			})
+		})
+
+		When("a listener blocks", func() {
+			It("returns to the caller without waiting for the listener", func(specCtx context.Context) {
+				release := make(chan struct{})
+				started := make(chan struct{}, 1)
+				evt.Subscribe(bus, "slow", func(_ context.Context, _ fooEvent) {
+					started <- struct{}{}
+					<-release // block until the test releases us
+				})
+				DeferCleanup(func() { close(release) })
+
+				returned := make(chan struct{})
+				go func() {
+					evt.EmitAsync(bus, specCtx, fooEvent{})
+					close(returned)
+				}()
+
+				// EmitAsync must return promptly even though the listener is still blocked.
+				Eventually(returned).WithTimeout(time.Second).Should(BeClosed())
+				Eventually(started).WithTimeout(time.Second).Should(Receive())
+			})
+		})
+	})
+
 	Describe("Subscribe with nil bus", func() {
 		It("is a no-op for Subscribe and Unsubscribe", func() {
 			Expect(func() {

--- a/evt/bus_test.go
+++ b/evt/bus_test.go
@@ -11,8 +11,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type fooEvent struct{ N int }
-type barEvent struct{ S string }
+type (
+	fooEvent struct{ N int }
+	barEvent struct{ S string }
+)
 
 var _ = Describe("Bus", func() {
 	var bus *evt.Bus

--- a/evt/bus_test.go
+++ b/evt/bus_test.go
@@ -1,0 +1,147 @@
+package evt_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/0xERR0R/blocky/evt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fooEvent struct{ N int }
+type barEvent struct{ S string }
+
+var _ = Describe("Bus", func() {
+	var bus *evt.Bus
+
+	BeforeEach(func() {
+		bus = evt.NewBus()
+	})
+
+	Describe("Emit", func() {
+		When("there are no listeners", func() {
+			It("is a no-op", func() {
+				Expect(func() {
+					evt.Emit(bus, context.Background(), fooEvent{N: 1})
+				}).ShouldNot(Panic())
+			})
+		})
+
+		When("the bus is nil", func() {
+			It("is a no-op (Bootstrap silence contract)", func() {
+				Expect(func() {
+					evt.Emit[fooEvent](nil, context.Background(), fooEvent{N: 1})
+				}).ShouldNot(Panic())
+			})
+		})
+
+		When("a listener is registered for the event type", func() {
+			It("delivers the event payload to the listener", func(specCtx context.Context) {
+				received := make(chan fooEvent, 1)
+				evt.Subscribe(bus, "k", func(_ context.Context, e fooEvent) {
+					received <- e
+				})
+
+				evt.Emit(bus, specCtx, fooEvent{N: 42})
+
+				Eventually(received).WithTimeout(time.Second).Should(Receive(Equal(fooEvent{N: 42})))
+			})
+		})
+
+		When("multiple listeners are registered for the same event type", func() {
+			It("delivers the event to every listener", func(specCtx context.Context) {
+				var count atomic.Int32
+				var wg sync.WaitGroup
+				wg.Add(2)
+
+				evt.Subscribe(bus, "a", func(_ context.Context, _ fooEvent) {
+					count.Add(1)
+					wg.Done()
+				})
+				evt.Subscribe(bus, "b", func(_ context.Context, _ fooEvent) {
+					count.Add(1)
+					wg.Done()
+				})
+
+				evt.Emit(bus, specCtx, fooEvent{})
+
+				done := make(chan struct{})
+				go func() { wg.Wait(); close(done) }()
+				Eventually(done).WithTimeout(time.Second).Should(BeClosed())
+				Expect(count.Load()).To(Equal(int32(2)))
+			})
+		})
+
+		When("listeners are registered for different event types", func() {
+			It("delivers to only the matching type", func(specCtx context.Context) {
+				received := make(chan fooEvent, 1)
+				var barCalls atomic.Int32
+
+				evt.Subscribe(bus, "foo", func(_ context.Context, e fooEvent) {
+					received <- e
+				})
+				evt.Subscribe(bus, "bar", func(_ context.Context, _ barEvent) {
+					barCalls.Add(1)
+				})
+
+				evt.Emit(bus, specCtx, fooEvent{N: 7})
+
+				Eventually(received).WithTimeout(time.Second).Should(Receive(Equal(fooEvent{N: 7})))
+				Consistently(barCalls.Load, 100*time.Millisecond).Should(Equal(int32(0)))
+			})
+		})
+	})
+
+	Describe("Subscribe with nil bus", func() {
+		It("is a no-op for Subscribe and Unsubscribe", func() {
+			Expect(func() {
+				evt.Subscribe[fooEvent](nil, "k", func(context.Context, fooEvent) {})
+				evt.Unsubscribe[fooEvent](nil, "k")
+			}).ShouldNot(Panic())
+		})
+	})
+
+	Describe("Unsubscribe", func() {
+		It("stops delivery to a listener identified by key", func(specCtx context.Context) {
+			var count atomic.Int32
+			received := make(chan struct{}, 1)
+
+			evt.Subscribe(bus, "to-remove", func(_ context.Context, _ fooEvent) {
+				count.Add(1)
+				received <- struct{}{}
+			})
+
+			evt.Emit(bus, specCtx, fooEvent{})
+			Eventually(received).WithTimeout(time.Second).Should(Receive())
+
+			evt.Unsubscribe[fooEvent](bus, "to-remove")
+			evt.Emit(bus, specCtx, fooEvent{})
+
+			Consistently(count.Load, 100*time.Millisecond).Should(Equal(int32(1)))
+		})
+	})
+
+	Describe("Concurrent emit and subscribe", func() {
+		It("does not race or panic", func(specCtx context.Context) {
+			const goroutines = 16
+			const perGoroutine = 100
+			var wg sync.WaitGroup
+
+			for i := 0; i < goroutines; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer GinkgoRecover()
+					defer wg.Done()
+					evt.Subscribe(bus, "k", func(_ context.Context, _ fooEvent) {})
+					for j := 0; j < perGoroutine; j++ {
+						evt.Emit(bus, specCtx, fooEvent{N: i*perGoroutine + j})
+					}
+				}(i)
+			}
+			wg.Wait()
+		})
+	})
+})

--- a/evt/events.go
+++ b/evt/events.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/asaskevich/EventBus"
+	_ "github.com/maniartech/signals"
 )
 
 const (

--- a/evt/events.go
+++ b/evt/events.go
@@ -4,12 +4,17 @@ import (
 	"time"
 
 	"github.com/asaskevich/EventBus"
-	_ "github.com/maniartech/signals"
 )
 
+// ---------------------------------------------------------------------------
+// Legacy string-based event bus. Will be removed in Task 9 once all callers
+// have migrated to the typed Bus in bus.go.
+// ---------------------------------------------------------------------------
+
 const (
-	// BlockingEnabledEvent fires if blocking status will be changed. Parameter: boolean (enabled = true)
-	BlockingEnabledEvent = "blocking:enabled"
+	// BlockingEnabledTopic fires if blocking status will be changed. Parameter: boolean (enabled = true)
+	// Renamed from BlockingEnabledEvent to free that identifier for the new typed payload struct.
+	BlockingEnabledTopic = "blocking:enabled"
 
 	// BlockingStateChanged fires when blocking state changes locally (for Redis bridge).
 	// Parameter: BlockingState
@@ -44,15 +49,77 @@ const (
 //nolint:gochecknoglobals
 var evtBus = EventBus.New()
 
-// LegacyBus returns the global legacy EventBus instance. It will be removed
-// once all callers are migrated to the typed evt.Bus in bus.go (Task 9).
+// LegacyBus returns the global legacy bus instance.
+//
+// Deprecated: use the typed Bus from bus.go instead. Will be removed once all
+// callers migrate (see plan 2026-05-29-typed-event-bus.md, Task 9).
 func LegacyBus() EventBus.Bus {
 	return evtBus
 }
+
+// ---------------------------------------------------------------------------
+// Typed event payloads. Used by the typed Bus in bus.go.
+// ---------------------------------------------------------------------------
 
 // BlockingState carries the full blocking state for cross-instance sync.
 type BlockingState struct {
 	Enabled  bool          `json:"enabled"`
 	Duration time.Duration `json:"duration,omitempty"`
 	Groups   []string      `json:"groups,omitempty"`
+}
+
+// AppStartedEvent fires once when the application is fully up.
+type AppStartedEvent struct {
+	Version   string
+	BuildTime string
+}
+
+// BlockingEnabledEvent fires when blocking is enabled or disabled.
+type BlockingEnabledEvent struct {
+	Enabled bool
+}
+
+// BlockingStateChangedEvent fires when local blocking state changes (consumed by the Redis bridge).
+type BlockingStateChangedEvent struct {
+	State BlockingState
+}
+
+// BlockingStateChangedRemoteEvent fires when blocking state changes on a remote instance (delivered via Redis).
+type BlockingStateChangedRemoteEvent struct {
+	State BlockingState
+}
+
+// BlockingCacheGroupChangedEvent fires when a denylist or allowlist group is refreshed.
+// ListType is the string form of lists.ListCacheType ("denylist" or "allowlist").
+// String is used (rather than lists.ListCacheType) to keep evt free of an
+// import-cycle-creating dependency on the lists package.
+type BlockingCacheGroupChangedEvent struct {
+	ListType  string
+	GroupName string
+	Count     int
+}
+
+// CachingDomainPrefetchedEvent fires when a domain is prefetched.
+type CachingDomainPrefetchedEvent struct {
+	Domain string
+}
+
+// CachingResultCacheChangedEvent fires when the result cache size changes.
+type CachingResultCacheChangedEvent struct {
+	Size int
+}
+
+// CachingPrefetchCacheHitEvent fires when a query result is served from the prefetch cache.
+type CachingPrefetchCacheHitEvent struct {
+	Domain string
+}
+
+// CachingDomainsToPrefetchCountChangedEvent fires when the number of prefetch-tracked domains changes.
+type CachingDomainsToPrefetchCountChangedEvent struct {
+	Count int
+}
+
+// CachingFailedDownloadEvent fires when a list/hosts-file download fails.
+type CachingFailedDownloadEvent struct {
+	URL string
 }

--- a/evt/events.go
+++ b/evt/events.go
@@ -2,64 +2,9 @@ package evt
 
 import (
 	"time"
-
-	"github.com/asaskevich/EventBus"
 )
 
-// ---------------------------------------------------------------------------
-// Legacy string-based event bus. Will be removed in Task 9 once all callers
-// have migrated to the typed Bus in bus.go.
-// ---------------------------------------------------------------------------
-
-const (
-	// BlockingEnabledTopic fires if blocking status will be changed. Parameter: boolean (enabled = true)
-	// Renamed from BlockingEnabledEvent to free that identifier for the new typed payload struct.
-	BlockingEnabledTopic = "blocking:enabled"
-
-	// BlockingStateChanged fires when blocking state changes locally (for Redis bridge).
-	// Parameter: BlockingState
-	BlockingStateChanged = "blocking:stateChanged"
-
-	// BlockingStateChangedRemote fires when blocking state changes from a remote instance via Redis.
-	// Parameter: BlockingState
-	BlockingStateChangedRemote = "blocking:stateChangedRemote"
-
-	// BlockingCacheGroupChanged fires, if a list group is changed. Parameter: list type, group name, element count
-	BlockingCacheGroupChanged = "blocking:cachingGroupChanged"
-
-	// CachingDomainPrefetched fires if a domain will be prefetched, Parameter: domain name
-	CachingDomainPrefetched = "caching:prefetched"
-
-	// CachingResultCacheChanged fires if a result cache was changed, Parameter: new cache size
-	CachingResultCacheChanged = "caching:resultCacheChanged"
-
-	// CachingPrefetchCacheHit fires if a query result was found in the prefetch cache, Parameter: domain name
-	CachingPrefetchCacheHit = "caching:prefetchHit"
-
-	// CachingDomainsToPrefetchCountChanged fires, if a number of domains being prefetched changed, Parameter: new count
-	CachingDomainsToPrefetchCountChanged = "caching:domainsToPrefetchCountChanged"
-
-	// CachingFailedDownloadChanged fires, if a download of a blocking list or hosts file fails
-	CachingFailedDownloadChanged = "caching:failedDownload"
-
-	// ApplicationStarted fires on start of the application. Parameter: version number, build time
-	ApplicationStarted = "application:started"
-)
-
-//nolint:gochecknoglobals
-var evtBus = EventBus.New()
-
-// LegacyBus returns the global legacy bus instance.
-//
-// Deprecated: use the typed Bus from bus.go instead. Will be removed once all
-// callers migrate (see plan 2026-05-29-typed-event-bus.md, Task 9).
-func LegacyBus() EventBus.Bus {
-	return evtBus
-}
-
-// ---------------------------------------------------------------------------
 // Typed event payloads. Used by the typed Bus in bus.go.
-// ---------------------------------------------------------------------------
 
 // BlockingState carries the full blocking state for cross-instance sync.
 type BlockingState struct {

--- a/evt/events.go
+++ b/evt/events.go
@@ -44,8 +44,9 @@ const (
 //nolint:gochecknoglobals
 var evtBus = EventBus.New()
 
-// Bus returns the global bus instance
-func Bus() EventBus.Bus {
+// LegacyBus returns the global legacy EventBus instance. It will be removed
+// once all callers are migrated to the typed evt.Bus in bus.go (Task 9).
+func LegacyBus() EventBus.Bus {
 	return evtBus
 }
 

--- a/evt/evt_suite_test.go
+++ b/evt/evt_suite_test.go
@@ -1,0 +1,13 @@
+package evt_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEvt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Evt Suite")
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/ThinkChaos/parcour v0.0.0-20230710171753-fbf917c9eaef
 	github.com/alicebob/miniredis/v2 v2.38.0
-	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/breml/rootcerts v0.3.5
 	github.com/creasty/defaults v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/invopop/jsonschema v0.14.0
 	github.com/jedisct1/go-dnsstamps v0.0.0-20260518121737-6579dc73e4a2
+	github.com/maniartech/signals v1.3.1
 	github.com/mattn/go-colorable v0.1.14
 	github.com/miekg/dns v1.1.72
 	github.com/moby/moby/api v1.54.2

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/maniartech/signals v1.3.1 h1:pT3dK6x5Un+B6L3ZLAKygEe+L49TClPreyT08vOoHXY=
+github.com/maniartech/signals v1.3.1/go.mod h1:AbE8Yy9ZjKCWNU/VhQ+0Ea9KOaTWHp6aOfdLBe5m1iM=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,6 @@ github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
-github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef h1:2JGTg6JapxP9/R33ZaagQtAM4EkkSYnIAlOG5EI8gkM=
-github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
 github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
 github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=

--- a/lists/downloader.go
+++ b/lists/downloader.go
@@ -34,17 +34,19 @@ type FileDownloader interface {
 // httpDownloader downloads files via HTTP protocol
 type httpDownloader struct {
 	cfg config.Downloader
+	bus *evt.Bus
 
 	client http.Client
 }
 
-func NewDownloader(cfg config.Downloader, transport http.RoundTripper) FileDownloader {
-	return newDownloader(cfg, transport)
+func NewDownloader(cfg config.Downloader, transport http.RoundTripper, bus *evt.Bus) FileDownloader {
+	return newDownloader(cfg, transport, bus)
 }
 
-func newDownloader(cfg config.Downloader, transport http.RoundTripper) *httpDownloader {
+func newDownloader(cfg config.Downloader, transport http.RoundTripper, bus *evt.Bus) *httpDownloader {
 	return &httpDownloader{
 		cfg: cfg,
+		bus: bus,
 
 		client: http.Client{
 			Transport: transport,

--- a/lists/downloader.go
+++ b/lists/downloader.go
@@ -118,5 +118,5 @@ func (d *httpDownloader) DownloadFile(ctx context.Context, link string) (io.Read
 }
 
 func onDownloadError(link string) {
-	evt.Bus().Publish(evt.CachingFailedDownloadChanged, link)
+	evt.LegacyBus().Publish(evt.CachingFailedDownloadChanged, link)
 }

--- a/lists/downloader.go
+++ b/lists/downloader.go
@@ -110,7 +110,7 @@ func (d *httpDownloader) DownloadFile(ctx context.Context, link string) (io.Read
 				logger.Warnf("Can't download file: %s", err)
 			}
 
-			onDownloadError(link)
+			d.onDownloadError(ctx, link)
 		}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to download file from '%s': %w", link, err)
@@ -119,6 +119,6 @@ func (d *httpDownloader) DownloadFile(ctx context.Context, link string) (io.Read
 	return body, nil
 }
 
-func onDownloadError(link string) {
-	evt.LegacyBus().Publish(evt.CachingFailedDownloadChanged, link)
+func (d *httpDownloader) onDownloadError(ctx context.Context, link string) {
+	evt.Emit(d.bus, ctx, evt.CachingFailedDownloadEvent{URL: link})
 }

--- a/lists/downloader_test.go
+++ b/lists/downloader_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Downloader", func() {
 	})
 
 	JustBeforeEach(func() {
-		sut = newDownloader(sutConfig, nil)
+		sut = newDownloader(sutConfig, nil, nil)
 	})
 
 	Describe("NewDownloader", func() {
@@ -63,6 +63,7 @@ var _ = Describe("Downloader", func() {
 					Timeout:  config.Duration(5 * time.Second),
 				},
 				transport,
+				nil,
 			).(*httpDownloader)
 
 			Expect(sut.cfg.Attempts).Should(BeNumerically("==", 5))
@@ -77,7 +78,7 @@ var _ = Describe("Downloader", func() {
 		When("Download was successful", func() {
 			BeforeEach(func() {
 				server = TestServer("line.one\nline.two")
-				sut = newDownloader(sutConfig, nil)
+				sut = newDownloader(sutConfig, nil, nil)
 			})
 			It("Should return all lines from the file", func(ctx context.Context) {
 				reader, err := sut.DownloadFile(ctx, server.URL)

--- a/lists/downloader_test.go
+++ b/lists/downloader_test.go
@@ -38,9 +38,9 @@ var _ = Describe("Downloader", func() {
 		fn := func(url string) {
 			failedDownloadCountEvtChannel <- url
 		}
-		Expect(Bus().Subscribe(CachingFailedDownloadChanged, fn)).Should(Succeed())
+		Expect(LegacyBus().Subscribe(CachingFailedDownloadChanged, fn)).Should(Succeed())
 		DeferCleanup(func() {
-			Expect(Bus().Unsubscribe(CachingFailedDownloadChanged, fn)).Should(Succeed())
+			Expect(LegacyBus().Unsubscribe(CachingFailedDownloadChanged, fn)).Should(Succeed())
 		})
 
 		loggerHook = test.NewGlobal()

--- a/lists/downloader_test.go
+++ b/lists/downloader_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Downloader", func() {
 	var (
 		sutConfig                     config.Downloader
 		sut                           *httpDownloader
+		bus                           *Bus
 		failedDownloadCountEvtChannel chan string
 		loggerHook                    *test.Hook
 	)
@@ -33,14 +34,11 @@ var _ = Describe("Downloader", func() {
 		sutConfig, err = config.WithDefaults[config.Downloader]()
 		Expect(err).Should(Succeed())
 
+		bus = NewBus()
 		failedDownloadCountEvtChannel = make(chan string, 5)
 		// collect received events in the channel
-		fn := func(url string) {
-			failedDownloadCountEvtChannel <- url
-		}
-		Expect(LegacyBus().Subscribe(CachingFailedDownloadChanged, fn)).Should(Succeed())
-		DeferCleanup(func() {
-			Expect(LegacyBus().Unsubscribe(CachingFailedDownloadChanged, fn)).Should(Succeed())
+		Subscribe(bus, "test:failed-download", func(_ context.Context, e CachingFailedDownloadEvent) {
+			failedDownloadCountEvtChannel <- e.URL
 		})
 
 		loggerHook = test.NewGlobal()
@@ -49,7 +47,7 @@ var _ = Describe("Downloader", func() {
 	})
 
 	JustBeforeEach(func() {
-		sut = newDownloader(sutConfig, nil, nil)
+		sut = newDownloader(sutConfig, nil, bus)
 	})
 
 	Describe("NewDownloader", func() {
@@ -78,7 +76,7 @@ var _ = Describe("Downloader", func() {
 		When("Download was successful", func() {
 			BeforeEach(func() {
 				server = TestServer("line.one\nline.two")
-				sut = newDownloader(sutConfig, nil, nil)
+				sut = newDownloader(sutConfig, nil, bus)
 			})
 			It("Should return all lines from the file", func(ctx context.Context) {
 				reader, err := sut.DownloadFile(ctx, server.URL)

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -143,7 +143,7 @@ func (b *ListCache) refresh(ctx context.Context) error {
 
 			count := b.groupedCache.ElementCount(group)
 
-			evt.Bus().Publish(evt.BlockingCacheGroupChanged, b.listType, group, count)
+			evt.LegacyBus().Publish(evt.BlockingCacheGroupChanged, b.listType, group, count)
 
 			logger().WithFields(logrus.Fields{
 				"group":       group,

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -146,7 +146,11 @@ func (b *ListCache) refresh(ctx context.Context) error {
 
 			count := b.groupedCache.ElementCount(group)
 
-			evt.LegacyBus().Publish(evt.BlockingCacheGroupChanged, b.listType, group, count)
+			evt.Emit(b.bus, ctx, evt.BlockingCacheGroupChangedEvent{
+				ListType:  b.listType.String(),
+				GroupName: group,
+				Count:     count,
+			})
 
 			logger().WithFields(logrus.Fields{
 				"group":       group,

--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -45,6 +45,7 @@ type ListCache struct {
 	listType     ListCacheType
 	groupSources map[string][]config.BytesSource
 	downloader   FileDownloader
+	bus          *evt.Bus
 }
 
 // LogConfig implements `config.Configurable`.
@@ -73,6 +74,7 @@ func (b *ListCache) LogConfig(logger *logrus.Entry) {
 func NewListCache(ctx context.Context,
 	t ListCacheType, cfg config.SourceLoading,
 	groupSources map[string][]config.BytesSource, downloader FileDownloader,
+	bus *evt.Bus,
 ) (*ListCache, error) {
 	regexCache := stringcache.NewInMemoryGroupedRegexCache()
 
@@ -88,6 +90,7 @@ func NewListCache(ctx context.Context,
 		listType:     t,
 		groupSources: groupSources,
 		downloader:   downloader,
+		bus:          bus,
 	}
 
 	err := cfg.StartPeriodicRefresh(ctx, c.refresh, func(err error) {

--- a/lists/list_cache_benchmark_test.go
+++ b/lists/list_cache_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/evt"
 )
 
 func BenchmarkRefresh(b *testing.B) {
@@ -19,8 +20,8 @@ func BenchmarkRefresh(b *testing.B) {
 		Concurrency:   5,
 		RefreshPeriod: config.Duration(-1),
 	}
-	downloader := NewDownloader(config.Downloader{}, nil)
-	cache, _ := NewListCache(context.Background(), ListCacheTypeDenylist, cfg, lists, downloader)
+	downloader := NewDownloader(config.Downloader{}, nil, evt.NewBus())
+	cache, _ := NewListCache(context.Background(), ListCacheTypeDenylist, cfg, lists, downloader, evt.NewBus())
 
 	b.ReportAllocs()
 

--- a/lists/list_cache_test.go
+++ b/lists/list_cache_test.go
@@ -54,7 +54,7 @@ var _ = Describe("ListCache", func() {
 
 		sutConfig.RefreshPeriod = -1
 
-		downloader = NewDownloader(config.Downloader{}, nil)
+		downloader = NewDownloader(config.Downloader{}, nil, NewBus())
 		mockDownloader = nil
 
 		server1 = TestServer("blocked1.com\nblocked1a.com\n192.168.178.55")
@@ -78,7 +78,7 @@ var _ = Describe("ListCache", func() {
 			downloader = mockDownloader
 		}
 
-		sut, err = NewListCache(ctx, listCacheType, sutConfig, lists, downloader)
+		sut, err = NewListCache(ctx, listCacheType, sutConfig, lists, downloader, NewBus())
 		if expectFail {
 			Expect(err).Should(HaveOccurred())
 		} else {
@@ -318,7 +318,7 @@ var _ = Describe("ListCache", func() {
 				}
 			})
 			It("should match", func() {
-				sut, err = NewListCache(ctx, ListCacheTypeDenylist, sutConfig, lists, downloader)
+				sut, err = NewListCache(ctx, ListCacheTypeDenylist, sutConfig, lists, downloader, NewBus())
 				Expect(err).Should(Succeed())
 
 				Expect(sut.groupedCache.ElementCount("gr1")).Should(Equal(lines1 + lines2 + lines3))
@@ -420,7 +420,7 @@ var _ = Describe("ListCache", func() {
 		})
 
 		It("should print list configuration", func() {
-			sut, err = NewListCache(ctx, ListCacheTypeDenylist, sutConfig, lists, downloader)
+			sut, err = NewListCache(ctx, ListCacheTypeDenylist, sutConfig, lists, downloader, NewBus())
 			Expect(err).Should(Succeed())
 
 			sut.LogConfig(logger)
@@ -444,7 +444,7 @@ var _ = Describe("ListCache", func() {
 			})
 
 			It("should never return an error", func() {
-				_, err := NewListCache(ctx, ListCacheTypeDenylist, sutConfig, lists, downloader)
+				_, err := NewListCache(ctx, ListCacheTypeDenylist, sutConfig, lists, downloader, NewBus())
 				Expect(err).Should(Succeed())
 			})
 		})

--- a/lists/list_cache_test.go
+++ b/lists/list_cache_test.go
@@ -36,6 +36,7 @@ var _ = Describe("ListCache", func() {
 		lists          map[string][]config.BytesSource
 		downloader     FileDownloader
 		mockDownloader *MockFileDownloader
+		bus            *Bus
 		ctx            context.Context
 		cancelFn       context.CancelFunc
 		err            error
@@ -54,6 +55,7 @@ var _ = Describe("ListCache", func() {
 
 		sutConfig.RefreshPeriod = -1
 
+		bus = NewBus()
 		downloader = NewDownloader(config.Downloader{}, nil, NewBus())
 		mockDownloader = nil
 
@@ -78,7 +80,7 @@ var _ = Describe("ListCache", func() {
 			downloader = mockDownloader
 		}
 
-		sut, err = NewListCache(ctx, listCacheType, sutConfig, lists, downloader, NewBus())
+		sut, err = NewListCache(ctx, listCacheType, sutConfig, lists, downloader, bus)
 		if expectFail {
 			Expect(err).Should(HaveOccurred())
 		} else {
@@ -271,8 +273,8 @@ var _ = Describe("ListCache", func() {
 					"gr1": config.NewBytesSources(server1.URL),
 				}
 
-				_ = LegacyBus().SubscribeOnce(BlockingCacheGroupChanged, func(listType ListCacheType, group string, cnt int) {
-					resultCnt = cnt
+				Subscribe(bus, "test:blocking-cache-group", func(_ context.Context, e BlockingCacheGroupChangedEvent) {
+					resultCnt = e.Count
 				})
 			})
 

--- a/lists/list_cache_test.go
+++ b/lists/list_cache_test.go
@@ -271,7 +271,7 @@ var _ = Describe("ListCache", func() {
 					"gr1": config.NewBytesSources(server1.URL),
 				}
 
-				_ = Bus().SubscribeOnce(BlockingCacheGroupChanged, func(listType ListCacheType, group string, cnt int) {
+				_ = LegacyBus().SubscribeOnce(BlockingCacheGroupChanged, func(listType ListCacheType, group string, cnt int) {
 					resultCnt = cnt
 				})
 			})

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -43,7 +43,7 @@ func registerBlockingEventListeners() {
 
 	RegisterMetric(enabledGauge)
 
-	subscribe(evt.BlockingEnabledEvent, func(enabled bool) {
+	subscribe(evt.BlockingEnabledTopic, func(enabled bool) {
 		if enabled {
 			enabledGauge.Set(1)
 		} else {

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -12,7 +12,7 @@ import (
 )
 
 // RegisterEventListeners registers all metric handlers by the event bus
-func RegisterEventListeners() {
+func RegisterEventListeners(bus *evt.Bus) {
 	registerBlockingEventListeners()
 	registerCachingEventListeners()
 	registerApplicationEventListeners()

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -15,15 +16,15 @@ import (
 func RegisterEventListeners(bus *evt.Bus) {
 	registerBlockingEventListeners()
 	registerCachingEventListeners()
-	registerApplicationEventListeners()
+	registerApplicationEventListeners(bus)
 }
 
-func registerApplicationEventListeners() {
+func registerApplicationEventListeners(bus *evt.Bus) {
 	v := versionNumberGauge()
 	RegisterMetric(v)
 
-	subscribe(evt.ApplicationStarted, func(version, buildTime string) {
-		v.WithLabelValues(version, buildTime).Set(1)
+	evt.Subscribe(bus, "metrics:app-started", func(_ context.Context, e evt.AppStartedEvent) {
+		v.WithLabelValues(e.Version, e.BuildTime).Set(1)
 	})
 }
 

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -14,7 +14,7 @@ import (
 
 // RegisterEventListeners registers all metric handlers by the event bus
 func RegisterEventListeners(bus *evt.Bus) {
-	registerBlockingEventListeners()
+	registerBlockingEventListeners(bus)
 	registerCachingEventListeners(bus)
 	registerApplicationEventListeners(bus)
 }
@@ -39,7 +39,7 @@ func versionNumberGauge() *prometheus.GaugeVec {
 	return denylistCnt
 }
 
-func registerBlockingEventListeners() {
+func registerBlockingEventListeners(bus *evt.Bus) {
 	enabledGauge := enabledGauge()
 
 	RegisterMetric(enabledGauge)
@@ -62,14 +62,14 @@ func registerBlockingEventListeners() {
 	RegisterMetric(allowlistCnt)
 	RegisterMetric(lastListGroupRefresh)
 
-	subscribe(evt.BlockingCacheGroupChanged, func(listType lists.ListCacheType, groupName string, cnt int) {
+	evt.Subscribe(bus, "metrics:blocking-cache-group", func(_ context.Context, e evt.BlockingCacheGroupChangedEvent) {
 		lastListGroupRefresh.Set(float64(time.Now().Unix()))
 
-		switch listType {
-		case lists.ListCacheTypeDenylist:
-			denylistCnt.WithLabelValues(groupName).Set(float64(cnt))
-		case lists.ListCacheTypeAllowlist:
-			allowlistCnt.WithLabelValues(groupName).Set(float64(cnt))
+		switch e.ListType {
+		case lists.ListCacheTypeDenylist.String():
+			denylistCnt.WithLabelValues(e.GroupName).Set(float64(e.Count))
+		case lists.ListCacheTypeAllowlist.String():
+			allowlistCnt.WithLabelValues(e.GroupName).Set(float64(e.Count))
 		}
 	})
 }
@@ -144,9 +144,7 @@ func registerCachingEventListeners(bus *evt.Bus) {
 		entryCount.Set(float64(e.Size))
 	})
 
-	// CachingFailedDownload subscription stays on the legacy bus for now;
-	// it migrates in Task 7.
-	subscribe(evt.CachingFailedDownloadChanged, func(_ string) {
+	evt.Subscribe(bus, "metrics:failed-download", func(_ context.Context, _ evt.CachingFailedDownloadEvent) {
 		failedDownloadCount.Inc()
 	})
 }

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -15,7 +15,7 @@ import (
 // RegisterEventListeners registers all metric handlers by the event bus
 func RegisterEventListeners(bus *evt.Bus) {
 	registerBlockingEventListeners()
-	registerCachingEventListeners()
+	registerCachingEventListeners(bus)
 	registerApplicationEventListeners(bus)
 }
 
@@ -115,7 +115,7 @@ func lastListGroupRefresh() prometheus.Gauge {
 	)
 }
 
-func registerCachingEventListeners() {
+func registerCachingEventListeners(bus *evt.Bus) {
 	entryCount := cacheEntryCount()
 	prefetchDomainCount := prefetchDomainCacheCount()
 	prefetchCount := domainPrefetchCount()
@@ -128,22 +128,24 @@ func registerCachingEventListeners() {
 	RegisterMetric(prefetchHitCount)
 	RegisterMetric(failedDownloadCount)
 
-	subscribe(evt.CachingDomainsToPrefetchCountChanged, func(cnt int) {
-		prefetchDomainCount.Set(float64(cnt))
+	evt.Subscribe(bus, "metrics:prefetch-count", func(_ context.Context, e evt.CachingDomainsToPrefetchCountChangedEvent) {
+		prefetchDomainCount.Set(float64(e.Count))
 	})
 
-	subscribe(evt.CachingDomainPrefetched, func(_ string) {
+	evt.Subscribe(bus, "metrics:prefetched", func(_ context.Context, _ evt.CachingDomainPrefetchedEvent) {
 		prefetchCount.Inc()
 	})
 
-	subscribe(evt.CachingPrefetchCacheHit, func(_ string) {
+	evt.Subscribe(bus, "metrics:prefetch-hit", func(_ context.Context, _ evt.CachingPrefetchCacheHitEvent) {
 		prefetchHitCount.Inc()
 	})
 
-	subscribe(evt.CachingResultCacheChanged, func(cnt int) {
-		entryCount.Set(float64(cnt))
+	evt.Subscribe(bus, "metrics:result-cache-size", func(_ context.Context, e evt.CachingResultCacheChangedEvent) {
+		entryCount.Set(float64(e.Size))
 	})
 
+	// CachingFailedDownload subscription stays on the legacy bus for now;
+	// it migrates in Task 7.
 	subscribe(evt.CachingFailedDownloadChanged, func(_ string) {
 		failedDownloadCount.Inc()
 	})

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -2,12 +2,10 @@ package metrics
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/0xERR0R/blocky/evt"
 	"github.com/0xERR0R/blocky/lists"
-	"github.com/0xERR0R/blocky/util"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -44,8 +42,8 @@ func registerBlockingEventListeners(bus *evt.Bus) {
 
 	RegisterMetric(enabledGauge)
 
-	subscribe(evt.BlockingEnabledTopic, func(enabled bool) {
-		if enabled {
+	evt.Subscribe(bus, "metrics:blocking-enabled", func(_ context.Context, e evt.BlockingEnabledEvent) {
+		if e.Enabled {
 			enabledGauge.Set(1)
 		} else {
 			enabledGauge.Set(0)
@@ -190,8 +188,4 @@ func prefetchDomainCacheCount() prometheus.Gauge {
 			Help: "Number of entries in domain cache",
 		},
 	)
-}
-
-func subscribe(topic string, fn any) {
-	util.FatalOnError(fmt.Sprintf("can't subscribe topic '%s'", topic), evt.LegacyBus().Subscribe(topic, fn))
 }

--- a/metrics/metrics_event_publisher.go
+++ b/metrics/metrics_event_publisher.go
@@ -192,5 +192,5 @@ func prefetchDomainCacheCount() prometheus.Gauge {
 }
 
 func subscribe(topic string, fn any) {
-	util.FatalOnError(fmt.Sprintf("can't subscribe topic '%s'", topic), evt.Bus().Subscribe(topic, fn))
+	util.FatalOnError(fmt.Sprintf("can't subscribe topic '%s'", topic), evt.LegacyBus().Subscribe(topic, fn))
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -146,8 +146,12 @@ func TestAllExpectedMetricsAreRegistered(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to call metrics resolver")
 	}
-	evt.LegacyBus().Publish(evt.BlockingCacheGroupChanged, lists.ListCacheTypeDenylist, "group", 0)
-	evt.LegacyBus().Publish(evt.BlockingCacheGroupChanged, lists.ListCacheTypeAllowlist, "group", 0)
+	evt.Emit(bus, context.Background(), evt.BlockingCacheGroupChangedEvent{
+		ListType: lists.ListCacheTypeDenylist.String(), GroupName: "group", Count: 0,
+	})
+	evt.Emit(bus, context.Background(), evt.BlockingCacheGroupChangedEvent{
+		ListType: lists.ListCacheTypeAllowlist.String(), GroupName: "group", Count: 0,
+	})
 
 	// createHTTPRouter
 	metrics.Start(chi.NewMux(), config)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -145,8 +145,8 @@ func TestAllExpectedMetricsAreRegistered(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to call metrics resolver")
 	}
-	evt.Bus().Publish(evt.BlockingCacheGroupChanged, lists.ListCacheTypeDenylist, "group", 0)
-	evt.Bus().Publish(evt.BlockingCacheGroupChanged, lists.ListCacheTypeAllowlist, "group", 0)
+	evt.LegacyBus().Publish(evt.BlockingCacheGroupChanged, lists.ListCacheTypeDenylist, "group", 0)
+	evt.LegacyBus().Publish(evt.BlockingCacheGroupChanged, lists.ListCacheTypeAllowlist, "group", 0)
 
 	// createHTTPRouter
 	metrics.Start(chi.NewMux(), config)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -118,7 +118,8 @@ func (m *MockResolver) Type() string {
 
 func TestAllExpectedMetricsAreRegistered(t *testing.T) {
 	// New Server
-	metrics.RegisterEventListeners()
+	bus := evt.NewBus()
+	metrics.RegisterEventListeners(bus)
 
 	config := config.Metrics{Enable: true, Path: "/metrics"}
 

--- a/redis/event_bridge.go
+++ b/redis/event_bridge.go
@@ -16,6 +16,7 @@ import (
 const (
 	EventBridgeChannel   = "blocky_sync_enabled"
 	bridgePublishTimeout = 5 * time.Second
+	eventBridgeSubKey    = "redis:bridge"
 )
 
 type bridgeMessage struct {
@@ -50,17 +51,15 @@ func NewEventBusBridge(ctx context.Context, client *goredis.Client, bus *evt.Bus
 		bus:     bus,
 	}
 
-	if err := evt.LegacyBus().Subscribe(evt.BlockingStateChanged, b.onLocalStateChanged); err != nil {
-		cancel()
-
-		return nil, err
-	}
+	evt.Subscribe(b.bus, eventBridgeSubKey, func(_ context.Context, e evt.BlockingStateChangedEvent) {
+		b.onLocalStateChanged(e.State)
+	})
 
 	ps := client.Subscribe(ctx, b.channel)
 
 	if _, err := ps.Receive(ctx); err != nil {
 		_ = ps.Close()
-		_ = evt.LegacyBus().Unsubscribe(evt.BlockingStateChanged, b.onLocalStateChanged)
+		evt.Unsubscribe[evt.BlockingStateChangedEvent](b.bus, eventBridgeSubKey)
 		cancel()
 
 		return nil, err
@@ -85,14 +84,12 @@ func NewEventBusBridge(ctx context.Context, client *goredis.Client, bus *evt.Bus
 // Close stops the subscriber goroutine and unsubscribes from the local event bus.
 // It is safe to call multiple times.
 func (b *EventBusBridge) Close() error {
-	var unsubErr error
-
 	b.once.Do(func() {
 		b.cancel()
-		unsubErr = evt.LegacyBus().Unsubscribe(evt.BlockingStateChanged, b.onLocalStateChanged)
+		evt.Unsubscribe[evt.BlockingStateChangedEvent](b.bus, eventBridgeSubKey)
 	})
 
-	return unsubErr
+	return nil
 }
 
 // onLocalStateChanged is called when a local blocking state change occurs.
@@ -126,7 +123,7 @@ func (b *EventBusBridge) onLocalStateChanged(state evt.BlockingState) {
 
 // handleMessage processes a single Redis pub/sub message, publishing remote
 // state changes to the local event bus and filtering out echoes.
-func (b *EventBusBridge) handleMessage(_ context.Context, payload string) {
+func (b *EventBusBridge) handleMessage(ctx context.Context, payload string) {
 	if len(payload) == 0 {
 		return
 	}
@@ -142,5 +139,5 @@ func (b *EventBusBridge) handleMessage(_ context.Context, payload string) {
 		return
 	}
 
-	evt.LegacyBus().Publish(evt.BlockingStateChangedRemote, bm.State)
+	evt.Emit(b.bus, ctx, evt.BlockingStateChangedRemoteEvent{State: bm.State})
 }

--- a/redis/event_bridge.go
+++ b/redis/event_bridge.go
@@ -48,7 +48,7 @@ func NewEventBusBridge(ctx context.Context, client *goredis.Client) (*EventBusBr
 		done:    ctx.Done(),
 	}
 
-	if err := evt.Bus().Subscribe(evt.BlockingStateChanged, b.onLocalStateChanged); err != nil {
+	if err := evt.LegacyBus().Subscribe(evt.BlockingStateChanged, b.onLocalStateChanged); err != nil {
 		cancel()
 
 		return nil, err
@@ -58,7 +58,7 @@ func NewEventBusBridge(ctx context.Context, client *goredis.Client) (*EventBusBr
 
 	if _, err := ps.Receive(ctx); err != nil {
 		_ = ps.Close()
-		_ = evt.Bus().Unsubscribe(evt.BlockingStateChanged, b.onLocalStateChanged)
+		_ = evt.LegacyBus().Unsubscribe(evt.BlockingStateChanged, b.onLocalStateChanged)
 		cancel()
 
 		return nil, err
@@ -87,7 +87,7 @@ func (b *EventBusBridge) Close() error {
 
 	b.once.Do(func() {
 		b.cancel()
-		unsubErr = evt.Bus().Unsubscribe(evt.BlockingStateChanged, b.onLocalStateChanged)
+		unsubErr = evt.LegacyBus().Unsubscribe(evt.BlockingStateChanged, b.onLocalStateChanged)
 	})
 
 	return unsubErr
@@ -140,5 +140,5 @@ func (b *EventBusBridge) handleMessage(_ context.Context, payload string) {
 		return
 	}
 
-	evt.Bus().Publish(evt.BlockingStateChangedRemote, bm.State)
+	evt.LegacyBus().Publish(evt.BlockingStateChangedRemote, bm.State)
 }

--- a/redis/event_bridge.go
+++ b/redis/event_bridge.go
@@ -32,11 +32,12 @@ type EventBusBridge struct {
 	cancel  context.CancelFunc
 	done    <-chan struct{}
 	once    sync.Once
+	bus     *evt.Bus
 }
 
 // NewEventBusBridge creates a new EventBusBridge that synchronizes blocking state
 // between local event bus and Redis pub/sub.
-func NewEventBusBridge(ctx context.Context, client *goredis.Client) (*EventBusBridge, error) {
+func NewEventBusBridge(ctx context.Context, client *goredis.Client, bus *evt.Bus) (*EventBusBridge, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	b := &EventBusBridge{
@@ -46,6 +47,7 @@ func NewEventBusBridge(ctx context.Context, client *goredis.Client) (*EventBusBr
 		l:       log.PrefixedLog("redis-event-bridge"),
 		cancel:  cancel,
 		done:    ctx.Done(),
+		bus:     bus,
 	}
 
 	if err := evt.LegacyBus().Subscribe(evt.BlockingStateChanged, b.onLocalStateChanged); err != nil {

--- a/redis/event_bridge_test.go
+++ b/redis/event_bridge_test.go
@@ -18,6 +18,7 @@ var _ = Describe("EventBusBridge", func() {
 		redisServer *miniredis.Miniredis
 		redisClient *goredis.Client
 		bridge      *EventBusBridge
+		bus         *evt.Bus
 		ctx         context.Context
 		cancel      context.CancelFunc
 	)
@@ -36,7 +37,8 @@ var _ = Describe("EventBusBridge", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 		DeferCleanup(cancel)
 
-		bridge, err = NewEventBusBridge(ctx, redisClient, evt.NewBus())
+		bus = evt.NewBus()
+		bridge, err = NewEventBusBridge(ctx, redisClient, bus)
 		Expect(err).Should(Succeed())
 		DeferCleanup(func() { bridge.Close() })
 	})
@@ -63,23 +65,19 @@ var _ = Describe("EventBusBridge", func() {
 		When("BlockingStateChanged is published on the local bus", func() {
 			It("should publish a message to the Redis channel that a second subscriber receives", func(specCtx context.Context) {
 				// Create a second bridge to act as receiver
-				bridge2, err := NewEventBusBridge(ctx, redisClient, evt.NewBus())
+				bridge2Bus := evt.NewBus()
+				bridge2, err := NewEventBusBridge(ctx, redisClient, bridge2Bus)
 				Expect(err).Should(Succeed())
 				DeferCleanup(func() { bridge2.Close() })
 
 				receivedStates := make(chan evt.BlockingState, 1)
 
-				handler := func(state evt.BlockingState) {
-					receivedStates <- state
-				}
-
-				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				DeferCleanup(func() {
-					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				evt.Subscribe(bridge2Bus, "test:remote-state", func(_ context.Context, e evt.BlockingStateChangedRemoteEvent) {
+					receivedStates <- e.State
 				})
 
 				expectedState := evt.BlockingState{Enabled: true}
-				evt.LegacyBus().Publish(evt.BlockingStateChanged, expectedState)
+				evt.Emit(bus, ctx, evt.BlockingStateChangedEvent{State: expectedState})
 
 				Eventually(receivedStates).WithTimeout(2 * time.Second).WithPolling(50 * time.Millisecond).Should(Receive(Equal(expectedState)))
 			}, SpecTimeout(3*time.Second))
@@ -91,13 +89,8 @@ var _ = Describe("EventBusBridge", func() {
 			It("should fire BlockingStateChangedRemote on the local bus with the correct state", func(specCtx context.Context) {
 				receivedStates := make(chan evt.BlockingState, 1)
 
-				handler := func(state evt.BlockingState) {
-					receivedStates <- state
-				}
-
-				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				DeferCleanup(func() {
-					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				evt.Subscribe(bus, "test:remote-state", func(_ context.Context, e evt.BlockingStateChangedRemoteEvent) {
+					receivedStates <- e.State
 				})
 
 				otherID := uuid.NewString()
@@ -126,13 +119,8 @@ var _ = Describe("EventBusBridge", func() {
 			It("should NOT fire BlockingStateChangedRemote on the local bus", func(specCtx context.Context) {
 				receivedStates := make(chan evt.BlockingState, 1)
 
-				handler := func(state evt.BlockingState) {
-					receivedStates <- state
-				}
-
-				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				DeferCleanup(func() {
-					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				evt.Subscribe(bus, "test:remote-state", func(_ context.Context, e evt.BlockingStateChangedRemoteEvent) {
+					receivedStates <- e.State
 				})
 
 				payload, err := json.Marshal(bridgeMessage{
@@ -162,13 +150,8 @@ var _ = Describe("EventBusBridge", func() {
 			It("should ignore it without error", func(specCtx context.Context) {
 				receivedStates := make(chan evt.BlockingState, 1)
 
-				handler := func(state evt.BlockingState) {
-					receivedStates <- state
-				}
-
-				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				DeferCleanup(func() {
-					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				evt.Subscribe(bus, "test:remote-state", func(_ context.Context, e evt.BlockingStateChangedRemoteEvent) {
+					receivedStates <- e.State
 				})
 
 				// Publish empty payload
@@ -182,13 +165,8 @@ var _ = Describe("EventBusBridge", func() {
 			It("should skip it without firing an event", func(specCtx context.Context) {
 				receivedStates := make(chan evt.BlockingState, 1)
 
-				handler := func(state evt.BlockingState) {
-					receivedStates <- state
-				}
-
-				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				DeferCleanup(func() {
-					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				evt.Subscribe(bus, "test:remote-state", func(_ context.Context, e evt.BlockingStateChangedRemoteEvent) {
+					receivedStates <- e.State
 				})
 
 				redisServer.Publish(EventBridgeChannel, "not-valid-json{{{")
@@ -216,13 +194,8 @@ var _ = Describe("EventBusBridge", func() {
 			It("should not panic when pub/sub connection drops", func(specCtx context.Context) {
 				receivedStates := make(chan evt.BlockingState, 5)
 
-				handler := func(state evt.BlockingState) {
-					receivedStates <- state
-				}
-
-				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				DeferCleanup(func() {
-					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				evt.Subscribe(bus, "test:remote-state", func(_ context.Context, e evt.BlockingStateChangedRemoteEvent) {
+					receivedStates <- e.State
 				})
 
 				otherID := uuid.NewString()
@@ -292,23 +265,16 @@ var _ = Describe("EventBusBridge", func() {
 			It("should preserve Duration and Groups through local → Redis → remote", func(specCtx context.Context) {
 				receivedStates := make(chan evt.BlockingState, 1)
 
-				handler := func(state evt.BlockingState) {
-					receivedStates <- state
-				}
-
-				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				DeferCleanup(func() {
-					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				})
-
 				// Create a second bridge acting as the "remote" receiver
-				bridge2, err := NewEventBusBridge(ctx, redisClient, evt.NewBus())
+				bridge2Bus := evt.NewBus()
+				bridge2, err := NewEventBusBridge(ctx, redisClient, bridge2Bus)
 				Expect(err).Should(Succeed())
 				DeferCleanup(func() { bridge2.Close() })
 
-				// Override bridge2's handler to forward to our channel
-				Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				// Subscribe on bridge2's bus to forward remote state to our channel
+				evt.Subscribe(bridge2Bus, "test:remote-state", func(_ context.Context, e evt.BlockingStateChangedRemoteEvent) {
+					receivedStates <- e.State
+				})
 
 				// Publish from bridge (bridge2 should receive since UUIDs differ)
 				originalState := evt.BlockingState{

--- a/redis/event_bridge_test.go
+++ b/redis/event_bridge_test.go
@@ -73,13 +73,13 @@ var _ = Describe("EventBusBridge", func() {
 					receivedStates <- state
 				}
 
-				Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				DeferCleanup(func() {
-					Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				})
 
 				expectedState := evt.BlockingState{Enabled: true}
-				evt.Bus().Publish(evt.BlockingStateChanged, expectedState)
+				evt.LegacyBus().Publish(evt.BlockingStateChanged, expectedState)
 
 				Eventually(receivedStates).WithTimeout(2 * time.Second).WithPolling(50 * time.Millisecond).Should(Receive(Equal(expectedState)))
 			}, SpecTimeout(3*time.Second))
@@ -95,9 +95,9 @@ var _ = Describe("EventBusBridge", func() {
 					receivedStates <- state
 				}
 
-				Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				DeferCleanup(func() {
-					Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				})
 
 				otherID := uuid.NewString()
@@ -130,9 +130,9 @@ var _ = Describe("EventBusBridge", func() {
 					receivedStates <- state
 				}
 
-				Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				DeferCleanup(func() {
-					Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				})
 
 				payload, err := json.Marshal(bridgeMessage{
@@ -166,9 +166,9 @@ var _ = Describe("EventBusBridge", func() {
 					receivedStates <- state
 				}
 
-				Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				DeferCleanup(func() {
-					Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				})
 
 				// Publish empty payload
@@ -186,9 +186,9 @@ var _ = Describe("EventBusBridge", func() {
 					receivedStates <- state
 				}
 
-				Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				DeferCleanup(func() {
-					Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				})
 
 				redisServer.Publish(EventBridgeChannel, "not-valid-json{{{")
@@ -220,9 +220,9 @@ var _ = Describe("EventBusBridge", func() {
 					receivedStates <- state
 				}
 
-				Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				DeferCleanup(func() {
-					Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				})
 
 				otherID := uuid.NewString()
@@ -296,9 +296,9 @@ var _ = Describe("EventBusBridge", func() {
 					receivedStates <- state
 				}
 
-				Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				DeferCleanup(func() {
-					Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+					Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 				})
 
 				// Create a second bridge acting as the "remote" receiver
@@ -307,8 +307,8 @@ var _ = Describe("EventBusBridge", func() {
 				DeferCleanup(func() { bridge2.Close() })
 
 				// Override bridge2's handler to forward to our channel
-				Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
-				Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+				Expect(evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
 
 				// Publish from bridge (bridge2 should receive since UUIDs differ)
 				originalState := evt.BlockingState{

--- a/redis/event_bridge_test.go
+++ b/redis/event_bridge_test.go
@@ -36,7 +36,7 @@ var _ = Describe("EventBusBridge", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 		DeferCleanup(cancel)
 
-		bridge, err = NewEventBusBridge(ctx, redisClient)
+		bridge, err = NewEventBusBridge(ctx, redisClient, evt.NewBus())
 		Expect(err).Should(Succeed())
 		DeferCleanup(func() { bridge.Close() })
 	})
@@ -53,7 +53,7 @@ var _ = Describe("EventBusBridge", func() {
 				newCtx, newCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 				DeferCleanup(newCancel)
 
-				_, err := NewEventBusBridge(newCtx, deadClient)
+				_, err := NewEventBusBridge(newCtx, deadClient, evt.NewBus())
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -63,7 +63,7 @@ var _ = Describe("EventBusBridge", func() {
 		When("BlockingStateChanged is published on the local bus", func() {
 			It("should publish a message to the Redis channel that a second subscriber receives", func(specCtx context.Context) {
 				// Create a second bridge to act as receiver
-				bridge2, err := NewEventBusBridge(ctx, redisClient)
+				bridge2, err := NewEventBusBridge(ctx, redisClient, evt.NewBus())
 				Expect(err).Should(Succeed())
 				DeferCleanup(func() { bridge2.Close() })
 
@@ -254,7 +254,7 @@ var _ = Describe("EventBusBridge", func() {
 				// Create a new bridge with its own context
 				bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
 
-				b, err := NewEventBusBridge(bridgeCtx, redisClient)
+				b, err := NewEventBusBridge(bridgeCtx, redisClient, evt.NewBus())
 				Expect(err).Should(Succeed())
 
 				// Close the Redis server to trigger reconnection
@@ -302,7 +302,7 @@ var _ = Describe("EventBusBridge", func() {
 				})
 
 				// Create a second bridge acting as the "remote" receiver
-				bridge2, err := NewEventBusBridge(ctx, redisClient)
+				bridge2, err := NewEventBusBridge(ctx, redisClient, evt.NewBus())
 				Expect(err).Should(Succeed())
 				DeferCleanup(func() { bridge2.Close() })
 

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -256,7 +256,7 @@ func (r *BlockingResolver) internalEnableBlocking() {
 	s.enabled = true
 	s.disabledGroups = []string{}
 
-	evt.LegacyBus().Publish(evt.BlockingEnabledEvent, true)
+	evt.LegacyBus().Publish(evt.BlockingEnabledTopic, true)
 }
 
 // DisableBlocking deactivates the blocking for a particular duration (or forever if 0).
@@ -297,7 +297,7 @@ func (r *BlockingResolver) internalDisableBlocking(ctx context.Context, duration
 	}
 
 	s.enabled = false
-	evt.LegacyBus().Publish(evt.BlockingEnabledEvent, false)
+	evt.LegacyBus().Publish(evt.BlockingEnabledTopic, false)
 
 	s.disableEnd = time.Now().Add(duration)
 

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -194,26 +194,24 @@ func (r *BlockingResolver) subscribeEvents(ctx context.Context) error {
 		go r.initFQDNIPCache(ctx)
 	})
 
-	remoteHandler := func(state evt.BlockingState) {
+	const remoteKey = "blocking:remote-state"
+
+	evt.Subscribe(r.bus, remoteKey, func(_ context.Context, e evt.BlockingStateChangedRemoteEvent) {
+		state := e.State
 		go func() {
 			if state.Enabled {
-				r.internalEnableBlocking()
+				r.internalEnableBlocking(ctx)
 			} else {
 				if disableErr := r.internalDisableBlocking(ctx, state.Duration, state.Groups); disableErr != nil {
 					log.PrefixedLog("blocking").Warn("blocking couldn't be disabled: ", disableErr)
 				}
 			}
 		}()
-	}
-
-	err := evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, remoteHandler)
-	if err != nil {
-		return fmt.Errorf("failed to subscribe to %s: %w", evt.BlockingStateChangedRemote, err)
-	}
+	})
 
 	go func() {
 		<-ctx.Done()
-		_ = evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, remoteHandler)
+		evt.Unsubscribe[evt.BlockingStateChangedRemoteEvent](r.bus, remoteKey)
 	}()
 
 	return nil
@@ -244,11 +242,11 @@ func (r *BlockingResolver) retrieveAllBlockingGroups() []string {
 
 // EnableBlocking enables the blocking against the denylists
 func (r *BlockingResolver) EnableBlocking(ctx context.Context) {
-	r.internalEnableBlocking()
-	evt.LegacyBus().Publish(evt.BlockingStateChanged, evt.BlockingState{Enabled: true})
+	r.internalEnableBlocking(ctx)
+	evt.Emit(r.bus, ctx, evt.BlockingStateChangedEvent{State: evt.BlockingState{Enabled: true}})
 }
 
-func (r *BlockingResolver) internalEnableBlocking() {
+func (r *BlockingResolver) internalEnableBlocking(ctx context.Context) {
 	s := r.status
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -256,18 +254,18 @@ func (r *BlockingResolver) internalEnableBlocking() {
 	s.enabled = true
 	s.disabledGroups = []string{}
 
-	evt.LegacyBus().Publish(evt.BlockingEnabledTopic, true)
+	evt.Emit(r.bus, ctx, evt.BlockingEnabledEvent{Enabled: true})
 }
 
 // DisableBlocking deactivates the blocking for a particular duration (or forever if 0).
 func (r *BlockingResolver) DisableBlocking(ctx context.Context, duration time.Duration, disableGroups []string) error {
 	err := r.internalDisableBlocking(ctx, duration, disableGroups)
 	if err == nil {
-		evt.LegacyBus().Publish(evt.BlockingStateChanged, evt.BlockingState{
+		evt.Emit(r.bus, ctx, evt.BlockingStateChangedEvent{State: evt.BlockingState{
 			Enabled:  false,
 			Duration: duration,
 			Groups:   disableGroups,
-		})
+		}})
 	}
 
 	return err
@@ -297,7 +295,7 @@ func (r *BlockingResolver) internalDisableBlocking(ctx context.Context, duration
 	}
 
 	s.enabled = false
-	evt.LegacyBus().Publish(evt.BlockingEnabledTopic, false)
+	evt.Emit(r.bus, ctx, evt.BlockingEnabledEvent{Enabled: false})
 
 	s.disableEnd = time.Now().Add(duration)
 

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -86,6 +86,7 @@ type BlockingResolver struct {
 	NextResolver
 	typed
 
+	bus                 *evt.Bus
 	denylistMatcher     *lists.ListCache
 	allowlistMatcher    *lists.ListCache
 	blockHandler        blockHandler
@@ -139,18 +140,19 @@ func clientGroupsBlock(cfg config.Blocking) map[string][]scheduledGroup {
 func NewBlockingResolver(ctx context.Context,
 	cfg config.Blocking,
 	bootstrap *Bootstrap,
+	bus *evt.Bus,
 ) (r *BlockingResolver, err error) {
 	blockHandler, err := createBlockHandler(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block handler: %w", err)
 	}
 
-	downloader := lists.NewDownloader(cfg.Loading.Downloads, bootstrap.NewHTTPTransport())
+	downloader := lists.NewDownloader(cfg.Loading.Downloads, bootstrap.NewHTTPTransport(), bus)
 
 	denylistMatcher, blErr := lists.NewListCache(ctx, lists.ListCacheTypeDenylist,
-		cfg.Loading, cfg.Denylists, downloader)
+		cfg.Loading, cfg.Denylists, downloader, bus)
 	allowlistMatcher, wlErr := lists.NewListCache(ctx, lists.ListCacheTypeAllowlist,
-		cfg.Loading, cfg.Allowlists, downloader)
+		cfg.Loading, cfg.Allowlists, downloader, bus)
 	allowlistOnlyGroups := determineAllowlistOnlyGroups(&cfg)
 
 	err = multierror.Append(err, blErr, wlErr).ErrorOrNil()
@@ -162,6 +164,7 @@ func NewBlockingResolver(ctx context.Context,
 		configurable: withConfig(&cfg),
 		typed:        withType("blocking"),
 
+		bus:                 bus,
 		blockHandler:        blockHandler,
 		denylistMatcher:     denylistMatcher,
 		allowlistMatcher:    allowlistMatcher,

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -190,12 +190,9 @@ func NewBlockingResolver(ctx context.Context,
 }
 
 func (r *BlockingResolver) subscribeEvents(ctx context.Context) error {
-	err := evt.LegacyBus().SubscribeOnce(evt.ApplicationStarted, func(_ ...string) {
+	evt.Subscribe(r.bus, "blocking:app-started", func(_ context.Context, _ evt.AppStartedEvent) {
 		go r.initFQDNIPCache(ctx)
 	})
-	if err != nil {
-		return fmt.Errorf("failed to subscribe to ApplicationStarted event: %w", err)
-	}
 
 	remoteHandler := func(state evt.BlockingState) {
 		go func() {
@@ -209,7 +206,7 @@ func (r *BlockingResolver) subscribeEvents(ctx context.Context) error {
 		}()
 	}
 
-	err = evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, remoteHandler)
+	err := evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, remoteHandler)
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to %s: %w", evt.BlockingStateChangedRemote, err)
 	}

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -187,7 +187,7 @@ func NewBlockingResolver(ctx context.Context,
 }
 
 func (r *BlockingResolver) subscribeEvents(ctx context.Context) error {
-	err := evt.Bus().SubscribeOnce(evt.ApplicationStarted, func(_ ...string) {
+	err := evt.LegacyBus().SubscribeOnce(evt.ApplicationStarted, func(_ ...string) {
 		go r.initFQDNIPCache(ctx)
 	})
 	if err != nil {
@@ -206,14 +206,14 @@ func (r *BlockingResolver) subscribeEvents(ctx context.Context) error {
 		}()
 	}
 
-	err = evt.Bus().Subscribe(evt.BlockingStateChangedRemote, remoteHandler)
+	err = evt.LegacyBus().Subscribe(evt.BlockingStateChangedRemote, remoteHandler)
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to %s: %w", evt.BlockingStateChangedRemote, err)
 	}
 
 	go func() {
 		<-ctx.Done()
-		_ = evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, remoteHandler)
+		_ = evt.LegacyBus().Unsubscribe(evt.BlockingStateChangedRemote, remoteHandler)
 	}()
 
 	return nil
@@ -245,7 +245,7 @@ func (r *BlockingResolver) retrieveAllBlockingGroups() []string {
 // EnableBlocking enables the blocking against the denylists
 func (r *BlockingResolver) EnableBlocking(ctx context.Context) {
 	r.internalEnableBlocking()
-	evt.Bus().Publish(evt.BlockingStateChanged, evt.BlockingState{Enabled: true})
+	evt.LegacyBus().Publish(evt.BlockingStateChanged, evt.BlockingState{Enabled: true})
 }
 
 func (r *BlockingResolver) internalEnableBlocking() {
@@ -256,14 +256,14 @@ func (r *BlockingResolver) internalEnableBlocking() {
 	s.enabled = true
 	s.disabledGroups = []string{}
 
-	evt.Bus().Publish(evt.BlockingEnabledEvent, true)
+	evt.LegacyBus().Publish(evt.BlockingEnabledEvent, true)
 }
 
 // DisableBlocking deactivates the blocking for a particular duration (or forever if 0).
 func (r *BlockingResolver) DisableBlocking(ctx context.Context, duration time.Duration, disableGroups []string) error {
 	err := r.internalDisableBlocking(ctx, duration, disableGroups)
 	if err == nil {
-		evt.Bus().Publish(evt.BlockingStateChanged, evt.BlockingState{
+		evt.LegacyBus().Publish(evt.BlockingStateChanged, evt.BlockingState{
 			Enabled:  false,
 			Duration: duration,
 			Groups:   disableGroups,
@@ -297,7 +297,7 @@ func (r *BlockingResolver) internalDisableBlocking(ctx context.Context, duration
 	}
 
 	s.enabled = false
-	evt.Bus().Publish(evt.BlockingEnabledEvent, false)
+	evt.LegacyBus().Publish(evt.BlockingEnabledEvent, false)
 
 	s.disableEnd = time.Now().Add(duration)
 

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -36,6 +36,7 @@ var _ = BeforeSuite(func() {
 var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 	var (
 		sut        *BlockingResolver
+		sutBus     *Bus
 		sutConfig  config.Blocking
 		m          *mockResolver
 		mockAnswer *dns.Msg
@@ -67,7 +68,8 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 
-		sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap, NewBus())
+		sutBus = NewBus()
+		sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap, sutBus)
 		Expect(err).Should(Succeed())
 		sut.Next(m)
 	})
@@ -1220,11 +1222,10 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Calling Rest API to deactivate blocking for 0.5 sec", func() {
 					enabled := make(chan bool, 1)
-					err := LegacyBus().SubscribeOnce(BlockingEnabledTopic, func(state bool) {
-						enabled <- state
+					Subscribe(sutBus, "test:enabled-1", func(_ context.Context, e BlockingEnabledEvent) {
+						enabled <- e.Enabled
 					})
-					Expect(err).Should(Succeed())
-					err = sut.DisableBlocking(context.TODO(), 500*time.Millisecond, []string{})
+					err := sut.DisableBlocking(context.TODO(), 500*time.Millisecond, []string{})
 					Expect(err).Should(Succeed())
 					Eventually(enabled, "1s").Should(Receive(BeFalse()))
 				})
@@ -1258,8 +1259,8 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Wait 1 sec and perform the same query again, should be blocked now", func() {
 					enabled := make(chan bool, 1)
-					_ = LegacyBus().SubscribeOnce(BlockingEnabledTopic, func(state bool) {
-						enabled <- state
+					Subscribe(sutBus, "test:enabled-2", func(_ context.Context, e BlockingEnabledEvent) {
+						enabled <- e.Enabled
 					})
 					// wait 1 sec
 					Eventually(enabled, "1s").Should(Receive(BeTrue()))
@@ -1310,11 +1311,10 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Calling Rest API to deactivate blocking for one group for 0.5 sec", func() {
 					enabled := make(chan bool, 1)
-					err := LegacyBus().SubscribeOnce(BlockingEnabledTopic, func(state bool) {
-						enabled <- false
+					Subscribe(sutBus, "test:enabled-1", func(_ context.Context, e BlockingEnabledEvent) {
+						enabled <- e.Enabled
 					})
-					Expect(err).Should(Succeed())
-					err = sut.DisableBlocking(context.TODO(), 500*time.Millisecond, []string{"group1"})
+					err := sut.DisableBlocking(context.TODO(), 500*time.Millisecond, []string{"group1"})
 					Expect(err).Should(Succeed())
 					Eventually(enabled, "1s").Should(Receive(BeFalse()))
 				})
@@ -1346,8 +1346,8 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Wait 1 sec and perform the same query again, should be blocked now", func() {
 					enabled := make(chan bool, 1)
-					_ = LegacyBus().SubscribeOnce(BlockingEnabledTopic, func(state bool) {
-						enabled <- state
+					Subscribe(sutBus, "test:enabled-2", func(_ context.Context, e BlockingEnabledEvent) {
+						enabled <- e.Enabled
 					})
 					// wait 1 sec
 					Eventually(enabled, "1s").Should(Receive(BeTrue()))
@@ -1438,7 +1438,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				Expect(sut.DisableBlocking(ctx, 0, []string{})).Should(Succeed())
 				Expect(sut.BlockingStatus().Enabled).Should(BeFalse())
 
-				LegacyBus().Publish(BlockingStateChangedRemote, BlockingState{Enabled: true})
+				Emit(sutBus, ctx, BlockingStateChangedRemoteEvent{State: BlockingState{Enabled: true}})
 
 				Eventually(func() bool {
 					return sut.BlockingStatus().Enabled
@@ -1447,10 +1447,10 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("BlockingStateChangedRemote with enabled=false is received", func() {
 			It("should disable blocking", func() {
-				LegacyBus().Publish(BlockingStateChangedRemote, BlockingState{
+				Emit(sutBus, ctx, BlockingStateChangedRemoteEvent{State: BlockingState{
 					Enabled: false,
 					Groups:  []string{},
-				})
+				}})
 
 				Eventually(func() bool {
 					return sut.BlockingStatus().Enabled

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -103,7 +103,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("List is refreshed", func() {
 			It("event should be fired", func() {
 				groupCnt := make(map[string]int)
-				err := Bus().Subscribe(BlockingCacheGroupChanged, func(listType lists.ListCacheType, group string, cnt int) {
+				err := LegacyBus().Subscribe(BlockingCacheGroupChanged, func(listType lists.ListCacheType, group string, cnt int) {
 					groupCnt[group] = cnt
 				})
 				Expect(err).Should(Succeed())
@@ -142,7 +142,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 					return nil, nil //nolint:nilnil
 				}
-				Bus().Publish(ApplicationStarted, "")
+				LegacyBus().Publish(ApplicationStarted, "")
 				Eventually(func(g Gomega) {
 					g.Expect(sut.Resolve(ctx, newRequestWithClient("blocked2.com.", A, "192.168.178.39", "client1"))).
 						Should(And(
@@ -1220,7 +1220,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Calling Rest API to deactivate blocking for 0.5 sec", func() {
 					enabled := make(chan bool, 1)
-					err := Bus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
+					err := LegacyBus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
 						enabled <- state
 					})
 					Expect(err).Should(Succeed())
@@ -1258,7 +1258,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Wait 1 sec and perform the same query again, should be blocked now", func() {
 					enabled := make(chan bool, 1)
-					_ = Bus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
+					_ = LegacyBus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
 						enabled <- state
 					})
 					// wait 1 sec
@@ -1310,7 +1310,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Calling Rest API to deactivate blocking for one group for 0.5 sec", func() {
 					enabled := make(chan bool, 1)
-					err := Bus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
+					err := LegacyBus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
 						enabled <- false
 					})
 					Expect(err).Should(Succeed())
@@ -1346,7 +1346,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Wait 1 sec and perform the same query again, should be blocked now", func() {
 					enabled := make(chan bool, 1)
-					_ = Bus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
+					_ = LegacyBus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
 						enabled <- state
 					})
 					// wait 1 sec
@@ -1438,7 +1438,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				Expect(sut.DisableBlocking(ctx, 0, []string{})).Should(Succeed())
 				Expect(sut.BlockingStatus().Enabled).Should(BeFalse())
 
-				Bus().Publish(BlockingStateChangedRemote, BlockingState{Enabled: true})
+				LegacyBus().Publish(BlockingStateChangedRemote, BlockingState{Enabled: true})
 
 				Eventually(func() bool {
 					return sut.BlockingStatus().Enabled
@@ -1447,7 +1447,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("BlockingStateChangedRemote with enabled=false is received", func() {
 			It("should disable blocking", func() {
-				Bus().Publish(BlockingStateChangedRemote, BlockingState{
+				LegacyBus().Publish(BlockingStateChangedRemote, BlockingState{
 					Enabled: false,
 					Groups:  []string{},
 				})

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -142,7 +142,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 					return nil, nil //nolint:nilnil
 				}
-				LegacyBus().Publish(ApplicationStarted, "")
+				Emit(sut.bus, ctx, AppStartedEvent{})
 				Eventually(func(g Gomega) {
 					g.Expect(sut.Resolve(ctx, newRequestWithClient("blocked2.com.", A, "192.168.178.39", "client1"))).
 						Should(And(

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/0xERR0R/blocky/config"
@@ -103,9 +104,14 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 		When("List is refreshed", func() {
 			It("event should be fired", func() {
+				// Groups refresh concurrently and signals dispatches each listener in its
+				// own goroutine, so guard the accumulator against concurrent writes/reads.
+				var mu sync.Mutex
 				groupCnt := make(map[string]int)
 				bus := NewBus()
 				Subscribe(bus, "test:blocking-cache-group", func(_ context.Context, e BlockingCacheGroupChangedEvent) {
+					mu.Lock()
+					defer mu.Unlock()
 					groupCnt[e.GroupName] = e.Count
 				})
 
@@ -114,7 +120,12 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap, bus)
 				Expect(err).Should(Succeed())
 
-				Eventually(groupCnt, "1s").Should(HaveLen(2))
+				Eventually(func() int {
+					mu.Lock()
+					defer mu.Unlock()
+
+					return len(groupCnt)
+				}, "1s").Should(Equal(2))
 			})
 		})
 	})

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/evt"
 	. "github.com/0xERR0R/blocky/helpertest"
-	"github.com/0xERR0R/blocky/lists"
 	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
 	"github.com/0xERR0R/blocky/util"
@@ -103,13 +102,14 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		When("List is refreshed", func() {
 			It("event should be fired", func() {
 				groupCnt := make(map[string]int)
-				err := LegacyBus().Subscribe(BlockingCacheGroupChanged, func(listType lists.ListCacheType, group string, cnt int) {
-					groupCnt[group] = cnt
+				bus := NewBus()
+				Subscribe(bus, "test:blocking-cache-group", func(_ context.Context, e BlockingCacheGroupChangedEvent) {
+					groupCnt[e.GroupName] = e.Count
 				})
-				Expect(err).Should(Succeed())
 
 				// recreate to trigger a reload
-				sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap, NewBus())
+				var err error
+				sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap, bus)
 				Expect(err).Should(Succeed())
 
 				Eventually(groupCnt, "1s").Should(HaveLen(2))

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -68,7 +68,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		m = &mockResolver{}
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 
-		sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap)
+		sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap, NewBus())
 		Expect(err).Should(Succeed())
 		sut.Next(m)
 	})
@@ -109,7 +109,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				Expect(err).Should(Succeed())
 
 				// recreate to trigger a reload
-				sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap)
+				sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap, NewBus())
 				Expect(err).Should(Succeed())
 
 				Eventually(groupCnt, "1s").Should(HaveLen(2))
@@ -1220,7 +1220,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Calling Rest API to deactivate blocking for 0.5 sec", func() {
 					enabled := make(chan bool, 1)
-					err := LegacyBus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
+					err := LegacyBus().SubscribeOnce(BlockingEnabledTopic, func(state bool) {
 						enabled <- state
 					})
 					Expect(err).Should(Succeed())
@@ -1258,7 +1258,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Wait 1 sec and perform the same query again, should be blocked now", func() {
 					enabled := make(chan bool, 1)
-					_ = LegacyBus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
+					_ = LegacyBus().SubscribeOnce(BlockingEnabledTopic, func(state bool) {
 						enabled <- state
 					})
 					// wait 1 sec
@@ -1310,7 +1310,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Calling Rest API to deactivate blocking for one group for 0.5 sec", func() {
 					enabled := make(chan bool, 1)
-					err := LegacyBus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
+					err := LegacyBus().SubscribeOnce(BlockingEnabledTopic, func(state bool) {
 						enabled <- false
 					})
 					Expect(err).Should(Succeed())
@@ -1346,7 +1346,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				By("Wait 1 sec and perform the same query again, should be blocked now", func() {
 					enabled := make(chan bool, 1)
-					_ = LegacyBus().SubscribeOnce(BlockingEnabledEvent, func(state bool) {
+					_ = LegacyBus().SubscribeOnce(BlockingEnabledTopic, func(state bool) {
 						enabled <- state
 					})
 					// wait 1 sec
@@ -1410,7 +1410,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			It("should return error", func() {
 				_, err := NewBlockingResolver(ctx, config.Blocking{
 					BlockType: "wrong",
-				}, systemResolverBootstrap)
+				}, systemResolverBootstrap, NewBus())
 
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring(
@@ -1426,7 +1426,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 						Init: config.Init{Strategy: config.InitStrategyFailOnError},
 					},
 					BlockType: "zeroIp",
-				}, systemResolverBootstrap)
+				}, systemResolverBootstrap, NewBus())
 				Expect(err).Should(HaveOccurred())
 			})
 		})

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -100,7 +100,7 @@ func NewBootstrap(ctx context.Context, cfg *config.Config) (b *Bootstrap, err er
 	}
 
 	b.bootstraped = bootstraped
-	cachingResolver, _ := newCachingResolver(ctx, cachingCfg, nil, false)
+	cachingResolver, _ := newCachingResolver(ctx, cachingCfg, nil, nil, false)
 
 	b.resolver = Chain(
 		NewFilteringResolver(cfg.Filtering),

--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -100,11 +100,12 @@ func NewBootstrap(ctx context.Context, cfg *config.Config) (b *Bootstrap, err er
 	}
 
 	b.bootstraped = bootstraped
-	cachingResolver, _ := newCachingResolver(ctx, cachingCfg, nil, nil, false)
+	// nil bus: this internal resolver must not emit events that would
+	// double-count against metrics for the main caching resolver.
+	cachingResolver, _ := newCachingResolver(ctx, cachingCfg, nil, nil)
 
 	b.resolver = Chain(
 		NewFilteringResolver(cfg.Filtering),
-		// false: no metrics, to not overwrite the main blocking resolver ones
 		cachingResolver,
 		newParallelBestResolver(pbCfg, bootstraped.Resolvers()),
 	)

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -52,6 +52,7 @@ type CachingResolver struct {
 	NextResolver
 	typed
 
+	bus              *evt.Bus
 	emitMetricEvents bool // disabled by Bootstrap
 
 	resultCache cache.ExpiringCache[[]byte]
@@ -63,18 +64,21 @@ type CachingResolver struct {
 func NewCachingResolver(ctx context.Context,
 	cfg config.Caching,
 	decorator CacheDecorator,
+	bus *evt.Bus,
 ) (*CachingResolver, error) {
-	return newCachingResolver(ctx, cfg, decorator, true)
+	return newCachingResolver(ctx, cfg, decorator, bus, true)
 }
 
 func newCachingResolver(ctx context.Context,
 	cfg config.Caching,
 	decorator CacheDecorator,
+	bus *evt.Bus,
 	emitMetricEvents bool,
 ) (*CachingResolver, error) {
 	c := &CachingResolver{
 		configurable:     withConfig(&cfg),
 		typed:            withType("caching"),
+		bus:              bus,
 		emitMetricEvents: emitMetricEvents,
 	}
 

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -364,7 +364,7 @@ func (r *CachingResolver) adjustTTLs(answer []dns.RR) (ttl time.Duration) {
 
 func (r *CachingResolver) publishMetricsIfEnabled(event string, val any) {
 	if r.emitMetricEvents {
-		evt.Bus().Publish(event, val)
+		evt.LegacyBus().Publish(event, val)
 	}
 }
 

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -52,8 +52,7 @@ type CachingResolver struct {
 	NextResolver
 	typed
 
-	bus              *evt.Bus
-	emitMetricEvents bool // disabled by Bootstrap
+	bus *evt.Bus
 
 	resultCache cache.ExpiringCache[[]byte]
 
@@ -66,20 +65,18 @@ func NewCachingResolver(ctx context.Context,
 	decorator CacheDecorator,
 	bus *evt.Bus,
 ) (*CachingResolver, error) {
-	return newCachingResolver(ctx, cfg, decorator, bus, true)
+	return newCachingResolver(ctx, cfg, decorator, bus)
 }
 
 func newCachingResolver(ctx context.Context,
 	cfg config.Caching,
 	decorator CacheDecorator,
 	bus *evt.Bus,
-	emitMetricEvents bool,
 ) (*CachingResolver, error) {
 	c := &CachingResolver{
-		configurable:     withConfig(&cfg),
-		typed:            withType("caching"),
-		bus:              bus,
-		emitMetricEvents: emitMetricEvents,
+		configurable: withConfig(&cfg),
+		typed:        withType("caching"),
+		bus:          bus,
 	}
 
 	configureCaches(ctx, c, &cfg)
@@ -108,7 +105,7 @@ func configureCaches(ctx context.Context, c *CachingResolver, cfg *config.Cachin
 			cacheMisses.Inc()
 		},
 		OnAfterPutFn: func(newSize int) {
-			c.publishMetricsIfEnabled(evt.CachingResultCacheChanged, newSize)
+			evt.Emit(c.bus, ctx, evt.CachingResultCacheChangedEvent{Size: newSize})
 		},
 	}
 
@@ -120,13 +117,13 @@ func configureCaches(ctx context.Context, c *CachingResolver, cfg *config.Cachin
 			PrefetchMaxItemsCount: cfg.PrefetchMaxItemsCount,
 			ReloadFn:              c.reloadCacheEntry,
 			OnPrefetchAfterPut: func(newSize int) {
-				c.publishMetricsIfEnabled(evt.CachingDomainsToPrefetchCountChanged, newSize)
+				evt.Emit(c.bus, ctx, evt.CachingDomainsToPrefetchCountChangedEvent{Count: newSize})
 			},
 			OnPrefetchEntryReloaded: func(key string) {
-				c.publishMetricsIfEnabled(evt.CachingDomainPrefetched, key)
+				evt.Emit(c.bus, ctx, evt.CachingDomainPrefetchedEvent{Domain: key})
 			},
 			OnPrefetchCacheHit: func(key string) {
-				c.publishMetricsIfEnabled(evt.CachingPrefetchCacheHit, key)
+				evt.Emit(c.bus, ctx, evt.CachingPrefetchCacheHitEvent{Domain: key})
 			},
 		}
 
@@ -364,12 +361,6 @@ func (r *CachingResolver) adjustTTLs(answer []dns.RR) (ttl time.Duration) {
 	}
 
 	return time.Duration(minTTL) * time.Second
-}
-
-func (r *CachingResolver) publishMetricsIfEnabled(event string, val any) {
-	if r.emitMetricEvents {
-		evt.LegacyBus().Publish(event, val)
-	}
 }
 
 func (r *CachingResolver) FlushCaches(ctx context.Context) {

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -30,6 +30,7 @@ var _ = Describe("CachingResolver", func() {
 		ctx        context.Context
 		cancelFn   context.CancelFunc
 		cacheMock  *cache.MockExpiringCache[[]byte]
+		bus        *Bus
 	)
 
 	Describe("Type", func() {
@@ -50,7 +51,8 @@ var _ = Describe("CachingResolver", func() {
 		ctx, cancelFn = context.WithCancel(context.Background())
 		DeferCleanup(cancelFn)
 
-		sut, _ = NewCachingResolver(ctx, sutConfig, nil, NewBus())
+		bus = NewBus()
+		sut, _ = NewCachingResolver(ctx, sutConfig, nil, bus)
 		m = &mockResolver{}
 		cacheMock = cache.NewMockExpiringCache[[]byte](GinkgoT())
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
@@ -103,16 +105,24 @@ var _ = Describe("CachingResolver", func() {
 				domainPrefetched := make(chan bool, 1)
 				prefetchHitDomain := make(chan bool, 1)
 				prefetchedCnt := make(chan int, 1)
-				Expect(LegacyBus().SubscribeOnce(CachingPrefetchCacheHit, func(domain string) {
-					prefetchHitDomain <- true
-				})).Should(Succeed())
-				Expect(LegacyBus().SubscribeOnce(CachingDomainPrefetched, func(domain string) {
-					domainPrefetched <- true
-				})).Should(Succeed())
-
-				Expect(LegacyBus().SubscribeOnce(CachingDomainsToPrefetchCountChanged, func(cnt int) {
-					prefetchedCnt <- cnt
-				})).Should(Succeed())
+				Subscribe(bus, "test:prefetch-hit", func(_ context.Context, _ CachingPrefetchCacheHitEvent) {
+					select {
+					case prefetchHitDomain <- true:
+					default:
+					}
+				})
+				Subscribe(bus, "test:prefetched", func(_ context.Context, _ CachingDomainPrefetchedEvent) {
+					select {
+					case domainPrefetched <- true:
+					default:
+					}
+				})
+				Subscribe(bus, "test:prefetch-count", func(_ context.Context, e CachingDomainsToPrefetchCountChangedEvent) {
+					select {
+					case prefetchedCnt <- e.Count:
+					default:
+					}
+				})
 
 				// first request
 				_, _ = sut.Resolve(ctx, newRequest("example.com.", A))
@@ -211,8 +221,11 @@ var _ = Describe("CachingResolver", func() {
 				It("should cache response and use response's TTL", func() {
 					By("first request", func() {
 						totalCacheCount := make(chan int, 1)
-						_ = LegacyBus().SubscribeOnce(CachingResultCacheChanged, func(d int) {
-							totalCacheCount <- d
+						Subscribe(bus, "test:result-cache", func(_ context.Context, e CachingResultCacheChangedEvent) {
+							select {
+							case totalCacheCount <- e.Size:
+							default:
+							}
 						})
 						Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
 							Should(

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -50,7 +50,7 @@ var _ = Describe("CachingResolver", func() {
 		ctx, cancelFn = context.WithCancel(context.Background())
 		DeferCleanup(cancelFn)
 
-		sut, _ = NewCachingResolver(ctx, sutConfig, nil)
+		sut, _ = NewCachingResolver(ctx, sutConfig, nil, NewBus())
 		m = &mockResolver{}
 		cacheMock = cache.NewMockExpiringCache[[]byte](GinkgoT())
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
@@ -762,7 +762,7 @@ var _ = Describe("CachingResolver", func() {
 			sutConfig = config.Caching{Exclude: exclude}
 			mockAnswer, _ = util.NewMsgWithAnswer(domain, 1000, A, "10.0.0.1")
 			request = newRequest(domain, A)
-			sut, _ = NewCachingResolver(ctx, sutConfig, nil)
+			sut, _ = NewCachingResolver(ctx, sutConfig, nil, NewBus())
 			m.On("Resolve", mock.Anything, mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 			cacheMock.On("Get", mock.Anything).Maybe().Return((*[]byte)(nil), 10*time.Second)
 			cacheMock.On("Put", mock.Anything, mock.Anything, mock.Anything).Maybe().Return()
@@ -772,7 +772,7 @@ var _ = Describe("CachingResolver", func() {
 
 		When("Exclude settings are wrong", func() {
 			It("should fail", func() {
-				_, err := NewCachingResolver(ctx, config.Caching{Exclude: []string{"/[]/"}}, nil)
+				_, err := NewCachingResolver(ctx, config.Caching{Exclude: []string{"/[]/"}}, nil, NewBus())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cache exclusion configuration '/[]/' fail because"))
 			})
@@ -780,7 +780,7 @@ var _ = Describe("CachingResolver", func() {
 
 		When("Exclude settings are wrong because of missing slashes", func() {
 			It("should fail", func() {
-				_, err := NewCachingResolver(ctx, config.Caching{Exclude: []string{"lan"}}, nil)
+				_, err := NewCachingResolver(ctx, config.Caching{Exclude: []string{"lan"}}, nil, NewBus())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cache exclusion configuration 'lan' fail because of missing slashes"))
 			})

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -103,14 +103,14 @@ var _ = Describe("CachingResolver", func() {
 				domainPrefetched := make(chan bool, 1)
 				prefetchHitDomain := make(chan bool, 1)
 				prefetchedCnt := make(chan int, 1)
-				Expect(Bus().SubscribeOnce(CachingPrefetchCacheHit, func(domain string) {
+				Expect(LegacyBus().SubscribeOnce(CachingPrefetchCacheHit, func(domain string) {
 					prefetchHitDomain <- true
 				})).Should(Succeed())
-				Expect(Bus().SubscribeOnce(CachingDomainPrefetched, func(domain string) {
+				Expect(LegacyBus().SubscribeOnce(CachingDomainPrefetched, func(domain string) {
 					domainPrefetched <- true
 				})).Should(Succeed())
 
-				Expect(Bus().SubscribeOnce(CachingDomainsToPrefetchCountChanged, func(cnt int) {
+				Expect(LegacyBus().SubscribeOnce(CachingDomainsToPrefetchCountChanged, func(cnt int) {
 					prefetchedCnt <- cnt
 				})).Should(Succeed())
 
@@ -211,7 +211,7 @@ var _ = Describe("CachingResolver", func() {
 				It("should cache response and use response's TTL", func() {
 					By("first request", func() {
 						totalCacheCount := make(chan int, 1)
-						_ = Bus().SubscribeOnce(CachingResultCacheChanged, func(d int) {
+						_ = LegacyBus().SubscribeOnce(CachingResultCacheChanged, func(d int) {
 							totalCacheCount <- d
 						})
 						Expect(sut.Resolve(ctx, newRequest("example.com.", A))).

--- a/resolver/hosts_file_resolver.go
+++ b/resolver/hosts_file_resolver.go
@@ -42,7 +42,7 @@ func NewHostsFileResolver(ctx context.Context,
 		configurable: withConfig(&cfg),
 		typed:        withType("hosts_file"),
 
-		downloader: lists.NewDownloader(cfg.Loading.Downloads, bootstrap.NewHTTPTransport()),
+		downloader: lists.NewDownloader(cfg.Loading.Downloads, bootstrap.NewHTTPTransport(), nil),
 	}
 
 	err := cfg.Loading.StartPeriodicRefresh(ctx, r.loadSources, func(err error) {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/evt"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/sirupsen/logrus"
 
@@ -123,7 +124,7 @@ var _ = Describe("Resolver", func() {
 		})
 		When("'Name' is called", func() {
 			It("should return resolver name", func() {
-				br, _ := NewBlockingResolver(ctx, config.Blocking{BlockType: "zeroIP"}, systemResolverBootstrap)
+				br, _ := NewBlockingResolver(ctx, config.Blocking{BlockType: "zeroIP"}, systemResolverBootstrap, evt.NewBus())
 				name := Name(br)
 				Expect(name).Should(Equal("blocking"))
 			})

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/0xERR0R/blocky/cache"
 	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/evt"
 	"github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/metrics"
 	"github.com/0xERR0R/blocky/model"
@@ -108,7 +109,7 @@ func newTLSConfig(cfg *config.Config) (*tls.Config, error) {
 // NewServer creates new server instance with passed config
 //
 //nolint:funlen
-func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err error) {
+func NewServer(ctx context.Context, cfg *config.Config, bus *evt.Bus) (server *Server, err error) {
 	var tlsCfg *tls.Config
 
 	if len(cfg.Ports.HTTPS) > 0 || len(cfg.Ports.TLS) > 0 {
@@ -128,7 +129,7 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 		return nil, fmt.Errorf("failed to create HTTP/HTTPS listeners: %w", err)
 	}
 
-	metrics.RegisterEventListeners()
+	metrics.RegisterEventListeners(bus)
 
 	bootstrap, err := resolver.NewBootstrap(ctx, cfg)
 	if err != nil {
@@ -147,12 +148,12 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 		}
 	}
 
-	redisResult, err := createRedisCacheDecorator(ctx, redisConn, cfg.Redis.Required)
+	redisResult, err := createRedisCacheDecorator(ctx, redisConn, cfg.Redis.Required, bus)
 	if err != nil {
 		return nil, err
 	}
 
-	queryResolver, queryError := createQueryResolver(ctx, cfg, bootstrap, redisResult.decorator)
+	queryResolver, queryError := createQueryResolver(ctx, cfg, bootstrap, redisResult.decorator, bus)
 	if queryError != nil {
 		return nil, queryError
 	}
@@ -355,13 +356,13 @@ type redisBridgeResult struct {
 }
 
 func createRedisCacheDecorator(
-	ctx context.Context, redisConn *goredis.Client, required bool,
+	ctx context.Context, redisConn *goredis.Client, required bool, bus *evt.Bus,
 ) (*redisBridgeResult, error) {
 	if redisConn == nil {
 		return &redisBridgeResult{}, nil
 	}
 
-	bridge, err := redis.NewEventBusBridge(ctx, redisConn)
+	bridge, err := redis.NewEventBusBridge(ctx, redisConn, bus)
 	if err != nil {
 		if required {
 			return nil, fmt.Errorf("failed to create required Redis event bridge: %w", err)
@@ -385,9 +386,10 @@ func createQueryResolver(
 	cfg *config.Config,
 	bootstrap *resolver.Bootstrap,
 	cacheDecorator resolver.CacheDecorator,
+	bus *evt.Bus,
 ) (resolver.ChainedResolver, error) {
 	upstreamTree, utErr := resolver.NewUpstreamTreeResolver(ctx, cfg.Upstreams, bootstrap)
-	blocking, blErr := resolver.NewBlockingResolver(ctx, cfg.Blocking, bootstrap)
+	blocking, blErr := resolver.NewBlockingResolver(ctx, cfg.Blocking, bootstrap, bus)
 	queryLogging, qlErr := resolver.NewQueryLoggingResolver(ctx, cfg.QueryLog)
 	condUpstream, cuErr := resolver.NewConditionalUpstreamResolver(ctx, cfg.Conditional, cfg.Upstreams, bootstrap)
 	customDNS := resolver.NewCustomDNSResolver(cfg.CustomDNS)
@@ -400,7 +402,7 @@ func createQueryResolver(
 		decorator = nil
 	}
 
-	cachingResolver, crErr := resolver.NewCachingResolver(ctx, cfg.Caching, decorator)
+	cachingResolver, crErr := resolver.NewCachingResolver(ctx, cfg.Caching, decorator, bus)
 	// Pass upstreamTree to DNSSEC resolver so it can query for DNSKEY/DS records
 	dnssecResolver, dsErr := resolver.NewDNSSECResolver(ctx, cfg.DNSSEC, upstreamTree)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/docs"
+	"github.com/0xERR0R/blocky/evt"
 	. "github.com/0xERR0R/blocky/helpertest"
 	. "github.com/0xERR0R/blocky/log"
 	"github.com/0xERR0R/blocky/model"
@@ -167,7 +168,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	// create server
-	sut, err = NewServer(ctx, cfg)
+	sut, err = NewServer(ctx, cfg, evt.NewBus())
 	Expect(err).Should(Succeed())
 
 	errChan := make(chan error, 10)
@@ -619,14 +620,14 @@ var _ = Describe("Running DNS server", func() {
 		})
 		When("Server is created", func() {
 			It("is created without redis connection", func() {
-				_, err = NewServer(ctx, &cfg)
+				_, err = NewServer(ctx, &cfg, evt.NewBus())
 
 				Expect(err).Should(Succeed())
 			})
 			It("can't be created if redis server is unavailable", func() {
 				cfg.Redis.Required = true
 
-				_, err = NewServer(ctx, &cfg)
+				_, err = NewServer(ctx, &cfg, evt.NewBus())
 
 				Expect(err).Should(HaveOccurred())
 			})
@@ -640,7 +641,7 @@ var _ = Describe("Running DNS server", func() {
 				cfg.Ports.HTTPS = config.ListenConfig{"127.0.0.1:0", "127.0.0.1:0"}
 				cfg.HTTP3.Enable = true
 
-				srv, err := NewServer(ctx, &cfg)
+				srv, err := NewServer(ctx, &cfg, evt.NewBus())
 
 				Expect(err).Should(Succeed())
 				DeferCleanup(func() { _ = srv.Stop(ctx) })
@@ -654,7 +655,7 @@ var _ = Describe("Running DNS server", func() {
 				cfg.Ports.HTTPS = config.ListenConfig{"127.0.0.1:0"}
 				cfg.HTTP3.Enable = true
 
-				srv, err := NewServer(ctx, &cfg)
+				srv, err := NewServer(ctx, &cfg, evt.NewBus())
 				Expect(err).Should(Succeed())
 
 				errCh := make(chan error, 10)
@@ -679,7 +680,7 @@ var _ = Describe("Running DNS server", func() {
 				logHook := installLogHook()
 				DeferCleanup(logHook.uninstall)
 
-				srv, err := NewServer(ctx, &cfg)
+				srv, err := NewServer(ctx, &cfg, evt.NewBus())
 
 				Expect(err).Should(Succeed())
 				Expect(srv.http3Server).Should(BeNil())
@@ -694,7 +695,7 @@ var _ = Describe("Running DNS server", func() {
 			It("opens no UDP listeners even with HTTPS configured", func() {
 				cfg.Ports.HTTPS = config.ListenConfig{"127.0.0.1:0"}
 
-				srv, err := NewServer(ctx, &cfg)
+				srv, err := NewServer(ctx, &cfg, evt.NewBus())
 
 				Expect(err).Should(Succeed())
 				Expect(srv.http3Server).Should(BeNil())
@@ -728,7 +729,7 @@ var _ = Describe("Running DNS server", func() {
 						DNS:     config.ListenConfig{GetHostPort("127.0.0.1", dnsBasePort2)},
 						DOHPath: "/dns-query",
 					},
-				})
+				}, evt.NewBus())
 
 				Expect(err).Should(Succeed())
 
@@ -773,7 +774,7 @@ var _ = Describe("Running DNS server", func() {
 						DNS:     config.ListenConfig{GetHostPort("127.0.0.1", dnsBasePort2)},
 						DOHPath: "/dns-query",
 					},
-				})
+				}, evt.NewBus())
 
 				Expect(err).Should(Succeed())
 


### PR DESCRIPTION
## Summary

Replaces the reflection-based `github.com/asaskevich/EventBus` with a typed, generics-based event bus built on `github.com/maniartech/signals`.

- **Type-safe events** — each event is a Go struct; producers and consumers are checked at compile time instead of relying on string topics + reflection dispatch.
- **No global singleton** — a `*evt.Bus` is created once at startup (`cmd/serve.go`) and injected through constructors. Tests construct their own bus, improving isolation.
- **Caching events fire unconditionally** — the old `emitMetricEvents` gate (and `publishMetricsIfEnabled`) is removed so future non-metrics subscribers can observe caching events even when Prometheus is disabled. The Bootstrap-internal caching resolver passes a `nil` bus to stay silent (Emit/Subscribe/Unsubscribe are nil-safe).
- **Dependency dropped** — `github.com/asaskevich/EventBus` removed from `go.mod`.

### Design

`evt.Bus` is a small registry (`map[reflect.Type]*signals.Signal[T]`) exposed via package-level generics `Emit[T]`, `Subscribe[T]`, `Unsubscribe[T]`. The `Bus` struct stays fixed-size; adding a new event is just adding a new Go struct — no bus changes. Reflection is used only for the type→signal lookup; listener dispatch is fully typed.

All 10 existing events migrated: `AppStartedEvent`, `BlockingEnabledEvent`, `BlockingStateChangedEvent`, `BlockingStateChangedRemoteEvent`, `BlockingCacheGroupChangedEvent`, and the four caching events. `BlockingCacheGroupChangedEvent.ListType` is a `string` (via `ListCacheType.String()`) to avoid an `evt`→`lists` import cycle.

Scope note: metrics that update Prometheus collectors directly inline (cache hits/misses, query/response totals, rate-limit counters, DNSSEC cache hits) were never routed through the event bus and remain unchanged.

## Test Plan

- [x] `go build ./...`
- [x] `go test ./...` (non-e2e) — all pass
- [x] `go test -race ./...` (non-e2e) — no data races; fixed one concurrent-listener write in a resolver test surfaced by `-race`
- [x] Binary builds and runs (`blocky version`)
- [x] No residual references to `LegacyBus`, `emitMetricEvents`, `publishMetricsIfEnabled`, or `asaskevich`