### PR TITLE
test(e2e): de-flake PROXY protocol and upstream init.strategy specs

### DIFF
--- a/e2e/proxy_protocol_test.go
+++ b/e2e/proxy_protocol_test.go
@@ -44,7 +44,9 @@ var _ = Describe("PROXY protocol behind an nginx stream proxy", func() {
 		})
 
 		It("uses the PROXY header source as the client IP for DoT", func(ctx context.Context) {
-			Expect(queryDoTViaProxy(ctx, nginx, "dotquery.")).Should(Succeed())
+			Eventually(func() error {
+				return queryDoTViaProxy(ctx, nginx, "dotquery.")
+			}, "30s", "1s").Should(Succeed())
 
 			nginxIP, err := getContainerNetworkIP(ctx, nginx, e2eNet.Name)
 			Expect(err).Should(Succeed())
@@ -56,7 +58,9 @@ var _ = Describe("PROXY protocol behind an nginx stream proxy", func() {
 		})
 
 		It("uses the PROXY header source as the client IP for DoH", func(ctx context.Context) {
-			Expect(queryDoHViaProxy(ctx, nginx, "dohquery.")).Should(Succeed())
+			Eventually(func() error {
+				return queryDoHViaProxy(ctx, nginx, "dohquery.")
+			}, "30s", "1s").Should(Succeed())
 
 			nginxIP, err := getContainerNetworkIP(ctx, nginx, e2eNet.Name)
 			Expect(err).Should(Succeed())
@@ -91,7 +95,9 @@ var _ = Describe("PROXY protocol behind an nginx stream proxy", func() {
 		})
 
 		It("records the proxy address as the client IP for DoT", func(ctx context.Context) {
-			Expect(queryDoTViaProxy(ctx, nginx, "dotquery.")).Should(Succeed())
+			Eventually(func() error {
+				return queryDoTViaProxy(ctx, nginx, "dotquery.")
+			}, "30s", "1s").Should(Succeed())
 
 			nginxIP, err := getContainerNetworkIP(ctx, nginx, e2eNet.Name)
 			Expect(err).Should(Succeed())
@@ -102,7 +108,9 @@ var _ = Describe("PROXY protocol behind an nginx stream proxy", func() {
 		})
 
 		It("records the proxy address as the client IP for DoH", func(ctx context.Context) {
-			Expect(queryDoHViaProxy(ctx, nginx, "dohquery.")).Should(Succeed())
+			Eventually(func() error {
+				return queryDoHViaProxy(ctx, nginx, "dohquery.")
+			}, "30s", "1s").Should(Succeed())
 
 			nginxIP, err := getContainerNetworkIP(ctx, nginx, e2eNet.Name)
 			Expect(err).Should(Succeed())

--- a/e2e/upstream_test.go
+++ b/e2e/upstream_test.go
@@ -60,7 +60,9 @@ var _ = Describe("Upstream resolver configuration tests", func() {
 			})
 			It("should start even if upstream server is not reachable", func(ctx context.Context) {
 				Expect(blocky.IsRunning()).Should(BeTrue())
-				Expect(getContainerLogs(ctx, blocky)).Should(ContainElement(ContainSubstring("initial resolver test failed")))
+				Eventually(ctx, func() ([]string, error) {
+					return getContainerLogs(ctx, blocky)
+				}).Should(ContainElement(ContainSubstring("initial resolver test failed")))
 			})
 		})
 		When("'upstreams.init.strategy' is failOnError and upstream as IP address server is not reachable", func() {


### PR DESCRIPTION
## Problem

Two e2e specs flake under parallel load. Both are **test-harness timing races — no production code is involved**.

### 1. PROXY protocol specs (`e2e/proxy_protocol_test.go`)
Observed on the CI run for #2094 (`make (e2e-test)`):

```
PROXY protocol behind an nginx stream proxy
  when the PROXY protocol is not enabled
  [It] records the proxy address as the client IP for DoT
[FAILED] Expected success, but got an error: EOF
```

Each spec fires a **single, un-retried** DoT/DoH query immediately after container startup. blocky's container `HEALTHCHECK` only probes the **DNS:53** listener (`cmd/healthcheck.go`), so `wait.ForHealthCheck()` can return before the **TLS:853 / HTTPS:443** listeners are accepting. Under parallel load the first query loses the race and the spec fails with a bare `EOF`.

### 2. Upstream `init.strategy: fast` spec (`e2e/upstream_test.go`)
Reproduced locally on a full `make e2e-test` run on `main`:

```
'upstreams.init.strategy' is fast and upstream server as host name is not reachable
  [It] should start even if upstream server is not reachable
[FAILED] Expected <[]string | len:0, cap:0>: nil to contain element matching "initial resolver test failed"
```

This spec reads the container logs **once with no retry**, racing log availability and asserting against an empty slice. Its sibling spec (IP-address variant, a few lines up) already wraps the identical check in `Eventually`.

## Fix

Wrap both in `Eventually` so a transient startup race retries instead of failing the build. Test-only change.

## Verification

- `gofmt`, `go vet ./e2e/`, `make lint` → clean (0 issues)
- Focused run, 8/8 green: `ginkgo -p --focus="PROXY protocol|init.strategy"`
- PROXY specs stress-run 10× back-to-back → 40/40 green