### PR TITLE
feat: support PROXY protocol on proxied DoT/DoH listeners

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -394,6 +394,15 @@ func (c *Ports) validate() error {
 		return fmt.Errorf("dohPath must not contain '#', got %q", c.DOHPath)
 	}
 
+	seenProxyProtocolListeners := make(map[ProxyProtocolType]struct{}, len(c.ProxyProtocol))
+	for _, listener := range c.ProxyProtocol {
+		if _, ok := seenProxyProtocolListeners[listener]; ok {
+			return fmt.Errorf("ports.proxyProtocol contains duplicate listener family %q", listener)
+		}
+
+		seenProxyProtocolListeners[listener] = struct{}{}
+	}
+
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -345,6 +345,19 @@ type Ports struct {
 	// brought up after startup). Has no effect on wildcard binds and is ignored, with a warning, on
 	// non-Linux platforms.
 	FreeBind bool `default:"false" yaml:"freeBind"`
+	// PROXY protocol support for TCP listeners. Enable only behind a trusted proxy.
+	ProxyProtocol ProxyProtocol `yaml:"proxyProtocol"`
+}
+
+type ProxyProtocol struct {
+	// Require and parse PROXY protocol headers on DNS-over-TCP listeners.
+	DNS bool `default:"false" yaml:"dns"`
+	// Require and parse PROXY protocol headers on HTTP listeners.
+	HTTP bool `default:"false" yaml:"http"`
+	// Require and parse PROXY protocol headers on HTTPS listeners before TLS handshake.
+	HTTPS bool `default:"false" yaml:"https"`
+	// Require and parse PROXY protocol headers on DoT listeners before TLS handshake.
+	TLS bool `default:"false" yaml:"tls"`
 }
 
 func (c *Ports) LogConfig(logger *logrus.Entry) {
@@ -354,6 +367,10 @@ func (c *Ports) LogConfig(logger *logrus.Entry) {
 	logger.Infof("HTTPS    = %s", c.HTTPS)
 	logger.Infof("DOHPath  = %s", c.DOHPath)
 	logger.Infof("FreeBind = %t", c.FreeBind)
+	logger.Infof("PROXY protocol DNS   = %t", c.ProxyProtocol.DNS)
+	logger.Infof("PROXY protocol HTTP  = %t", c.ProxyProtocol.HTTP)
+	logger.Infof("PROXY protocol HTTPS = %t", c.ProxyProtocol.HTTPS)
+	logger.Infof("PROXY protocol TLS   = %t", c.ProxyProtocol.TLS)
 }
 
 func (c *Ports) validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -145,6 +146,10 @@ func (s InitStrategy) Do(ctx context.Context, init func(context.Context) error, 
 // QueryLogField data field to be logged
 // ENUM(clientIP,clientName,responseReason,responseAnswer,question,duration)
 type QueryLogField string
+
+// ProxyProtocolType is a TCP listener family that requires a PROXY protocol header.
+// ENUM(dns,http,https,tls)
+type ProxyProtocolType string
 
 // UpstreamStrategy upstream server usage strategy ENUM(
 // parallel_best // Picks 2 random weighted resolvers per query and returns the fastest answer (default).
@@ -345,19 +350,17 @@ type Ports struct {
 	// brought up after startup). Has no effect on wildcard binds and is ignored, with a warning, on
 	// non-Linux platforms.
 	FreeBind bool `default:"false" yaml:"freeBind"`
-	// PROXY protocol support for TCP listeners. Enable only behind a trusted proxy.
-	ProxyProtocol ProxyProtocol `yaml:"proxyProtocol"`
+	// PROXY protocol listener families. List the TCP listeners that sit behind a trusted proxy and
+	// must require a PROXY protocol header before the connection is handled, e.g. [https, tls].
+	ProxyProtocol ProxyProtocolListeners `yaml:"proxyProtocol"`
 }
 
-type ProxyProtocol struct {
-	// Require and parse PROXY protocol headers on DNS-over-TCP listeners.
-	DNS bool `default:"false" yaml:"dns"`
-	// Require and parse PROXY protocol headers on HTTP listeners.
-	HTTP bool `default:"false" yaml:"http"`
-	// Require and parse PROXY protocol headers on HTTPS listeners before TLS handshake.
-	HTTPS bool `default:"false" yaml:"https"`
-	// Require and parse PROXY protocol headers on DoT listeners before TLS handshake.
-	TLS bool `default:"false" yaml:"tls"`
+// ProxyProtocolListeners is the set of TCP listener families that require a PROXY protocol header.
+type ProxyProtocolListeners []ProxyProtocolType
+
+// Has reports whether the given listener family requires the PROXY protocol.
+func (p ProxyProtocolListeners) Has(t ProxyProtocolType) bool {
+	return slices.Contains(p, t)
 }
 
 func (c *Ports) LogConfig(logger *logrus.Entry) {
@@ -367,10 +370,7 @@ func (c *Ports) LogConfig(logger *logrus.Entry) {
 	logger.Infof("HTTPS    = %s", c.HTTPS)
 	logger.Infof("DOHPath  = %s", c.DOHPath)
 	logger.Infof("FreeBind = %t", c.FreeBind)
-	logger.Infof("PROXY protocol DNS   = %t", c.ProxyProtocol.DNS)
-	logger.Infof("PROXY protocol HTTP  = %t", c.ProxyProtocol.HTTP)
-	logger.Infof("PROXY protocol HTTPS = %t", c.ProxyProtocol.HTTPS)
-	logger.Infof("PROXY protocol TLS   = %t", c.ProxyProtocol.TLS)
+	logger.Infof("PROXY protocol = %s", c.ProxyProtocol)
 }
 
 func (c *Ports) validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -403,7 +403,28 @@ func (c *Ports) validate() error {
 		seenProxyProtocolListeners[listener] = struct{}{}
 	}
 
+	for _, listener := range c.ProxyProtocol {
+		if listenConfig, ok := c.proxyProtocolListenConfig(listener); ok && len(listenConfig) == 0 {
+			return fmt.Errorf("ports.proxyProtocol includes %q but ports.%s is empty", listener, listener)
+		}
+	}
+
 	return nil
+}
+
+func (c *Ports) proxyProtocolListenConfig(listener ProxyProtocolType) (ListenConfig, bool) {
+	switch listener {
+	case ProxyProtocolTypeDns:
+		return c.DNS, true
+	case ProxyProtocolTypeHttp:
+		return c.HTTP, true
+	case ProxyProtocolTypeHttps:
+		return c.HTTPS, true
+	case ProxyProtocolTypeTls:
+		return c.TLS, true
+	default:
+		return nil, false
+	}
 }
 
 // privilegedPortCeiling is the first non-privileged TCP/UDP port. Ports below

--- a/config/config_enum.go
+++ b/config/config_enum.go
@@ -358,6 +358,105 @@ func (NetProtocol) EnumValues() []string {
 }
 
 const (
+	// ProxyProtocolTypeDns is a ProxyProtocolType of type dns.
+	ProxyProtocolTypeDns ProxyProtocolType = "dns"
+	// ProxyProtocolTypeHttp is a ProxyProtocolType of type http.
+	ProxyProtocolTypeHttp ProxyProtocolType = "http"
+	// ProxyProtocolTypeHttps is a ProxyProtocolType of type https.
+	ProxyProtocolTypeHttps ProxyProtocolType = "https"
+	// ProxyProtocolTypeTls is a ProxyProtocolType of type tls.
+	ProxyProtocolTypeTls ProxyProtocolType = "tls"
+)
+
+var ErrInvalidProxyProtocolType = fmt.Errorf("not a valid ProxyProtocolType, try [%s]", strings.Join(_ProxyProtocolTypeNames, ", "))
+
+var _ProxyProtocolTypeNames = []string{
+	string(ProxyProtocolTypeDns),
+	string(ProxyProtocolTypeHttp),
+	string(ProxyProtocolTypeHttps),
+	string(ProxyProtocolTypeTls),
+}
+
+// ProxyProtocolTypeNames returns a list of possible string values of ProxyProtocolType.
+func ProxyProtocolTypeNames() []string {
+	tmp := make([]string, len(_ProxyProtocolTypeNames))
+	copy(tmp, _ProxyProtocolTypeNames)
+	return tmp
+}
+
+// ProxyProtocolTypeValues returns a list of the values for ProxyProtocolType
+func ProxyProtocolTypeValues() []ProxyProtocolType {
+	return []ProxyProtocolType{
+		ProxyProtocolTypeDns,
+		ProxyProtocolTypeHttp,
+		ProxyProtocolTypeHttps,
+		ProxyProtocolTypeTls,
+	}
+}
+
+// String implements the Stringer interface.
+func (x ProxyProtocolType) String() string {
+	return string(x)
+}
+
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
+func (x ProxyProtocolType) IsValid() bool {
+	_, err := ParseProxyProtocolType(string(x))
+	return err == nil
+}
+
+var _ProxyProtocolTypeValue = map[string]ProxyProtocolType{
+	"dns":   ProxyProtocolTypeDns,
+	"http":  ProxyProtocolTypeHttp,
+	"https": ProxyProtocolTypeHttps,
+	"tls":   ProxyProtocolTypeTls,
+}
+
+// ParseProxyProtocolType attempts to convert a string to a ProxyProtocolType.
+func ParseProxyProtocolType(name string) (ProxyProtocolType, error) {
+	if x, ok := _ProxyProtocolTypeValue[name]; ok {
+		return x, nil
+	}
+	return ProxyProtocolType(""), fmt.Errorf("%s is %w", name, ErrInvalidProxyProtocolType)
+}
+
+// MarshalText implements the text marshaller method.
+func (x ProxyProtocolType) MarshalText() ([]byte, error) {
+	return []byte(string(x)), nil
+}
+
+// UnmarshalText implements the text unmarshaller method.
+func (x *ProxyProtocolType) UnmarshalText(text []byte) error {
+	tmp, err := ParseProxyProtocolType(string(text))
+	if err != nil {
+		return err
+	}
+	*x = tmp
+	return nil
+}
+
+// AppendText appends the textual representation of itself to the end of b
+// (allocating a larger slice if necessary) and returns the updated slice.
+//
+// Implementations must not retain b, nor mutate any bytes within b[:len(b)].
+func (x *ProxyProtocolType) AppendText(b []byte) ([]byte, error) {
+	return append(b, x.String()...), nil
+}
+
+// EnumDescriptions returns each enum value's description, taken from the
+// `// comment` in the ENUM(...) declaration. Generated; do not edit.
+func (ProxyProtocolType) EnumDescriptions() map[string]string {
+	return map[string]string{}
+}
+
+// EnumValues returns the enum's accepted string values, used to build the JSON
+// schema enum constraint. Generated; do not edit.
+func (ProxyProtocolType) EnumValues() []string {
+	return ProxyProtocolTypeNames()
+}
+
+const (
 	// QueryLogFieldClientIP is a QueryLogField of type clientIP.
 	QueryLogFieldClientIP QueryLogField = "clientIP"
 	// QueryLogFieldClientName is a QueryLogField of type clientName.

--- a/config/config_schema_test.go
+++ b/config/config_schema_test.go
@@ -29,22 +29,40 @@ var _ = Describe("schema-enriched config loading", func() {
 			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")))
 		})
 
-		It("accepts PROXY protocol listener flags", func() {
+		It("accepts PROXY protocol listener families", func() {
 			data := []byte(`upstreams:
   groups:
     default:
       - 1.1.1.1
 ports:
   proxyProtocol:
-    dns: true
-    http: true
-    https: true
-    tls: true
+    - dns
+    - http
+    - https
+    - tls
 `)
 
 			err := unmarshalConfig(logger, data, &Config{})
 			Expect(err).Should(Succeed())
 			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")))
+		})
+	})
+
+	When("a PROXY protocol listener family is unknown", func() {
+		It("returns an error naming the valid families", func() {
+			data := []byte(`upstreams:
+  groups:
+    default:
+      - 1.1.1.1
+ports:
+  proxyProtocol:
+    - bogus
+`)
+
+			err := unmarshalConfig(logger, data, &Config{})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("proxyProtocol"))
+			Expect(err.Error()).Should(ContainSubstring("'dns', 'http', 'https', 'tls'"))
 		})
 	})
 

--- a/config/config_schema_test.go
+++ b/config/config_schema_test.go
@@ -28,6 +28,24 @@ var _ = Describe("schema-enriched config loading", func() {
 			Expect(err).Should(Succeed())
 			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")))
 		})
+
+		It("accepts PROXY protocol listener flags", func() {
+			data := []byte(`upstreams:
+  groups:
+    default:
+      - 1.1.1.1
+ports:
+  proxyProtocol:
+    dns: true
+    http: true
+    https: true
+    tls: true
+`)
+
+			err := unmarshalConfig(logger, data, &Config{})
+			Expect(err).Should(Succeed())
+			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")))
+		})
 	})
 
 	When("bootstrapDns uses the resolvFile object form", func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1369,6 +1369,12 @@ var _ = Describe("Ports", func() {
 				TLS:      ListenConfig{":853"},
 				DOHPath:  "/dns-query",
 				FreeBind: true,
+				ProxyProtocol: ProxyProtocol{
+					DNS:   true,
+					HTTP:  true,
+					HTTPS: true,
+					TLS:   true,
+				},
 			}
 
 			cfg.LogConfig(logger)
@@ -1381,6 +1387,10 @@ var _ = Describe("Ports", func() {
 				ContainSubstring("TLS"),
 				ContainSubstring("DOHPath"),
 				ContainSubstring("FreeBind"),
+				ContainSubstring("PROXY protocol DNS"),
+				ContainSubstring("PROXY protocol HTTP"),
+				ContainSubstring("PROXY protocol HTTPS"),
+				ContainSubstring("PROXY protocol TLS"),
 			))
 		})
 	})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1369,11 +1369,11 @@ var _ = Describe("Ports", func() {
 				TLS:      ListenConfig{":853"},
 				DOHPath:  "/dns-query",
 				FreeBind: true,
-				ProxyProtocol: ProxyProtocol{
-					DNS:   true,
-					HTTP:  true,
-					HTTPS: true,
-					TLS:   true,
+				ProxyProtocol: ProxyProtocolListeners{
+					ProxyProtocolTypeDns,
+					ProxyProtocolTypeHttp,
+					ProxyProtocolTypeHttps,
+					ProxyProtocolTypeTls,
 				},
 			}
 
@@ -1387,10 +1387,7 @@ var _ = Describe("Ports", func() {
 				ContainSubstring("TLS"),
 				ContainSubstring("DOHPath"),
 				ContainSubstring("FreeBind"),
-				ContainSubstring("PROXY protocol DNS"),
-				ContainSubstring("PROXY protocol HTTP"),
-				ContainSubstring("PROXY protocol HTTPS"),
-				ContainSubstring("PROXY protocol TLS"),
+				ContainSubstring("PROXY protocol = [dns http https tls]"),
 			))
 		})
 	})

--- a/config/ports_test.go
+++ b/config/ports_test.go
@@ -42,6 +42,16 @@ var _ = Describe("Ports.ProxyProtocol", func() {
 		Expect(ports.validate()).Should(MatchError(ContainSubstring(
 			`ports.proxyProtocol contains duplicate listener family "https"`)))
 	})
+
+	It("rejects listener families without a configured port", func() {
+		ports := Ports{
+			DOHPath:       "/dns-query",
+			ProxyProtocol: ProxyProtocolListeners{ProxyProtocolTypeTls},
+		}
+
+		Expect(ports.validate()).Should(MatchError(ContainSubstring(
+			`ports.proxyProtocol includes "tls" but ports.tls is empty`)))
+	})
 })
 
 var _ = Describe("Ports.PrivilegedPorts", func() {

--- a/config/ports_test.go
+++ b/config/ports_test.go
@@ -29,6 +29,19 @@ var _ = Describe("Ports.ProxyProtocol", func() {
 		Expect(ports.ProxyProtocol.Has(ProxyProtocolTypeDns)).Should(BeFalse())
 		Expect(ports.ProxyProtocol.Has(ProxyProtocolTypeHttp)).Should(BeFalse())
 	})
+
+	It("rejects duplicate listener families", func() {
+		ports := Ports{
+			DOHPath: "/dns-query",
+			ProxyProtocol: ProxyProtocolListeners{
+				ProxyProtocolTypeHttps,
+				ProxyProtocolTypeHttps,
+			},
+		}
+
+		Expect(ports.validate()).Should(MatchError(ContainSubstring(
+			`ports.proxyProtocol contains duplicate listener family "https"`)))
+	})
 })
 
 var _ = Describe("Ports.PrivilegedPorts", func() {

--- a/config/ports_test.go
+++ b/config/ports_test.go
@@ -15,13 +15,19 @@ var _ = Describe("Ports.FreeBind", func() {
 })
 
 var _ = Describe("Ports.ProxyProtocol", func() {
-	It("defaults to false for every TCP listener family", func() {
+	It("defaults to no PROXY protocol listeners", func() {
 		var ports Ports
 		Expect(defaults.Set(&ports)).Should(Succeed())
-		Expect(ports.ProxyProtocol.DNS).Should(BeFalse())
-		Expect(ports.ProxyProtocol.HTTP).Should(BeFalse())
-		Expect(ports.ProxyProtocol.HTTPS).Should(BeFalse())
-		Expect(ports.ProxyProtocol.TLS).Should(BeFalse())
+		Expect(ports.ProxyProtocol).Should(BeEmpty())
+		Expect(ports.ProxyProtocol.Has(ProxyProtocolTypeDns)).Should(BeFalse())
+	})
+
+	It("reports the configured listener families via Has", func() {
+		ports := Ports{ProxyProtocol: ProxyProtocolListeners{ProxyProtocolTypeHttps, ProxyProtocolTypeTls}}
+		Expect(ports.ProxyProtocol.Has(ProxyProtocolTypeHttps)).Should(BeTrue())
+		Expect(ports.ProxyProtocol.Has(ProxyProtocolTypeTls)).Should(BeTrue())
+		Expect(ports.ProxyProtocol.Has(ProxyProtocolTypeDns)).Should(BeFalse())
+		Expect(ports.ProxyProtocol.Has(ProxyProtocolTypeHttp)).Should(BeFalse())
 	})
 })
 

--- a/config/ports_test.go
+++ b/config/ports_test.go
@@ -14,6 +14,17 @@ var _ = Describe("Ports.FreeBind", func() {
 	})
 })
 
+var _ = Describe("Ports.ProxyProtocol", func() {
+	It("defaults to false for every TCP listener family", func() {
+		var ports Ports
+		Expect(defaults.Set(&ports)).Should(Succeed())
+		Expect(ports.ProxyProtocol.DNS).Should(BeFalse())
+		Expect(ports.ProxyProtocol.HTTP).Should(BeFalse())
+		Expect(ports.ProxyProtocol.HTTPS).Should(BeFalse())
+		Expect(ports.ProxyProtocol.TLS).Should(BeFalse())
+	})
+})
+
 var _ = Describe("Ports.PrivilegedPorts", func() {
 	It("returns privileged listen entries across DNS, HTTP, HTTPS and TLS", func() {
 		ports := Ports{

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1009,6 +1009,33 @@
           "type": "boolean",
           "description": "Allow binding the DNS and DoT listeners to addresses that are not yet assigned to a network\ninterface, via the Linux IP_FREEBIND socket option (e.g. for Tailscale/WireGuard/VRRP addresses\nbrought up after startup). Has no effect on wildcard binds and is ignored, with a warning, on\nnon-Linux platforms.",
           "default": false
+        },
+        "proxyProtocol": {
+          "properties": {
+            "dns": {
+              "type": "boolean",
+              "description": "Require and parse PROXY protocol headers on DNS-over-TCP listeners.",
+              "default": false
+            },
+            "http": {
+              "type": "boolean",
+              "description": "Require and parse PROXY protocol headers on HTTP listeners.",
+              "default": false
+            },
+            "https": {
+              "type": "boolean",
+              "description": "Require and parse PROXY protocol headers on HTTPS listeners before TLS handshake.",
+              "default": false
+            },
+            "tls": {
+              "type": "boolean",
+              "description": "Require and parse PROXY protocol headers on DoT listeners before TLS handshake.",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "description": "PROXY protocol support for TCP listeners. Enable only behind a trusted proxy."
         }
       },
       "additionalProperties": false,

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1011,31 +1011,17 @@
           "default": false
         },
         "proxyProtocol": {
-          "properties": {
-            "dns": {
-              "type": "boolean",
-              "description": "Require and parse PROXY protocol headers on DNS-over-TCP listeners.",
-              "default": false
-            },
-            "http": {
-              "type": "boolean",
-              "description": "Require and parse PROXY protocol headers on HTTP listeners.",
-              "default": false
-            },
-            "https": {
-              "type": "boolean",
-              "description": "Require and parse PROXY protocol headers on HTTPS listeners before TLS handshake.",
-              "default": false
-            },
-            "tls": {
-              "type": "boolean",
-              "description": "Require and parse PROXY protocol headers on DoT listeners before TLS handshake.",
-              "default": false
-            }
+          "items": {
+            "type": "string",
+            "enum": [
+              "dns",
+              "http",
+              "https",
+              "tls"
+            ]
           },
-          "additionalProperties": false,
-          "type": "object",
-          "description": "PROXY protocol support for TCP listeners. Enable only behind a trusted proxy."
+          "type": "array",
+          "description": "PROXY protocol listener families. List the TCP listeners that sit behind a trusted proxy and\nmust require a PROXY protocol header before the connection is handled, e.g. [https, tls]."
         }
       },
       "additionalProperties": false,

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -431,6 +431,14 @@ ports:
   #           startup). No effect on wildcard binds; ignored with a warning on non-Linux platforms.
   # default: false
   freeBind: false
+  # optional: require and parse HAProxy PROXY protocol headers on TCP listeners.
+  #           Enable only when Blocky is reachable only through a trusted proxy.
+  # default: all false
+  proxyProtocol:
+    dns: false
+    http: false
+    https: false
+    tls: false
 
 # optional: configuration for DOH  over HTTP/3
 http3:

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -431,14 +431,11 @@ ports:
   #           startup). No effect on wildcard binds; ignored with a warning on non-Linux platforms.
   # default: false
   freeBind: false
-  # optional: require and parse HAProxy PROXY protocol headers on TCP listeners.
-  #           Enable only when Blocky is reachable only through a trusted proxy.
-  # default: all false
-  proxyProtocol:
-    dns: false
-    http: false
-    https: false
-    tls: false
+  # optional: require and parse HAProxy PROXY protocol headers on the listed TCP listener families
+  #           (any of: dns, http, https, tls). Enable only when Blocky is reachable only through a
+  #           trusted proxy.
+  # default: empty
+  proxyProtocol: []
 
 # optional: configuration for DOH  over HTTP/3
 http3:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ All values in this section are optional.
 | ports.https   | One or more [IP]:Port |               | Listen address for HTTPS used for prometheus metrics, pprof, REST API, DoH... Example: `443`, `:443`, `192.168.0.1:443`, `[443, "[::1]:443"]`     |
 | ports.dohPath | string                | /dns-query    | URL path for DoH queries.                                                                                                                         |
 | ports.freeBind | bool                 | false         | Allow binding the DNS/DoT listeners to addresses not yet assigned to an interface (Linux only, via `IP_FREEBIND`; e.g. Tailscale/WireGuard/VRRP). No effect on wildcard binds; ignored with a warning on non-Linux. |
+| ports.proxyProtocol.dns/http/https/tls | bool | false | Require and parse HAProxy PROXY protocol headers on the selected TCP listener family. Enable only when the listener is reachable only through a trusted proxy. |
 
 !!! example
 
@@ -68,6 +69,9 @@ All values in this section are optional.
         - 4000
       https: 443
       dohPath: /my-custom-dns-query
+      proxyProtocol:
+        https: true
+        tls: true
     ```
 
 ## Logging configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ All values in this section are optional.
 | ports.https   | One or more [IP]:Port |               | Listen address for HTTPS used for prometheus metrics, pprof, REST API, DoH... Example: `443`, `:443`, `192.168.0.1:443`, `[443, "[::1]:443"]`     |
 | ports.dohPath | string                | /dns-query    | URL path for DoH queries.                                                                                                                         |
 | ports.freeBind | bool                 | false         | Allow binding the DNS/DoT listeners to addresses not yet assigned to an interface (Linux only, via `IP_FREEBIND`; e.g. Tailscale/WireGuard/VRRP). No effect on wildcard binds; ignored with a warning on non-Linux. |
-| ports.proxyProtocol.dns/http/https/tls | bool | false | Require and parse HAProxy PROXY protocol headers on the selected TCP listener family. Enable only when the listener is reachable only through a trusted proxy. |
+| ports.proxyProtocol | list | _empty_ | TCP listener families (any of `dns`, `http`, `https`, `tls`) that must require a HAProxy PROXY protocol header. Enable only when the listener is reachable only through a trusted proxy. |
 
 !!! example
 
@@ -70,8 +70,8 @@ All values in this section are optional.
       https: 443
       dohPath: /my-custom-dns-query
       proxyProtocol:
-        https: true
-        tls: true
+        - https
+        - tls
     ```
 
 ## Logging configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -955,6 +955,8 @@ Prometheus metrics, web UI).
   `minTlsServeVersion` config does not affect it.
 - If `http3.enable` is true but `ports.https` is empty, Blocky logs a
   warning at startup and does not open any UDP listeners.
+- If `ports.proxyProtocol` includes `https`, HTTP/3 is disabled because
+  QUIC/UDP cannot carry a PROXY protocol header.
 - When HTTP/3 is enabled, HTTPS responses include an `Alt-Svc: h3=...`
   header so capable clients can switch transports automatically.
 

--- a/docs/network_configuration.md
+++ b/docs/network_configuration.md
@@ -122,6 +122,13 @@ protocol on the Blocky listener and configure the proxy to send it.
     a PROXY protocol header, so enabling `https` here automatically disables
     HTTP/3. Plain DNS-over-UDP is likewise unaffected by `dns`.
 
+    The `http` and `https` listeners also serve the Prometheus metrics, the REST
+    API and the `/debug` pprof endpoints. Enabling `http`/`https` here makes *all*
+    of them require a PROXY protocol header, so anything that connects to that
+    port directly (e.g. a Prometheus scrape not routed through the proxy) is
+    rejected. Bind those tools behind the same trusted proxy, or expose metrics
+    and API on a separate listener without PROXY protocol.
+
 !!! example "Blocky"
 
     ```yaml

--- a/docs/network_configuration.md
+++ b/docs/network_configuration.md
@@ -114,7 +114,7 @@ protocol on the Blocky listener and configure the proxy to send it.
 
 !!! warning
 
-    Enable `ports.proxyProtocol.*` only on listeners that are reachable only
+    List a listener under `ports.proxyProtocol` only when it is reachable only
     from trusted proxies. When enabled, Blocky requires a PROXY protocol header
     and uses the source address from that header as the client IP.
 
@@ -125,8 +125,8 @@ protocol on the Blocky listener and configure the proxy to send it.
       https: 443
       tls: 853
       proxyProtocol:
-        https: true
-        tls: true
+        - https
+        - tls
     ```
 
 !!! example "nginx stream"

--- a/docs/network_configuration.md
+++ b/docs/network_configuration.md
@@ -106,4 +106,53 @@ proxy sets both `Forwarded` and `X-Forwarded-For`, Blocky uses
       # Traefik sets X-Forwarded-For automatically; no extra config needed.
     ```
 
+## Running DoT/DoH behind a TCP proxy
+
+For DNS-over-TLS and HTTPS passthrough, HTTP forwarding headers are not
+available before Blocky handles the TLS connection. Enable the HAProxy PROXY
+protocol on the Blocky listener and configure the proxy to send it.
+
+!!! warning
+
+    Enable `ports.proxyProtocol.*` only on listeners that are reachable only
+    from trusted proxies. When enabled, Blocky requires a PROXY protocol header
+    and uses the source address from that header as the client IP.
+
+!!! example "Blocky"
+
+    ```yaml
+    ports:
+      https: 443
+      tls: 853
+      proxyProtocol:
+        https: true
+        tls: true
+    ```
+
+!!! example "nginx stream"
+
+    ```nginx
+    stream {
+        upstream blocky_dot {
+            server blocky-backend:853;
+        }
+
+        server {
+            listen 853;
+            proxy_pass blocky_dot;
+            proxy_protocol on;
+        }
+
+        upstream blocky_doh {
+            server blocky-backend:443;
+        }
+
+        server {
+            listen 443;
+            proxy_pass blocky_doh;
+            proxy_protocol on;
+        }
+    }
+    ```
+
 --8<-- "docs/includes/abbreviations.md"

--- a/docs/network_configuration.md
+++ b/docs/network_configuration.md
@@ -118,6 +118,10 @@ protocol on the Blocky listener and configure the proxy to send it.
     from trusted proxies. When enabled, Blocky requires a PROXY protocol header
     and uses the source address from that header as the client IP.
 
+    The PROXY protocol only covers TCP listeners. HTTP/3 (QUIC/UDP) cannot carry
+    a PROXY protocol header, so enabling `https` here automatically disables
+    HTTP/3. Plain DNS-over-UDP is likewise unaffected by `dns`.
+
 !!! example "Blocky"
 
     ```yaml

--- a/e2e/containers.go
+++ b/e2e/containers.go
@@ -36,6 +36,7 @@ const (
 	mariaDBImage      = "mariadb:11"
 	mokaImage         = "ghcr.io/0xerr0r/dns-mokka:0.4.0"
 	staticServerImage = "halverneus/static-file-server:latest"
+	nginxImage        = "nginx:1.27-alpine"
 	blockyImage       = "blocky-e2e"
 )
 
@@ -117,6 +118,55 @@ func createHTTPServerContainer(ctx context.Context, alias string, e2eNet *testco
 	}
 
 	return startContainerWithNetwork(ctx, req, alias, e2eNet)
+}
+
+// createNginxStreamProxyContainer starts an nginx stream (L4) proxy in front of blocky on the test
+// network under the alias 'nginx'. It forwards TCP 853 -> blocky:853 (DoT) and 443 -> blocky:443
+// (DoH/HTTPS). When proxyProtocol is true, nginx prepends a HAProxy PROXY protocol header to each
+// upstream connection. blocky must already be running so nginx can resolve the 'blocky' alias at
+// startup. It is automatically terminated when the test is finished.
+func createNginxStreamProxyContainer(ctx context.Context, e2eNet *testcontainers.DockerNetwork,
+	proxyProtocol bool,
+) (testcontainers.Container, error) {
+	proxyProtocolDirective := ""
+	if proxyProtocol {
+		proxyProtocolDirective = "proxy_protocol on;"
+	}
+
+	// Minimal nginx.conf with only the stream module: TCP passthrough to blocky so the TLS
+	// handshake (DoT/DoH) terminates at blocky, optionally prefixed with a PROXY protocol header.
+	conf := fmt.Sprintf(`worker_processes 1;
+events {}
+stream {
+    server {
+        listen 853;
+        proxy_pass blocky:853;
+        %[1]s
+    }
+    server {
+        listen 443;
+        proxy_pass blocky:443;
+        %[1]s
+    }
+}
+`, proxyProtocolDirective)
+
+	req := testcontainers.ContainerRequest{
+		Image:        nginxImage,
+		ExposedPorts: []string{"853/tcp", "443/tcp"},
+		// The nginx image EXPOSEs port 80, which it does not listen on with our stream-only
+		// config, so wait for the DoT port we actually bind instead of the first exposed port.
+		WaitingFor: wait.ForListeningPort("853/tcp"),
+		Files: []testcontainers.ContainerFile{
+			{
+				HostFilePath:      createTempFile(conf),
+				ContainerFilePath: "/etc/nginx/nginx.conf",
+				FileMode:          modeWorldReadable,
+			},
+		},
+	}
+
+	return startContainerWithNetwork(ctx, req, "nginx", e2eNet)
 }
 
 // createRedisContainer creates a redis container attached to the test network under the alias 'redis'.

--- a/e2e/proxy_protocol_test.go
+++ b/e2e/proxy_protocol_test.go
@@ -147,7 +147,7 @@ func queryDoTViaProxy(ctx context.Context, nginx testcontainers.Container, quest
 	c := &dns.Client{
 		Net:       "tcp-tls",
 		Timeout:   5 * time.Second,
-		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed cert in tests
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
 	_, _, err = c.Exchange(util.NewMsgWithQuestion(question, dns.Type(dns.TypeA)), net.JoinHostPort(host, port))
@@ -173,7 +173,7 @@ func queryDoHViaProxy(ctx context.Context, nginx testcontainers.Container, quest
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed cert in tests
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
 

--- a/e2e/proxy_protocol_test.go
+++ b/e2e/proxy_protocol_test.go
@@ -1,0 +1,229 @@
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/0xERR0R/blocky/util"
+)
+
+var _ = Describe("PROXY protocol behind an nginx stream proxy", func() {
+	When("blocky and the nginx stream proxy both use the PROXY protocol", Ordered, func() {
+		var (
+			e2eNet *testcontainers.DockerNetwork
+			blocky testcontainers.Container
+			nginx  testcontainers.Container
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			e2eNet = getRandomNetwork(ctx)
+
+			_, err := createDNSMokkaContainer(ctx, "moka1", e2eNet,
+				`A dotquery/NOERROR("A 1.2.3.4 123")`,
+				`A dohquery/NOERROR("A 1.2.3.4 123")`)
+			Expect(err).Should(Succeed())
+
+			blocky, err = createBlockyContainerFromString(ctx, e2eNet, proxyProtocolBlockyConfig("tls, https"))
+			Expect(err).Should(Succeed())
+
+			// nginx must start after blocky so it can resolve the 'blocky' alias.
+			nginx, err = createNginxStreamProxyContainer(ctx, e2eNet, true)
+			Expect(err).Should(Succeed())
+		})
+
+		It("uses the PROXY header source as the client IP for DoT", func(ctx context.Context) {
+			Expect(queryDoTViaProxy(ctx, nginx, "dotquery.")).Should(Succeed())
+
+			nginxIP, err := getContainerNetworkIP(ctx, nginx, e2eNet.Name)
+			Expect(err).Should(Succeed())
+
+			clientIP := proxyProtocolClientIP(ctx, blocky, "dotquery")
+			Expect(net.ParseIP(clientIP)).ShouldNot(BeNil())
+			Expect(clientIP).ShouldNot(Equal(nginxIP),
+				"blocky should log the real client IP from the PROXY header, not the proxy's address")
+		})
+
+		It("uses the PROXY header source as the client IP for DoH", func(ctx context.Context) {
+			Expect(queryDoHViaProxy(ctx, nginx, "dohquery.")).Should(Succeed())
+
+			nginxIP, err := getContainerNetworkIP(ctx, nginx, e2eNet.Name)
+			Expect(err).Should(Succeed())
+
+			clientIP := proxyProtocolClientIP(ctx, blocky, "dohquery")
+			Expect(net.ParseIP(clientIP)).ShouldNot(BeNil())
+			Expect(clientIP).ShouldNot(Equal(nginxIP),
+				"blocky should log the real client IP from the PROXY header, not the proxy's address")
+		})
+	})
+
+	When("the PROXY protocol is not enabled", Ordered, func() {
+		var (
+			e2eNet *testcontainers.DockerNetwork
+			blocky testcontainers.Container
+			nginx  testcontainers.Container
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			e2eNet = getRandomNetwork(ctx)
+
+			_, err := createDNSMokkaContainer(ctx, "moka1", e2eNet,
+				`A dotquery/NOERROR("A 1.2.3.4 123")`,
+				`A dohquery/NOERROR("A 1.2.3.4 123")`)
+			Expect(err).Should(Succeed())
+
+			blocky, err = createBlockyContainerFromString(ctx, e2eNet, proxyProtocolBlockyConfig(""))
+			Expect(err).Should(Succeed())
+
+			nginx, err = createNginxStreamProxyContainer(ctx, e2eNet, false)
+			Expect(err).Should(Succeed())
+		})
+
+		It("records the proxy address as the client IP for DoT", func(ctx context.Context) {
+			Expect(queryDoTViaProxy(ctx, nginx, "dotquery.")).Should(Succeed())
+
+			nginxIP, err := getContainerNetworkIP(ctx, nginx, e2eNet.Name)
+			Expect(err).Should(Succeed())
+
+			clientIP := proxyProtocolClientIP(ctx, blocky, "dotquery")
+			Expect(clientIP).Should(Equal(nginxIP),
+				"without PROXY protocol blocky sees the connection coming from the proxy")
+		})
+
+		It("records the proxy address as the client IP for DoH", func(ctx context.Context) {
+			Expect(queryDoHViaProxy(ctx, nginx, "dohquery.")).Should(Succeed())
+
+			nginxIP, err := getContainerNetworkIP(ctx, nginx, e2eNet.Name)
+			Expect(err).Should(Succeed())
+
+			clientIP := proxyProtocolClientIP(ctx, blocky, "dohquery")
+			Expect(clientIP).Should(Equal(nginxIP),
+				"without PROXY protocol blocky sees the connection coming from the proxy")
+		})
+	})
+})
+
+// proxyProtocolBlockyConfig returns a blocky config listening for DNS (53), DoT (853) and
+// HTTPS/DoH (443). It requires the PROXY protocol on the given comma-separated listener families
+// (empty disables it) and logs resolved queries to the console, so the recorded client IP can be
+// asserted from the container logs.
+func proxyProtocolBlockyConfig(families string) string {
+	return fmt.Sprintf(`log:
+  level: info
+ports:
+  dns: 53
+  tls: 853
+  https: 443
+  proxyProtocol: [%s]
+queryLog:
+  type: console
+  flushInterval: 1s
+upstreams:
+  groups:
+    default:
+      - moka1
+`, families)
+}
+
+// queryDoTViaProxy sends a DNS-over-TLS query for the given question through the nginx proxy's
+// mapped 853 port. The TLS handshake terminates at blocky (nginx is a plain TCP passthrough).
+func queryDoTViaProxy(ctx context.Context, nginx testcontainers.Container, question string) error {
+	host, port, err := getContainerHostPort(ctx, nginx, "853/tcp")
+	if err != nil {
+		return err
+	}
+
+	c := &dns.Client{
+		Net:       "tcp-tls",
+		Timeout:   5 * time.Second,
+		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed cert in tests
+	}
+
+	_, _, err = c.Exchange(util.NewMsgWithQuestion(question, dns.Type(dns.TypeA)), net.JoinHostPort(host, port))
+
+	return err
+}
+
+// queryDoHViaProxy sends a DNS-over-HTTPS query for the given question through the nginx proxy's
+// mapped 443 port.
+func queryDoHViaProxy(ctx context.Context, nginx testcontainers.Container, question string) error {
+	host, port, err := getContainerHostPort(ctx, nginx, "443/tcp")
+	if err != nil {
+		return err
+	}
+
+	packed, err := util.NewMsgWithQuestion(question, dns.Type(dns.TypeA)).Pack()
+	if err != nil {
+		return err
+	}
+
+	url := "https://" + net.JoinHostPort(host, port) + "/dns-query?dns=" + base64.RawURLEncoding.EncodeToString(packed)
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed cert in tests
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected DoH status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+var clientIPLogRe = regexp.MustCompile(`client_ip="?([0-9a-fA-F.:]+)`)
+
+// proxyProtocolClientIP polls the blocky container logs for the resolved-query log entry of the
+// given question name and returns the client_ip it recorded.
+func proxyProtocolClientIP(ctx context.Context, blocky testcontainers.Container, questionName string) string {
+	var clientIP string
+
+	Eventually(func() string {
+		lines, err := getContainerLogs(ctx, blocky)
+		if err != nil {
+			return ""
+		}
+
+		clientIP = ""
+
+		for _, line := range lines {
+			if !strings.Contains(line, "query resolved") || !strings.Contains(line, questionName) {
+				continue
+			}
+
+			if m := clientIPLogRe.FindStringSubmatch(line); m != nil {
+				clientIP = m[1]
+			}
+		}
+
+		return clientIP
+	}, "15s", "500ms").ShouldNot(BeEmpty(),
+		"expected a resolved-query log entry for %q with a client_ip field", questionName)
+
+	return clientIP
+}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/oapi-codegen/runtime v1.4.1
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
+	github.com/pires/go-proxyproto v0.12.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/quic-go/quic-go v0.60.0
 	github.com/ramr/go-reaper v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/pires/go-proxyproto v0.12.0 h1:TTCxD66dU898tahivkqc3hoceZp7P44FnorWyo9d5vM=
+github.com/pires/go-proxyproto v0.12.0/go.mod h1:qUvfqUMEoX7T8g0q7TQLDnhMjdTrxnG0hvpMn+7ePNI=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/miekg/dns"
+	"github.com/pires/go-proxyproto"
 	"github.com/quic-go/quic-go"
 	"github.com/sirupsen/logrus"
 )
@@ -37,6 +38,9 @@ const (
 	maxUDPBufferSize = 65535
 	caExpiryYears    = 10
 	certExpiryYears  = 5
+	networkUDP       = "udp"
+	networkTCP       = "tcp"
+	networkTCPTLS    = "tcp-tls"
 )
 
 // Server controls the endpoints for DNS and HTTP
@@ -244,10 +248,10 @@ func createServers(ctx context.Context, cfg *config.Config, tlsCfg *tls.Config) 
 			return createUDPServer(ctx, address, freeBind)
 		}, cfg.Ports.DNS),
 		addServers(func(address string) (*dns.Server, error) {
-			return createTCPServer(ctx, address, freeBind)
+			return createTCPServer(ctx, address, freeBind, cfg.Ports.ProxyProtocol.DNS)
 		}, cfg.Ports.DNS),
 		addServers(func(address string) (*dns.Server, error) {
-			return createTLSServer(ctx, address, tlsCfg, freeBind)
+			return createTLSServer(ctx, address, tlsCfg, freeBind, cfg.Ports.ProxyProtocol.TLS)
 		}, cfg.Ports.TLS))
 
 	if multiErr := err.ErrorOrNil(); multiErr != nil {
@@ -260,12 +264,12 @@ func createServers(ctx context.Context, cfg *config.Config, tlsCfg *tls.Config) 
 func createHTTPListeners(
 	ctx context.Context, cfg *config.Config, tlsCfg *tls.Config,
 ) (httpListeners, httpsListeners []net.Listener, http3PacketConns []net.PacketConn, err error) {
-	httpListeners, err = newTCPListeners(ctx, "http", cfg.Ports.HTTP)
+	httpListeners, err = newTCPListeners(ctx, "http", cfg.Ports.HTTP, cfg.Ports.ProxyProtocol.HTTP)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create HTTP listeners: %w", err)
 	}
 
-	httpsListeners, err = newTLSListeners(ctx, "https", cfg.Ports.HTTPS, tlsCfg)
+	httpsListeners, err = newTLSListeners(ctx, "https", cfg.Ports.HTTPS, tlsCfg, cfg.Ports.ProxyProtocol.HTTPS)
 	if err != nil {
 		closeAll(httpListeners)
 
@@ -296,7 +300,7 @@ func closeAll[T io.Closer](closers []T) {
 }
 
 func newTCPListeners(
-	ctx context.Context, proto string, addresses config.ListenConfig,
+	ctx context.Context, proto string, addresses config.ListenConfig, proxyProtocol bool,
 ) ([]net.Listener, error) {
 	listeners := make([]net.Listener, 0, len(addresses))
 	lc := &net.ListenConfig{}
@@ -307,6 +311,8 @@ func newTCPListeners(
 			return nil, fmt.Errorf("start %s listener on %s failed: %w", proto, address, err)
 		}
 
+		listener = newProxyProtocolListener(listener, proxyProtocol)
+
 		listeners = append(listeners, listener)
 	}
 
@@ -314,9 +320,9 @@ func newTCPListeners(
 }
 
 func newTLSListeners(
-	ctx context.Context, proto string, addresses config.ListenConfig, tlsCfg *tls.Config,
+	ctx context.Context, proto string, addresses config.ListenConfig, tlsCfg *tls.Config, proxyProtocol bool,
 ) ([]net.Listener, error) {
-	listeners, err := newTCPListeners(ctx, proto, addresses)
+	listeners, err := newTCPListeners(ctx, proto, addresses, proxyProtocol)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TCP listeners for TLS: %w", err)
 	}
@@ -328,7 +334,20 @@ func newTLSListeners(
 	return listeners, nil
 }
 
-func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.Config, freeBind bool,
+func newProxyProtocolListener(listener net.Listener, enabled bool) net.Listener {
+	if !enabled {
+		return listener
+	}
+
+	return &proxyproto.Listener{
+		Listener: listener,
+		ConnPolicy: func(proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+			return proxyproto.REQUIRE, nil
+		},
+	}
+}
+
+func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.Config, freeBind, proxyProtocol bool,
 ) (*dns.Server, error) {
 	srv := &dns.Server{
 		Addr:    address,
@@ -339,7 +358,7 @@ func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.C
 		},
 	}
 
-	if network == "udp" {
+	if network == networkUDP {
 		srv.UDPSize = maxUDPBufferSize
 	}
 
@@ -349,8 +368,10 @@ func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.C
 
 	// When freeBind is enabled (and supported), pre-create the listener with the IP_FREEBIND socket
 	// option and hand it to the server, which is then started via ActivateAndServe (see Server.Start).
-	if freeBind && freebind.Supported {
-		if err := attachFreeBindListener(ctx, srv, network, address, tlsCfg); err != nil {
+	if (freeBind && freebind.Supported) || (proxyProtocol && network != networkUDP) {
+		if err := attachListener(
+			ctx, srv, network, address, tlsCfg, freeBind && freebind.Supported, proxyProtocol,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -358,55 +379,59 @@ func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.C
 	return srv, nil
 }
 
-// attachFreeBindListener creates the listener/packet connection for the given DNS server using the
-// freebind Control hook and assigns it to srv.Listener / srv.PacketConn so it can be started with
-// ActivateAndServe. It mirrors how miekg/dns creates listeners in ListenAndServe (including wrapping
-// the DoT listener in TLS).
-func attachFreeBindListener(ctx context.Context, srv *dns.Server, network, address string,
-	tlsCfg *tls.Config,
+// attachListener creates a listener/packet connection for DNS servers that need custom socket handling
+// before miekg/dns starts serving, such as freebind or PROXY protocol wrapping.
+func attachListener(ctx context.Context, srv *dns.Server, network, address string,
+	tlsCfg *tls.Config, freeBind, proxyProtocol bool,
 ) error {
-	lc := net.ListenConfig{Control: freebind.Control}
+	lc := net.ListenConfig{}
+	if freeBind {
+		lc.Control = freebind.Control
+	}
 
 	switch network {
-	case "udp":
-		pc, err := lc.ListenPacket(ctx, "udp", address)
+	case networkUDP:
+		pc, err := lc.ListenPacket(ctx, networkUDP, address)
 		if err != nil {
 			return fmt.Errorf("freebind udp listener on %s failed: %w", address, err)
 		}
 
 		srv.PacketConn = pc
-	case "tcp":
-		l, err := lc.Listen(ctx, "tcp", address)
+	case networkTCP:
+		l, err := lc.Listen(ctx, networkTCP, address)
 		if err != nil {
-			return fmt.Errorf("freebind tcp listener on %s failed: %w", address, err)
+			return fmt.Errorf("tcp listener on %s failed: %w", address, err)
 		}
 
+		l = newProxyProtocolListener(l, proxyProtocol)
 		srv.Listener = l
-	case "tcp-tls":
-		l, err := lc.Listen(ctx, "tcp", address)
+	case networkTCPTLS:
+		l, err := lc.Listen(ctx, networkTCP, address)
 		if err != nil {
-			return fmt.Errorf("freebind tcp-tls listener on %s failed: %w", address, err)
+			return fmt.Errorf("tcp-tls listener on %s failed: %w", address, err)
 		}
 
+		l = newProxyProtocolListener(l, proxyProtocol)
 		srv.Listener = tls.NewListener(l, tlsCfg)
 	default:
-		return fmt.Errorf("freebind: unsupported network %q", network)
+		return fmt.Errorf("unsupported DNS listener network %q", network)
 	}
 
 	return nil
 }
 
 func createTLSServer(ctx context.Context, address string, tlsCfg *tls.Config, freeBind bool,
+	proxyProtocol bool,
 ) (*dns.Server, error) {
-	return createDNSServer(ctx, "tcp-tls", address, tlsCfg, freeBind)
+	return createDNSServer(ctx, networkTCPTLS, address, tlsCfg, freeBind, proxyProtocol)
 }
 
-func createTCPServer(ctx context.Context, address string, freeBind bool) (*dns.Server, error) {
-	return createDNSServer(ctx, "tcp", address, nil, freeBind)
+func createTCPServer(ctx context.Context, address string, freeBind, proxyProtocol bool) (*dns.Server, error) {
+	return createDNSServer(ctx, networkTCP, address, nil, freeBind, proxyProtocol)
 }
 
 func createUDPServer(ctx context.Context, address string, freeBind bool) (*dns.Server, error) {
-	return createDNSServer(ctx, "udp", address, nil, freeBind)
+	return createDNSServer(ctx, networkUDP, address, nil, freeBind, false)
 }
 
 type redisBridgeResult struct {

--- a/server/server.go
+++ b/server/server.go
@@ -245,13 +245,19 @@ func createServers(ctx context.Context, cfg *config.Config, tlsCfg *tls.Config) 
 
 	err = multierror.Append(err,
 		addServers(func(address string) (*dns.Server, error) {
-			return createUDPServer(ctx, address, freeBind)
+			return createUDPServer(ctx, address, listenerOptions{freeBind: freeBind})
 		}, cfg.Ports.DNS),
 		addServers(func(address string) (*dns.Server, error) {
-			return createTCPServer(ctx, address, freeBind, cfg.Ports.ProxyProtocol.DNS)
+			return createTCPServer(ctx, address, listenerOptions{
+				freeBind:      freeBind,
+				proxyProtocol: cfg.Ports.ProxyProtocol.Has(config.ProxyProtocolTypeDns),
+			})
 		}, cfg.Ports.DNS),
 		addServers(func(address string) (*dns.Server, error) {
-			return createTLSServer(ctx, address, tlsCfg, freeBind, cfg.Ports.ProxyProtocol.TLS)
+			return createTLSServer(ctx, address, tlsCfg, listenerOptions{
+				freeBind:      freeBind,
+				proxyProtocol: cfg.Ports.ProxyProtocol.Has(config.ProxyProtocolTypeTls),
+			})
 		}, cfg.Ports.TLS))
 
 	if multiErr := err.ErrorOrNil(); multiErr != nil {
@@ -264,12 +270,13 @@ func createServers(ctx context.Context, cfg *config.Config, tlsCfg *tls.Config) 
 func createHTTPListeners(
 	ctx context.Context, cfg *config.Config, tlsCfg *tls.Config,
 ) (httpListeners, httpsListeners []net.Listener, http3PacketConns []net.PacketConn, err error) {
-	httpListeners, err = newTCPListeners(ctx, "http", cfg.Ports.HTTP, cfg.Ports.ProxyProtocol.HTTP)
+	httpListeners, err = newTCPListeners(ctx, "http", cfg.Ports.HTTP, cfg.Ports.ProxyProtocol.Has(config.ProxyProtocolTypeHttp))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create HTTP listeners: %w", err)
 	}
 
-	httpsListeners, err = newTLSListeners(ctx, "https", cfg.Ports.HTTPS, tlsCfg, cfg.Ports.ProxyProtocol.HTTPS)
+	httpsListeners, err = newTLSListeners(ctx, "https", cfg.Ports.HTTPS, tlsCfg,
+		cfg.Ports.ProxyProtocol.Has(config.ProxyProtocolTypeHttps))
 	if err != nil {
 		closeAll(httpListeners)
 
@@ -347,7 +354,14 @@ func newProxyProtocolListener(listener net.Listener, enabled bool) net.Listener 
 	}
 }
 
-func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.Config, freeBind, proxyProtocol bool,
+// listenerOptions bundles the socket-level options applied when a DNS listener is pre-created
+// before miekg/dns starts serving (freebind socket option, PROXY protocol wrapping).
+type listenerOptions struct {
+	freeBind      bool
+	proxyProtocol bool
+}
+
+func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.Config, opts listenerOptions,
 ) (*dns.Server, error) {
 	srv := &dns.Server{
 		Addr:    address,
@@ -368,10 +382,11 @@ func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.C
 
 	// When freeBind is enabled (and supported), pre-create the listener with the IP_FREEBIND socket
 	// option and hand it to the server, which is then started via ActivateAndServe (see Server.Start).
-	if (freeBind && freebind.Supported) || (proxyProtocol && network != networkUDP) {
-		if err := attachListener(
-			ctx, srv, network, address, tlsCfg, freeBind && freebind.Supported, proxyProtocol,
-		); err != nil {
+	if (opts.freeBind && freebind.Supported) || (opts.proxyProtocol && network != networkUDP) {
+		if err := attachListener(ctx, srv, network, address, tlsCfg, listenerOptions{
+			freeBind:      opts.freeBind && freebind.Supported,
+			proxyProtocol: opts.proxyProtocol,
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -382,10 +397,10 @@ func createDNSServer(ctx context.Context, network, address string, tlsCfg *tls.C
 // attachListener creates a listener/packet connection for DNS servers that need custom socket handling
 // before miekg/dns starts serving, such as freebind or PROXY protocol wrapping.
 func attachListener(ctx context.Context, srv *dns.Server, network, address string,
-	tlsCfg *tls.Config, freeBind, proxyProtocol bool,
+	tlsCfg *tls.Config, opts listenerOptions,
 ) error {
 	lc := net.ListenConfig{}
-	if freeBind {
+	if opts.freeBind {
 		lc.Control = freebind.Control
 	}
 
@@ -403,7 +418,7 @@ func attachListener(ctx context.Context, srv *dns.Server, network, address strin
 			return fmt.Errorf("tcp listener on %s failed: %w", address, err)
 		}
 
-		l = newProxyProtocolListener(l, proxyProtocol)
+		l = newProxyProtocolListener(l, opts.proxyProtocol)
 		srv.Listener = l
 	case networkTCPTLS:
 		l, err := lc.Listen(ctx, networkTCP, address)
@@ -411,7 +426,7 @@ func attachListener(ctx context.Context, srv *dns.Server, network, address strin
 			return fmt.Errorf("tcp-tls listener on %s failed: %w", address, err)
 		}
 
-		l = newProxyProtocolListener(l, proxyProtocol)
+		l = newProxyProtocolListener(l, opts.proxyProtocol)
 		srv.Listener = tls.NewListener(l, tlsCfg)
 	default:
 		return fmt.Errorf("unsupported DNS listener network %q", network)
@@ -420,18 +435,17 @@ func attachListener(ctx context.Context, srv *dns.Server, network, address strin
 	return nil
 }
 
-func createTLSServer(ctx context.Context, address string, tlsCfg *tls.Config, freeBind bool,
-	proxyProtocol bool,
+func createTLSServer(ctx context.Context, address string, tlsCfg *tls.Config, opts listenerOptions,
 ) (*dns.Server, error) {
-	return createDNSServer(ctx, networkTCPTLS, address, tlsCfg, freeBind, proxyProtocol)
+	return createDNSServer(ctx, networkTCPTLS, address, tlsCfg, opts)
 }
 
-func createTCPServer(ctx context.Context, address string, freeBind, proxyProtocol bool) (*dns.Server, error) {
-	return createDNSServer(ctx, networkTCP, address, nil, freeBind, proxyProtocol)
+func createTCPServer(ctx context.Context, address string, opts listenerOptions) (*dns.Server, error) {
+	return createDNSServer(ctx, networkTCP, address, nil, opts)
 }
 
-func createUDPServer(ctx context.Context, address string, freeBind bool) (*dns.Server, error) {
-	return createDNSServer(ctx, networkUDP, address, nil, freeBind, false)
+func createUDPServer(ctx context.Context, address string, opts listenerOptions) (*dns.Server, error) {
+	return createDNSServer(ctx, networkUDP, address, nil, opts)
 }
 
 type redisBridgeResult struct {

--- a/server/server.go
+++ b/server/server.go
@@ -38,9 +38,10 @@ const (
 	maxUDPBufferSize = 65535
 	caExpiryYears    = 10
 	certExpiryYears  = 5
-	networkUDP       = "udp"
-	networkTCP       = "tcp"
-	networkTCPTLS    = "tcp-tls"
+
+	networkUDP    = "udp"
+	networkTCP    = "tcp"
+	networkTCPTLS = "tcp-tls"
 )
 
 // Server controls the endpoints for DNS and HTTP
@@ -270,7 +271,8 @@ func createServers(ctx context.Context, cfg *config.Config, tlsCfg *tls.Config) 
 func createHTTPListeners(
 	ctx context.Context, cfg *config.Config, tlsCfg *tls.Config,
 ) (httpListeners, httpsListeners []net.Listener, http3PacketConns []net.PacketConn, err error) {
-	httpListeners, err = newTCPListeners(ctx, "http", cfg.Ports.HTTP, cfg.Ports.ProxyProtocol.Has(config.ProxyProtocolTypeHttp))
+	httpListeners, err = newTCPListeners(ctx, "http", cfg.Ports.HTTP,
+		cfg.Ports.ProxyProtocol.Has(config.ProxyProtocolTypeHttp))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create HTTP listeners: %w", err)
 	}
@@ -317,7 +319,7 @@ func newTCPListeners(
 	lc := &net.ListenConfig{}
 
 	for _, address := range addresses {
-		listener, err := lc.Listen(ctx, "tcp", address)
+		listener, err := lc.Listen(ctx, networkTCP, address)
 		if err != nil {
 			return nil, fmt.Errorf("start %s listener on %s failed: %w", proto, address, err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -284,9 +284,13 @@ func createHTTPListeners(
 	}
 
 	if cfg.HTTP3.IsEnabled() {
-		if len(cfg.Ports.HTTPS) == 0 {
+		switch {
+		case len(cfg.Ports.HTTPS) == 0:
 			logger().Warn("http3.enable is true but ports.https is empty; HTTP/3 disabled")
-		} else {
+		case cfg.Ports.ProxyProtocol.Has(config.ProxyProtocolTypeHttps):
+			logger().Warn("http3.enable is true but ports.proxyProtocol includes 'https'; " +
+				"HTTP/3 cannot carry PROXY protocol headers and is disabled to keep the client IP consistent")
+		default:
 			http3PacketConns, err = newUDPPacketConns(ctx, cfg.Ports.HTTPS)
 			if err != nil {
 				closeAll(httpListeners)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -600,6 +601,97 @@ var _ = Describe("Running DNS server", func() {
 		})
 	})
 
+	Describe("PROXY protocol", func() {
+		It("uses the PROXY source address for DoT requests", func() {
+			srv := newProxyProtocolTestServer(ctx, func(ports *config.Ports) {
+				ports.TLS = config.ListenConfig{"127.0.0.1:0"}
+				ports.ProxyProtocol.TLS = true
+			})
+			addr := srv.dnsServers[0].Listener.Addr().String()
+
+			expectedIP := net.ParseIP("192.0.2.10")
+			response := util.NewMsgWithQuestion("example.com.", A)
+			response.SetReply(response)
+
+			mockResolver := resolver.NewMockChainedResolver(GinkgoT())
+			mockResolver.EXPECT().Resolve(mock.Anything, mock.MatchedBy(func(req *model.Request) bool {
+				return expectedIP.Equal(req.ClientIP) && req.Protocol == model.RequestProtocolTCP
+			})).Return(&model.Response{Res: response}, nil).Once()
+			srv.queryResolver = mockResolver
+
+			rawConn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+			Expect(err).Should(Succeed())
+			DeferCleanup(rawConn.Close)
+
+			_, err = rawConn.Write([]byte(proxyProtocolLine(expectedIP, net.ParseIP("127.0.0.1"))))
+			Expect(err).Should(Succeed())
+
+			tlsConn := tls.Client(rawConn, &tls.Config{InsecureSkipVerify: true})
+			Expect(tlsConn.HandshakeContext(ctx)).Should(Succeed())
+
+			dnsConn := &dns.Conn{Conn: tlsConn}
+			query := util.NewMsgWithQuestion("example.com.", A)
+			Expect(dnsConn.WriteMsg(query)).Should(Succeed())
+
+			msg, err := dnsConn.ReadMsg()
+			Expect(err).Should(Succeed())
+			Expect(msg.Rcode).Should(Equal(dns.RcodeSuccess))
+		})
+
+		It("uses the PROXY source address for HTTPS DoH requests", func() {
+			srv := newProxyProtocolTestServer(ctx, func(ports *config.Ports) {
+				ports.HTTPS = config.ListenConfig{"127.0.0.1:0"}
+				ports.ProxyProtocol.HTTPS = true
+			})
+			addr := firstHTTPListenerAddr(srv)
+
+			expectedIP := net.ParseIP("192.0.2.11")
+			response := util.NewMsgWithQuestion("example.com.", A)
+			response.SetReply(response)
+
+			mockResolver := resolver.NewMockChainedResolver(GinkgoT())
+			mockResolver.EXPECT().Resolve(mock.Anything, mock.MatchedBy(func(req *model.Request) bool {
+				return expectedIP.Equal(req.ClientIP) && req.Protocol == model.RequestProtocolTCP
+			})).Return(&model.Response{Res: response}, nil).Once()
+			srv.queryResolver = mockResolver
+
+			rawConn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+			Expect(err).Should(Succeed())
+			DeferCleanup(rawConn.Close)
+
+			_, err = rawConn.Write([]byte(proxyProtocolLine(expectedIP, net.ParseIP("127.0.0.1"))))
+			Expect(err).Should(Succeed())
+
+			tlsConn := tls.Client(rawConn, &tls.Config{InsecureSkipVerify: true})
+			Expect(tlsConn.HandshakeContext(ctx)).Should(Succeed())
+
+			query := util.NewMsgWithQuestion("example.com.", A)
+			rawQuery, err := query.Pack()
+			Expect(err).Should(Succeed())
+
+			req, err := http.NewRequest(http.MethodPost, "https://"+addr+"/dns-query", bytes.NewReader(rawQuery))
+			Expect(err).Should(Succeed())
+			req.Header.Set(contentTypeHeader, dnsContentType)
+
+			Expect(req.Write(tlsConn)).Should(Succeed())
+			resp, err := http.ReadResponse(bufio.NewReader(tlsConn), req)
+			Expect(err).Should(Succeed())
+			DeferCleanup(resp.Body.Close)
+			Expect(resp).Should(HaveHTTPStatus(http.StatusOK))
+		})
+
+		It("keeps HTTPS working without PROXY protocol enabled", func() {
+			client := &http.Client{Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}}
+
+			resp, err := client.Get(fmt.Sprintf("https://%s/docs/config.schema.json", GetHostPort("localhost", httpsBasePort)))
+			Expect(err).Should(Succeed())
+			DeferCleanup(resp.Body.Close)
+			Expect(resp).Should(HaveHTTPStatus(http.StatusOK))
+		})
+	})
+
 	Describe("Server create", func() {
 		var (
 			cfg  config.Config
@@ -1066,6 +1158,44 @@ func requestServer(ctx context.Context, request *dns.Msg) *dns.Msg {
 	}
 
 	return nil
+}
+
+func newProxyProtocolTestServer(ctx context.Context, configurePorts func(*config.Ports)) *Server {
+	cfg := config.Config{}
+	Expect(defaults.Set(&cfg)).Should(Succeed())
+	cfg.Upstreams.Groups = map[string][]config.Upstream{
+		"default": {config.Upstream{Net: config.NetProtocolTcpUdp, Host: "1.1.1.1", Port: 53}},
+	}
+	cfg.Ports.DNS = config.ListenConfig{}
+	cfg.Ports.HTTP = config.ListenConfig{}
+	cfg.Ports.HTTPS = config.ListenConfig{}
+	cfg.Ports.TLS = config.ListenConfig{}
+	cfg.Ports.DOHPath = "/dns-query"
+	configurePorts(&cfg.Ports)
+
+	srv, err := NewServer(ctx, &cfg)
+	Expect(err).Should(Succeed())
+
+	errChan := make(chan error, 10)
+	go srv.Start(ctx, errChan)
+	DeferCleanup(func() { Expect(srv.Stop(ctx)).Should(Succeed()) })
+	Consistently(errChan, "200ms").ShouldNot(Receive())
+
+	return srv
+}
+
+func firstHTTPListenerAddr(srv *Server) string {
+	for listener := range srv.servers {
+		return listener.Addr().String()
+	}
+
+	Fail("server has no HTTP listener")
+
+	return ""
+}
+
+func proxyProtocolLine(srcIP, dstIP net.IP) string {
+	return fmt.Sprintf("PROXY TCP4 %s %s 12345 443\r\n", srcIP, dstIP)
 }
 
 type countingMsgWriter struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -605,7 +605,7 @@ var _ = Describe("Running DNS server", func() {
 		It("uses the PROXY source address for DoT requests", func() {
 			srv := newProxyProtocolTestServer(ctx, func(ports *config.Ports) {
 				ports.TLS = config.ListenConfig{"127.0.0.1:0"}
-				ports.ProxyProtocol.TLS = true
+				ports.ProxyProtocol = config.ProxyProtocolListeners{config.ProxyProtocolTypeTls}
 			})
 			addr := srv.dnsServers[0].Listener.Addr().String()
 
@@ -641,7 +641,7 @@ var _ = Describe("Running DNS server", func() {
 		It("uses the PROXY source address for HTTPS DoH requests", func() {
 			srv := newProxyProtocolTestServer(ctx, func(ports *config.Ports) {
 				ports.HTTPS = config.ListenConfig{"127.0.0.1:0"}
-				ports.ProxyProtocol.HTTPS = true
+				ports.ProxyProtocol = config.ProxyProtocolListeners{config.ProxyProtocolTypeHttps}
 			})
 			addr := firstHTTPListenerAddr(srv)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -680,6 +680,85 @@ var _ = Describe("Running DNS server", func() {
 			Expect(resp).Should(HaveHTTPStatus(http.StatusOK))
 		})
 
+		It("uses the PROXY source address for DNS-over-TCP requests", func() {
+			srv := newProxyProtocolTestServer(ctx, func(ports *config.Ports) {
+				ports.DNS = config.ListenConfig{"127.0.0.1:0"}
+				ports.ProxyProtocol = config.ProxyProtocolListeners{config.ProxyProtocolTypeDns}
+			})
+
+			var addr string
+			for _, dnsSrv := range srv.dnsServers {
+				if dnsSrv.Net == "tcp" {
+					addr = dnsSrv.Listener.Addr().String()
+				}
+			}
+			Expect(addr).ShouldNot(BeEmpty())
+
+			expectedIP := net.ParseIP("192.0.2.12")
+			response := util.NewMsgWithQuestion("example.com.", A)
+			response.SetReply(response)
+
+			mockResolver := resolver.NewMockChainedResolver(GinkgoT())
+			mockResolver.EXPECT().Resolve(mock.Anything, mock.MatchedBy(func(req *model.Request) bool {
+				return expectedIP.Equal(req.ClientIP) && req.Protocol == model.RequestProtocolTCP
+			})).Return(&model.Response{Res: response}, nil).Once()
+			srv.queryResolver = mockResolver
+
+			rawConn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+			Expect(err).Should(Succeed())
+			DeferCleanup(rawConn.Close)
+
+			_, err = rawConn.Write([]byte(proxyProtocolLine(expectedIP, net.ParseIP("127.0.0.1"))))
+			Expect(err).Should(Succeed())
+
+			dnsConn := &dns.Conn{Conn: rawConn}
+			query := util.NewMsgWithQuestion("example.com.", A)
+			Expect(dnsConn.WriteMsg(query)).Should(Succeed())
+
+			msg, err := dnsConn.ReadMsg()
+			Expect(err).Should(Succeed())
+			Expect(msg.Rcode).Should(Equal(dns.RcodeSuccess))
+		})
+
+		It("uses the PROXY source address for HTTP DoH requests", func() {
+			srv := newProxyProtocolTestServer(ctx, func(ports *config.Ports) {
+				ports.HTTP = config.ListenConfig{"127.0.0.1:0"}
+				ports.ProxyProtocol = config.ProxyProtocolListeners{config.ProxyProtocolTypeHttp}
+			})
+			addr := firstHTTPListenerAddr(srv)
+
+			expectedIP := net.ParseIP("192.0.2.13")
+			response := util.NewMsgWithQuestion("example.com.", A)
+			response.SetReply(response)
+
+			mockResolver := resolver.NewMockChainedResolver(GinkgoT())
+			mockResolver.EXPECT().Resolve(mock.Anything, mock.MatchedBy(func(req *model.Request) bool {
+				return expectedIP.Equal(req.ClientIP) && req.Protocol == model.RequestProtocolTCP
+			})).Return(&model.Response{Res: response}, nil).Once()
+			srv.queryResolver = mockResolver
+
+			rawConn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+			Expect(err).Should(Succeed())
+			DeferCleanup(rawConn.Close)
+
+			_, err = rawConn.Write([]byte(proxyProtocolLine(expectedIP, net.ParseIP("127.0.0.1"))))
+			Expect(err).Should(Succeed())
+
+			query := util.NewMsgWithQuestion("example.com.", A)
+			rawQuery, err := query.Pack()
+			Expect(err).Should(Succeed())
+
+			req, err := http.NewRequest(http.MethodPost, "http://"+addr+"/dns-query", bytes.NewReader(rawQuery))
+			Expect(err).Should(Succeed())
+			req.Header.Set(contentTypeHeader, dnsContentType)
+
+			Expect(req.Write(rawConn)).Should(Succeed())
+			resp, err := http.ReadResponse(bufio.NewReader(rawConn), req)
+			Expect(err).Should(Succeed())
+			DeferCleanup(resp.Body.Close)
+			Expect(resp).Should(HaveHTTPStatus(http.StatusOK))
+		})
+
 		It("keeps HTTPS working without PROXY protocol enabled", func() {
 			client := &http.Client{Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -782,6 +782,31 @@ var _ = Describe("Running DNS server", func() {
 			})
 		})
 
+		When("HTTP/3 is enabled together with proxyProtocol on https", func() {
+			It("disables HTTP/3 and logs a warning", func() {
+				// Clear the default DNS port so Stop has no never-started
+				// dns.Server to shut down.
+				cfg.Ports.DNS = config.ListenConfig{}
+				cfg.Ports.HTTPS = config.ListenConfig{"127.0.0.1:0"}
+				cfg.HTTP3.Enable = true
+				cfg.Ports.ProxyProtocol = config.ProxyProtocolListeners{config.ProxyProtocolTypeHttps}
+
+				logHook := installLogHook()
+				DeferCleanup(logHook.uninstall)
+
+				srv, err := NewServer(ctx, &cfg)
+
+				Expect(err).Should(Succeed())
+				DeferCleanup(func() { _ = srv.Stop(ctx) })
+
+				Expect(srv.http3Server).Should(BeNil())
+				Expect(srv.http3PacketConns).To(BeEmpty())
+
+				Expect(logHook.messages()).Should(ContainElement(
+					ContainSubstring("ports.proxyProtocol includes 'https'")))
+			})
+		})
+
 		When("HTTP/3 is disabled", func() {
 			It("opens no UDP listeners even with HTTPS configured", func() {
 				cfg.Ports.HTTPS = config.ListenConfig{"127.0.0.1:0"}


### PR DESCRIPTION
## Summary
- add opt-in PROXY protocol support per listener family under `ports.proxyProtocol`
- apply PROXY parsing before TLS for DoT and HTTPS/DoH listeners, and on DNS-over-TCP/HTTP when enabled
- document trusted-proxy usage and regenerate config schema

Closes https://github.com/0xERR0R/blocky/issues/320

## Test plan
- `GOCACHE=/tmp/go-build go test ./config ./server ./util`
- `GOCACHE=/tmp/go-build go tool ginkgo --label-filter="!e2e" -r`
- `GOCACHE=/tmp/go-build make generate-check`