### PR TITLE
feat(resolver): UDP-first plain-DNS upstream and EDNS0 buffer floor

### DIFF
--- a/resolver/mock_tcp_udp_upstream_server_test.go
+++ b/resolver/mock_tcp_udp_upstream_server_test.go
@@ -1,0 +1,91 @@
+package resolver
+
+import (
+	"net"
+	"sync/atomic"
+
+	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/util"
+	"github.com/miekg/dns"
+	"github.com/onsi/ginkgo/v2"
+)
+
+// answerFn builds the response for a received query. The mock fixes the response ID and the
+// response bit afterwards, so a handler is free to return a mismatched question section or set the
+// TC bit to exercise blocky's fallback logic.
+type answerFn func(request *dns.Msg) *dns.Msg
+
+// mockTCPUDPUpstreamServer is a test upstream that listens on a single address over BOTH UDP and
+// TCP, with independent handlers and per-protocol call counters. Unlike MockUDPUpstreamServer (UDP
+// only) it lets a test assert which transport blocky actually used — e.g. that TCP is never dialed
+// when the UDP answer is already clean.
+type mockTCPUDPUpstreamServer struct {
+	udpAnswer answerFn
+	tcpAnswer answerFn
+	udpCount  atomic.Int32
+	tcpCount  atomic.Int32
+	udpSrv    *dns.Server
+	tcpSrv    *dns.Server
+}
+
+func newMockTCPUDPUpstreamServer(udpAnswer, tcpAnswer answerFn) *mockTCPUDPUpstreamServer {
+	srv := &mockTCPUDPUpstreamServer{udpAnswer: udpAnswer, tcpAnswer: tcpAnswer}
+
+	ginkgo.DeferCleanup(srv.Close)
+
+	return srv
+}
+
+func (m *mockTCPUDPUpstreamServer) UDPCallCount() int { return int(m.udpCount.Load()) }
+func (m *mockTCPUDPUpstreamServer) TCPCallCount() int { return int(m.tcpCount.Load()) }
+
+func (m *mockTCPUDPUpstreamServer) Close() {
+	if m.udpSrv != nil {
+		_ = m.udpSrv.Shutdown()
+	}
+
+	if m.tcpSrv != nil {
+		_ = m.tcpSrv.Shutdown()
+	}
+}
+
+func (m *mockTCPUDPUpstreamServer) handler(counter *atomic.Int32, answer answerFn) dns.HandlerFunc {
+	return func(w dns.ResponseWriter, request *dns.Msg) {
+		defer ginkgo.GinkgoRecover()
+
+		counter.Add(1)
+
+		resp := answer(request)
+		resp.Id = request.Id
+		resp.Response = true
+
+		_ = w.WriteMsg(resp)
+	}
+}
+
+func (m *mockTCPUDPUpstreamServer) Start() config.Upstream {
+	ip := net.ParseIP("127.0.0.1")
+
+	udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: ip})
+	util.FatalOnError("can't create UDP connection: ", err)
+
+	port := udpConn.LocalAddr().(*net.UDPAddr).Port
+
+	tcpLn, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: ip, Port: port})
+	util.FatalOnError("can't create TCP listener: ", err)
+
+	m.udpSrv = &dns.Server{PacketConn: udpConn, Handler: m.handler(&m.udpCount, m.udpAnswer)}
+	m.tcpSrv = &dns.Server{Listener: tcpLn, Handler: m.handler(&m.tcpCount, m.tcpAnswer)}
+
+	go func() {
+		defer ginkgo.GinkgoRecover()
+		_ = m.udpSrv.ActivateAndServe()
+	}()
+
+	go func() {
+		defer ginkgo.GinkgoRecover()
+		_ = m.tcpSrv.ActivateAndServe()
+	}()
+
+	return config.Upstream{Net: config.NetProtocolTcpUdp, Host: ip.String(), Port: uint16(port)}
+}

--- a/resolver/mock_tcp_udp_upstream_server_test.go
+++ b/resolver/mock_tcp_udp_upstream_server_test.go
@@ -56,6 +56,14 @@ func (m *mockTCPUDPUpstreamServer) handler(counter *atomic.Int32, answer answerF
 		counter.Add(1)
 
 		resp := answer(request)
+		if resp == nil {
+			// nil simulates a broken upstream, like in MockUDPUpstreamServer: answer with
+			// garbage the client can't parse
+			_, _ = w.Write([]byte("dummy"))
+
+			return
+		}
+
 		resp.Id = request.Id
 		resp.Response = true
 

--- a/resolver/mock_tcp_udp_upstream_server_test.go
+++ b/resolver/mock_tcp_udp_upstream_server_test.go
@@ -64,6 +64,24 @@ func (m *mockTCPUDPUpstreamServer) handler(counter *atomic.Int32, answer answerF
 }
 
 func (m *mockTCPUDPUpstreamServer) Start() config.Upstream {
+	return m.start(true, true)
+}
+
+// StartTCPOnly is Start with the UDP socket closed again after claiming the port: UDP queries are
+// refused, simulating an upstream reachable only over TCP (e.g. UDP blocked by a firewall).
+func (m *mockTCPUDPUpstreamServer) StartTCPOnly() config.Upstream {
+	return m.start(false, true)
+}
+
+// StartUDPOnly is Start with the TCP listener closed again after claiming the port: TCP connections
+// are refused, simulating an upstream whose TCP fallback is unavailable.
+func (m *mockTCPUDPUpstreamServer) StartUDPOnly() config.Upstream {
+	return m.start(true, false)
+}
+
+// start always binds both sockets so the port is guaranteed to belong to this mock on both
+// protocols, then closes the ones not asked for so queries over them are refused immediately.
+func (m *mockTCPUDPUpstreamServer) start(udp, tcp bool) config.Upstream {
 	ip := net.ParseIP("127.0.0.1")
 
 	udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: ip})
@@ -74,18 +92,27 @@ func (m *mockTCPUDPUpstreamServer) Start() config.Upstream {
 	tcpLn, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: ip, Port: port})
 	util.FatalOnError("can't create TCP listener: ", err)
 
-	m.udpSrv = &dns.Server{PacketConn: udpConn, Handler: m.handler(&m.udpCount, m.udpAnswer)}
-	m.tcpSrv = &dns.Server{Listener: tcpLn, Handler: m.handler(&m.tcpCount, m.tcpAnswer)}
+	if udp {
+		m.udpSrv = &dns.Server{PacketConn: udpConn, Handler: m.handler(&m.udpCount, m.udpAnswer)}
 
-	go func() {
-		defer ginkgo.GinkgoRecover()
-		_ = m.udpSrv.ActivateAndServe()
-	}()
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			_ = m.udpSrv.ActivateAndServe()
+		}()
+	} else {
+		_ = udpConn.Close()
+	}
 
-	go func() {
-		defer ginkgo.GinkgoRecover()
-		_ = m.tcpSrv.ActivateAndServe()
-	}()
+	if tcp {
+		m.tcpSrv = &dns.Server{Listener: tcpLn, Handler: m.handler(&m.tcpCount, m.tcpAnswer)}
+
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			_ = m.tcpSrv.ActivateAndServe()
+		}()
+	} else {
+		_ = tcpLn.Close()
+	}
 
 	return config.Upstream{Net: config.NetProtocolTcpUdp, Host: ip.String(), Port: uint16(port)}
 }

--- a/resolver/quic_upstream_client.go
+++ b/resolver/quic_upstream_client.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/0xERR0R/blocky/config"
 	"github.com/0xERR0R/blocky/log"
-	"github.com/0xERR0R/blocky/model"
 
 	"github.com/miekg/dns"
 	"github.com/quic-go/quic-go"
@@ -54,7 +53,7 @@ func (r *quicUpstreamClient) fmtURL(ip net.IP, port uint16, _ string) string {
 }
 
 func (r *quicUpstreamClient) callExternal(
-	ctx context.Context, msg *dns.Msg, upstreamURL string, _ model.RequestProtocol,
+	ctx context.Context, msg *dns.Msg, upstreamURL string,
 ) (*dns.Msg, time.Duration, error) {
 	start := time.Now()
 

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -45,6 +45,10 @@ const (
 	// enough to carry most answers without truncation, small enough to avoid IP fragmentation. A
 	// shared-cache miss can then fetch the full answer over UDP instead of falling back to TCP.
 	upstreamUDPBufferFloor = 1232
+
+	// transport names as understood by dns.Client.Net
+	transportTCP = "tcp"
+	transportUDP = "udp"
 )
 
 // UpstreamServerError wraps a response with RCode ServFail so no other resolver tries to use it.
@@ -107,8 +111,9 @@ type upstreamClient interface {
 type dnsUpstreamClient struct {
 	tcpClient, udpClient *dns.Client
 	// pool reuses persistent connections for the connection-oriented DoT path;
-	// nil for the plain tcp+udp client, whose TCP leg is usually cancelled by the
-	// UDP race and so does not benefit from pooling.
+	// nil for the plain tcp+udp client, whose TCP leg is only a rare fallback
+	// (truncation, question mismatch, UDP failure) and so does not benefit from
+	// pooling.
 	pool *connPool
 }
 
@@ -221,10 +226,10 @@ func createUpstreamClient(cfg upstreamConfig) upstreamClient {
 	case config.NetProtocolTcpUdp:
 		return &dnsUpstreamClient{
 			tcpClient: &dns.Client{
-				Net: "tcp",
+				Net: transportTCP,
 			},
 			udpClient: &dns.Client{
-				Net: "udp",
+				Net: transportUDP,
 			},
 		}
 
@@ -337,20 +342,29 @@ func (r *dnsUpstreamClient) callExternal(
 			return nil, 0, fmt.Errorf("TCP DNS exchange failed to %s: %w", upstreamURL, err)
 		}
 
-		return resp, rtt, nil
+		return resp, rtt, servFailToError(resp)
 	}
 
 	return r.exchangeUDPWithTCPFallback(ctx, msg, upstreamURL)
 }
 
-// exchange performs a single DNS exchange and maps an upstream SERVFAIL to an UpstreamServerError so
-// that no other resolver tries to reuse the response.
+// servFailToError returns an UpstreamServerError if resp is a SERVFAIL, so no other resolver tries
+// to reuse the response; nil otherwise.
+func servFailToError(resp *dns.Msg) error {
+	if resp.Rcode == dns.RcodeServerFailure {
+		return &UpstreamServerError{resp}
+	}
+
+	return nil
+}
+
+// exchange performs a single DNS exchange and maps an upstream SERVFAIL to an UpstreamServerError.
 func (r *dnsUpstreamClient) exchange(
 	ctx context.Context, client *dns.Client, msg *dns.Msg, upstreamURL string,
 ) (*dns.Msg, time.Duration, error) {
 	resp, rtt, err := client.ExchangeContext(ctx, msg, upstreamURL)
-	if err == nil && resp.Rcode == dns.RcodeServerFailure {
-		err = &UpstreamServerError{resp}
+	if err == nil {
+		err = servFailToError(resp)
 	}
 
 	return resp, rtt, err

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -100,7 +100,7 @@ type upstreamClient interface {
 
 	fmtURL(ip net.IP, port uint16, path string) string
 	callExternal(
-		ctx context.Context, msg *dns.Msg, upstreamURL string, protocol model.RequestProtocol,
+		ctx context.Context, msg *dns.Msg, upstreamURL string,
 	) (response *dns.Msg, rtt time.Duration, err error)
 }
 
@@ -246,7 +246,7 @@ func (r *httpUpstreamClient) Close() error {
 }
 
 func (r *httpUpstreamClient) callExternal(
-	ctx context.Context, msg *dns.Msg, upstreamURL string, _ model.RequestProtocol,
+	ctx context.Context, msg *dns.Msg, upstreamURL string,
 ) (*dns.Msg, time.Duration, error) {
 	start := time.Now()
 
@@ -315,7 +315,7 @@ func (r *dnsUpstreamClient) Close() error {
 }
 
 func (r *dnsUpstreamClient) callExternal(
-	ctx context.Context, msg *dns.Msg, upstreamURL string, _ model.RequestProtocol,
+	ctx context.Context, msg *dns.Msg, upstreamURL string,
 ) (response *dns.Msg, rtt time.Duration, err error) {
 	if r.udpClient == nil {
 		// Single connection-oriented client (DoT): reuse pooled connections when a
@@ -357,31 +357,53 @@ func (r *dnsUpstreamClient) exchange(
 }
 
 // exchangeUDPWithTCPFallback queries the upstream over UDP first and only re-queries over TCP when
-// the UDP answer can't be used as-is: it is truncated (TC bit) or its question section doesn't match
-// the request. UDP serves the vast majority of queries, so this avoids opening a TCP connection —
-// and paying its dial/handshake/goroutine cost — on the common path. The UDP query advertises an
-// EDNS0 buffer floor (see udpRequestWithBufferFloor) so larger answers arrive over UDP rather than
-// forcing the TCP fallback.
+// the UDP exchange failed (timeout, network error, SERVFAIL — e.g. UDP/53 blocked while TCP still
+// works) or its answer can't be used as-is: it is truncated (TC bit) or its question section doesn't
+// match the request. UDP serves the vast majority of queries, so this avoids opening a TCP
+// connection — and paying its dial/handshake/goroutine cost — on the common path. The UDP query
+// advertises an EDNS0 buffer floor (see udpRequestWithBufferFloor) so larger answers arrive over UDP
+// rather than forcing the TCP fallback.
 //
-// On a hard UDP failure (timeout, network error, SERVFAIL) there is no usable answer to inspect, so
-// we return it without trying TCP: the resolver retries the whole exchange (see retry.Do in Resolve)
-// and parallel_best races other upstreams, which together cover transient UDP loss.
+// Note the UDP exchange shares the per-attempt context deadline with the fallback: if UDP fails by
+// timing out, the TCP fallback inherits an (almost) expired context and fails immediately, and the
+// retry in Resolve takes over. The fallback helps when UDP fails fast (e.g. ICMP port unreachable).
 func (r *dnsUpstreamClient) exchangeUDPWithTCPFallback(
 	ctx context.Context, msg *dns.Msg, upstreamURL string,
 ) (*dns.Msg, time.Duration, error) {
 	resp, rtt, err := r.exchange(ctx, r.udpClient, udpRequestWithBufferFloor(msg), upstreamURL)
-	if err != nil {
-		return resp, rtt, err
-	}
 
-	if resp.Truncated || !responseMatchesRequest(msg, resp) {
+	switch {
+	case err != nil:
+		// Hard UDP failure (timeout, network error, SERVFAIL): re-ask over TCP, which may still work
+		// on networks where UDP/53 is blocked or dropped. On TCP failure, return the UDP result —
+		// it's the primary transport, so its error is the more representative one.
+		tcpResp, tcpRTT, tcpErr := r.exchange(ctx, r.tcpClient, msg, upstreamURL)
+		if tcpErr != nil {
+			return resp, rtt, err
+		}
+
+		resp, rtt = tcpResp, tcpRTT
+
+	case resp.Truncated:
 		// Re-ask over TCP, which has no size limit. The original request is sent so we don't
 		// advertise an EDNS0 buffer the client never asked for over the TCP hop.
 		if tcpResp, tcpRTT, tcpErr := r.exchange(ctx, r.tcpClient, msg, upstreamURL); tcpErr == nil {
 			resp, rtt = tcpResp, tcpRTT
 		}
-		// On TCP failure we keep the UDP answer; the downstream `Server` sets the TC bit if that
-		// (possibly truncated) answer is too big for the client's transport.
+		// On TCP failure we keep the truncated UDP answer: it is a valid (partial) answer for the
+		// right question, and the downstream `Server` sets the TC bit if it is too big for the
+		// client's transport.
+
+	case !responseMatchesRequest(msg, resp):
+		// The UDP answer can't be trusted at all, so unlike the truncated case it must not be
+		// returned: a TCP failure here fails the whole exchange.
+		tcpResp, tcpRTT, tcpErr := r.exchange(ctx, r.tcpClient, msg, upstreamURL)
+		if tcpErr != nil {
+			return nil, 0, fmt.Errorf(
+				"UDP response question section doesn't match the request and TCP fallback failed: %w", tcpErr)
+		}
+
+		resp, rtt = tcpResp, tcpRTT
 	}
 
 	if msg.IsEdns0() == nil {
@@ -399,27 +421,31 @@ func (r *dnsUpstreamClient) exchangeUDPWithTCPFallback(
 // so the caller's shared request — which also drives per-client response truncation in the Server —
 // is never mutated.
 func udpRequestWithBufferFloor(msg *dns.Msg) *dns.Msg {
-	if opt := msg.IsEdns0(); opt != nil {
-		if opt.UDPSize() >= upstreamUDPBufferFloor {
-			return msg
-		}
-
-		clone := msg.Copy()
-		clone.IsEdns0().SetUDPSize(upstreamUDPBufferFloor)
-
-		return clone
+	if opt := msg.IsEdns0(); opt != nil && opt.UDPSize() >= upstreamUDPBufferFloor {
+		return msg
 	}
 
 	clone := msg.Copy()
-	clone.SetEdns0(upstreamUDPBufferFloor, false)
+	if opt := clone.IsEdns0(); opt != nil {
+		// raise the existing OPT in place so its options and DO bit are kept
+		opt.SetUDPSize(upstreamUDPBufferFloor)
+	} else {
+		clone.SetEdns0(upstreamUDPBufferFloor, false)
+	}
 
 	return clone
 }
 
-// responseMatchesRequest reports whether resp answers req: same number of questions, each with a
-// matching type, class, and (case-insensitive) name. A mismatch indicates a buggy or confused
-// upstream whose UDP answer can't be trusted, so the caller re-asks over TCP.
+// responseMatchesRequest reports whether resp can be trusted as an answer to req: its question
+// section must be empty — servers commonly omit it on error rcodes such as REFUSED — or contain the
+// same questions, each with a matching type, class, and (case-insensitive) name. A question for
+// something else indicates a buggy or confused upstream whose UDP answer can't be trusted, so the
+// caller re-asks over TCP.
 func responseMatchesRequest(req, resp *dns.Msg) bool {
+	if len(resp.Question) == 0 {
+		return true
+	}
+
 	if len(resp.Question) != len(req.Question) {
 		return false
 	}
@@ -516,7 +542,7 @@ func (r *UpstreamResolver) Resolve(ctx context.Context, request *model.Request) 
 			ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout.ToDuration())
 			defer cancel()
 
-			response, rtt, err := r.upstreamClient.callExternal(ctx, request.Req, upstreamURL, request.Protocol)
+			response, rtt, err := r.upstreamClient.callExternal(ctx, request.Req, upstreamURL)
 			if err != nil {
 				return fmt.Errorf("can't resolve request via upstream server %s (%s): %w", r.cfg, upstreamURL, err)
 			}

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -38,6 +39,12 @@ const (
 	// connPoolIdleTimeout discards pooled connections idle longer than this,
 	// before an upstream is likely to have closed them.
 	connPoolIdleTimeout = 30 * time.Second
+
+	// upstreamUDPBufferFloor is the minimum EDNS0 UDP buffer (bytes) blocky advertises to plain-DNS
+	// upstreams, independent of what the client requested. 1232 is the DNS-flag-day-2020 value: big
+	// enough to carry most answers without truncation, small enough to avoid IP fragmentation. A
+	// shared-cache miss can then fetch the full answer over UDP instead of falling back to TCP.
+	upstreamUDPBufferFloor = 1232
 )
 
 // UpstreamServerError wraps a response with RCode ServFail so no other resolver tries to use it.
@@ -308,7 +315,7 @@ func (r *dnsUpstreamClient) Close() error {
 }
 
 func (r *dnsUpstreamClient) callExternal(
-	ctx context.Context, msg *dns.Msg, upstreamURL string, protocol model.RequestProtocol,
+	ctx context.Context, msg *dns.Msg, upstreamURL string, _ model.RequestProtocol,
 ) (response *dns.Msg, rtt time.Duration, err error) {
 	if r.udpClient == nil {
 		// Single connection-oriented client (DoT): reuse pooled connections when a
@@ -333,71 +340,98 @@ func (r *dnsUpstreamClient) callExternal(
 		return resp, rtt, nil
 	}
 
-	return r.raceClients(ctx, msg, upstreamURL, protocol)
+	return r.exchangeUDPWithTCPFallback(ctx, msg, upstreamURL)
 }
 
-type exchangeResult struct {
-	proto model.RequestProtocol
-	msg   *dns.Msg
-	rtt   time.Duration
-	err   error
+// exchange performs a single DNS exchange and maps an upstream SERVFAIL to an UpstreamServerError so
+// that no other resolver tries to reuse the response.
+func (r *dnsUpstreamClient) exchange(
+	ctx context.Context, client *dns.Client, msg *dns.Msg, upstreamURL string,
+) (*dns.Msg, time.Duration, error) {
+	resp, rtt, err := client.ExchangeContext(ctx, msg, upstreamURL)
+	if err == nil && resp.Rcode == dns.RcodeServerFailure {
+		err = &UpstreamServerError{resp}
+	}
+
+	return resp, rtt, err
 }
 
-func (r *dnsUpstreamClient) raceClients(
-	ctx context.Context, msg *dns.Msg, upstreamURL string, protocol model.RequestProtocol,
-) (response *dns.Msg, rtt time.Duration, err error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+// exchangeUDPWithTCPFallback queries the upstream over UDP first and only re-queries over TCP when
+// the UDP answer can't be used as-is: it is truncated (TC bit) or its question section doesn't match
+// the request. UDP serves the vast majority of queries, so this avoids opening a TCP connection —
+// and paying its dial/handshake/goroutine cost — on the common path. The UDP query advertises an
+// EDNS0 buffer floor (see udpRequestWithBufferFloor) so larger answers arrive over UDP rather than
+// forcing the TCP fallback.
+//
+// On a hard UDP failure (timeout, network error, SERVFAIL) there is no usable answer to inspect, so
+// we return it without trying TCP: the resolver retries the whole exchange (see retry.Do in Resolve)
+// and parallel_best races other upstreams, which together cover transient UDP loss.
+func (r *dnsUpstreamClient) exchangeUDPWithTCPFallback(
+	ctx context.Context, msg *dns.Msg, upstreamURL string,
+) (*dns.Msg, time.Duration, error) {
+	resp, rtt, err := r.exchange(ctx, r.udpClient, udpRequestWithBufferFloor(msg), upstreamURL)
+	if err != nil {
+		return resp, rtt, err
+	}
 
-	// We don't explicitly close the channel, but since the buffer is big enough for all goroutines,
-	// it will be GC'ed and closed automatically.
-	ch := make(chan exchangeResult, 2) // TCP and UDP
+	if resp.Truncated || !responseMatchesRequest(msg, resp) {
+		// Re-ask over TCP, which has no size limit. The original request is sent so we don't
+		// advertise an EDNS0 buffer the client never asked for over the TCP hop.
+		if tcpResp, tcpRTT, tcpErr := r.exchange(ctx, r.tcpClient, msg, upstreamURL); tcpErr == nil {
+			resp, rtt = tcpResp, tcpRTT
+		}
+		// On TCP failure we keep the UDP answer; the downstream `Server` sets the TC bit if that
+		// (possibly truncated) answer is too big for the client's transport.
+	}
 
-	exchange := func(client *dns.Client, proto model.RequestProtocol) {
-		msg, rtt, err := client.ExchangeContext(ctx, msg, upstreamURL)
+	if msg.IsEdns0() == nil {
+		// We may have advertised the EDNS0 buffer floor the client never asked for; don't leak the
+		// resulting OPT record back to a client that didn't request EDNS0.
+		util.RemoveEdns0Record(resp)
+	}
 
-		if err == nil && msg.Rcode == dns.RcodeServerFailure {
-			err = &UpstreamServerError{msg}
+	return resp, rtt, nil
+}
+
+// udpRequestWithBufferFloor returns the message to send to an upstream over UDP, ensuring it
+// advertises an EDNS0 UDP buffer of at least upstreamUDPBufferFloor. If msg already advertises
+// enough it is returned unchanged; otherwise a copy with a raised (or newly added) OPT is returned,
+// so the caller's shared request — which also drives per-client response truncation in the Server —
+// is never mutated.
+func udpRequestWithBufferFloor(msg *dns.Msg) *dns.Msg {
+	if opt := msg.IsEdns0(); opt != nil {
+		if opt.UDPSize() >= upstreamUDPBufferFloor {
+			return msg
 		}
 
-		ch <- exchangeResult{proto, msg, rtt, err}
+		clone := msg.Copy()
+		clone.IsEdns0().SetUDPSize(upstreamUDPBufferFloor)
+
+		return clone
 	}
 
-	go exchange(r.tcpClient, model.RequestProtocolTCP)
-	go exchange(r.udpClient, model.RequestProtocolUDP)
+	clone := msg.Copy()
+	clone.SetEdns0(upstreamUDPBufferFloor, false)
 
-	// We don't care about a response too big for the downstream protocol: that's handled by `Server`,
-	// and returning a larger request from here might allow us to cache it.
+	return clone
+}
 
-	res1 := <-ch
-	if res1.err == nil && !res1.msg.Truncated {
-		return res1.msg, res1.rtt, nil
+// responseMatchesRequest reports whether resp answers req: same number of questions, each with a
+// matching type, class, and (case-insensitive) name. A mismatch indicates a buggy or confused
+// upstream whose UDP answer can't be trusted, so the caller re-asks over TCP.
+func responseMatchesRequest(req, resp *dns.Msg) bool {
+	if len(resp.Question) != len(req.Question) {
+		return false
 	}
 
-	res2 := <-ch
-	if res2.err == nil && !res2.msg.Truncated {
-		return res2.msg, res2.rtt, nil
-	}
-
-	resWhere := func(pred func(*exchangeResult) bool) *exchangeResult {
-		if pred(&res1) {
-			return &res1
+	for i := range req.Question {
+		q, rq := req.Question[i], resp.Question[i]
+		if rq.Qtype != q.Qtype || rq.Qclass != q.Qclass || !strings.EqualFold(rq.Name, q.Name) {
+			return false
 		}
-
-		return &res2
 	}
 
-	// When both failed, return the result that used the same protocol as the downstream request
-	if res1.err != nil && res2.err != nil {
-		sameProto := resWhere(func(r *exchangeResult) bool { return r.proto == protocol })
-
-		return sameProto.msg, sameProto.rtt, sameProto.err
-	}
-
-	// Only a single one failed, use the one that succeeded
-	successful := resWhere(func(r *exchangeResult) bool { return r.err == nil })
-
-	return successful.msg, successful.rtt, nil
+	return true
 }
 
 // NewUpstreamResolver creates new resolver instance

--- a/resolver/upstream_resolver_test.go
+++ b/resolver/upstream_resolver_test.go
@@ -271,6 +271,28 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 			})
 		})
 
+		When("the UDP handler simulates a broken upstream (returns nil)", func() {
+			It("falls back to TCP and returns the TCP answer", func() {
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					func(req *dns.Msg) *dns.Msg {
+						return nil // the mock answers with garbage the client can't parse
+					},
+					func(req *dns.Msg) *dns.Msg {
+						return replyWithRR(req, "example.com. 123 IN A 5.6.7.8")
+					},
+				)
+
+				sutConfig.Upstream = mockUpstream.Start()
+				sut := newUpstreamResolverUnchecked(sutConfig, nil)
+
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
+					Should(BeDNSRecord("example.com.", A, "5.6.7.8"))
+
+				Expect(mockUpstream.UDPCallCount()).Should(Equal(1))
+				Expect(mockUpstream.TCPCallCount()).Should(Equal(1))
+			})
+		})
+
 		When("UDP is unreachable but TCP works", func() {
 			It("falls back to TCP and returns the TCP answer", func() {
 				mockUpstream := newMockTCPUDPUpstreamServer(
@@ -900,12 +922,37 @@ var _ = Describe("UpstreamResolver connection pooling", Label("upstreamResolver"
 		It("falls back to the tcp client instead of nil-dereferencing the pool", func() {
 			// A connection-oriented client with neither a udp client nor a pool
 			// (e.g. a future tcp-only client) must surface an error, not panic.
-			client := &dnsUpstreamClient{tcpClient: &dns.Client{Net: "tcp"}}
+			client := &dnsUpstreamClient{tcpClient: &dns.Client{Net: transportTCP}}
 
-			_, _, err := client.callExternal(
-				ctx, newRequest("example.com.", A).Req, "127.0.0.1:0", RequestProtocolTCP,
-			)
+			_, _, err := client.callExternal(ctx, newRequest("example.com.", A).Req, "127.0.0.1:0")
 			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Describe("TCP-only upstream client (DoT path)", func() {
+		When("the upstream responds with SERVFAIL", func() {
+			It("maps the response to an UpstreamServerError like the UDP/TCP path", func() {
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					nil, // a TCP-only client never dials UDP
+					func(req *dns.Msg) *dns.Msg {
+						resp := new(dns.Msg)
+						resp.SetReply(req)
+						resp.Rcode = dns.RcodeServerFailure
+
+						return resp
+					},
+				)
+				upstream := mockUpstream.StartTCPOnly()
+
+				client := &dnsUpstreamClient{tcpClient: &dns.Client{Net: transportTCP}}
+				url := client.fmtURL(net.ParseIP(upstream.Host), upstream.Port, "")
+
+				_, _, err := client.callExternal(ctx, newRequest("example.com.", A).Req, url)
+
+				var servErr *UpstreamServerError
+				Expect(errors.As(err, &servErr)).Should(BeTrue())
+				Expect(servErr.Msg.Rcode).Should(Equal(dns.RcodeServerFailure))
+			})
 		})
 	})
 

--- a/resolver/upstream_resolver_test.go
+++ b/resolver/upstream_resolver_test.go
@@ -23,6 +23,18 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// replyWithRR builds a reply to req whose answer section holds the single given record.
+func replyWithRR(req *dns.Msg, rr string) *dns.Msg {
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+
+	parsed, err := dns.NewRR(rr)
+	Expect(err).Should(Succeed())
+	resp.Answer = []dns.RR{parsed}
+
+	return resp
+}
+
 var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 	var (
 		sut       *UpstreamResolver
@@ -204,17 +216,6 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 		// make the UDP-vs-TCP ordering deterministic, so raise the timeout comfortably above them.
 		const handlerDelay = 30 * time.Millisecond
 
-		reply := func(req *dns.Msg, rr string) *dns.Msg {
-			resp := new(dns.Msg)
-			resp.SetReply(req)
-
-			parsed, err := dns.NewRR(rr)
-			Expect(err).Should(Succeed())
-			resp.Answer = []dns.RR{parsed}
-
-			return resp
-		}
-
 		BeforeEach(func() {
 			sutConfig.Timeout = config.Duration(time.Second)
 		})
@@ -226,10 +227,10 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 						// Delay UDP so a speculative TCP race (the old behavior) would win if started.
 						time.Sleep(handlerDelay)
 
-						return reply(req, "example.com. 123 IN A 1.2.3.4")
+						return replyWithRR(req, "example.com. 123 IN A 1.2.3.4")
 					},
 					func(req *dns.Msg) *dns.Msg {
-						return reply(req, "example.com. 123 IN A 5.6.7.8")
+						return replyWithRR(req, "example.com. 123 IN A 5.6.7.8")
 					},
 				)
 
@@ -255,7 +256,7 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 						return resp
 					},
 					func(req *dns.Msg) *dns.Msg {
-						return reply(req, "example.com. 123 IN A 5.6.7.8")
+						return replyWithRR(req, "example.com. 123 IN A 5.6.7.8")
 					},
 				)
 
@@ -266,6 +267,25 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 					Should(BeDNSRecord("example.com.", A, "5.6.7.8"))
 
 				Expect(mockUpstream.UDPCallCount()).Should(Equal(1))
+				Expect(mockUpstream.TCPCallCount()).Should(Equal(1))
+			})
+		})
+
+		When("UDP is unreachable but TCP works", func() {
+			It("falls back to TCP and returns the TCP answer", func() {
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					nil, // UDP queries are refused, the handler is never reached
+					func(req *dns.Msg) *dns.Msg {
+						return replyWithRR(req, "example.com. 123 IN A 5.6.7.8")
+					},
+				)
+
+				sutConfig.Upstream = mockUpstream.StartTCPOnly()
+				sut := newUpstreamResolverUnchecked(sutConfig, nil)
+
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
+					Should(BeDNSRecord("example.com.", A, "5.6.7.8"))
+
 				Expect(mockUpstream.TCPCallCount()).Should(Equal(1))
 			})
 		})
@@ -291,7 +311,7 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 						// Delay TCP so the (old) racing UDP answer would win and be returned if it could.
 						time.Sleep(handlerDelay)
 
-						return reply(req, "example.com. 123 IN A 5.6.7.8")
+						return replyWithRR(req, "example.com. 123 IN A 5.6.7.8")
 					},
 				)
 
@@ -304,20 +324,36 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 				Expect(mockUpstream.TCPCallCount()).Should(Equal(1))
 			})
 		})
+
+		When("the UDP answer's question section doesn't match and TCP is unreachable", func() {
+			It("returns an error instead of the mismatched answer", func() {
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					func(req *dns.Msg) *dns.Msg {
+						resp := new(dns.Msg)
+						resp.SetReply(req)
+						resp.Question = []dns.Question{{
+							Name: "wrong.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET,
+						}}
+
+						parsed, err := dns.NewRR("wrong.example. 123 IN A 1.2.3.4")
+						Expect(err).Should(Succeed())
+						resp.Answer = []dns.RR{parsed}
+
+						return resp
+					},
+					nil, // TCP connections are refused, the handler is never reached
+				)
+
+				sutConfig.Upstream = mockUpstream.StartUDPOnly()
+				sut := newUpstreamResolverUnchecked(sutConfig, nil)
+
+				_, err := sut.Resolve(ctx, newRequest("example.com.", A))
+				Expect(err).Should(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("EDNS0 UDP buffer floor for upstream queries", func() {
-		reply := func(req *dns.Msg, rr string) *dns.Msg {
-			resp := new(dns.Msg)
-			resp.SetReply(req)
-
-			parsed, err := dns.NewRR(rr)
-			Expect(err).Should(Succeed())
-			resp.Answer = []dns.RR{parsed}
-
-			return resp
-		}
-
 		When("the client did not request EDNS0", func() {
 			It("advertises the buffer floor upstream but returns no OPT to the client", func() {
 				var advertised atomic.Int32
@@ -328,13 +364,13 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 							advertised.Store(int32(opt.UDPSize()))
 						}
 
-						resp := reply(req, "example.com. 123 IN A 1.2.3.4")
+						resp := replyWithRR(req, "example.com. 123 IN A 1.2.3.4")
 						resp.SetEdns0(upstreamUDPBufferFloor, false) // a real upstream echoes EDNS0
 
 						return resp
 					},
 					func(req *dns.Msg) *dns.Msg {
-						return reply(req, "example.com. 123 IN A 5.6.7.8")
+						return replyWithRR(req, "example.com. 123 IN A 5.6.7.8")
 					},
 				)
 
@@ -365,10 +401,10 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 							advertised.Store(int32(opt.UDPSize()))
 						}
 
-						return reply(req, "example.com. 123 IN A 1.2.3.4")
+						return replyWithRR(req, "example.com. 123 IN A 1.2.3.4")
 					},
 					func(req *dns.Msg) *dns.Msg {
-						return reply(req, "example.com. 123 IN A 5.6.7.8")
+						return replyWithRR(req, "example.com. 123 IN A 5.6.7.8")
 					},
 				)
 

--- a/resolver/upstream_resolver_test.go
+++ b/resolver/upstream_resolver_test.go
@@ -199,6 +199,191 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 		})
 	})
 
+	Describe("Plain DNS UDP-first with TCP fallback", func() {
+		// The suite-wide upstream timeout is tiny (50ms). These specs add small handler delays to
+		// make the UDP-vs-TCP ordering deterministic, so raise the timeout comfortably above them.
+		const handlerDelay = 30 * time.Millisecond
+
+		reply := func(req *dns.Msg, rr string) *dns.Msg {
+			resp := new(dns.Msg)
+			resp.SetReply(req)
+
+			parsed, err := dns.NewRR(rr)
+			Expect(err).Should(Succeed())
+			resp.Answer = []dns.RR{parsed}
+
+			return resp
+		}
+
+		BeforeEach(func() {
+			sutConfig.Timeout = config.Duration(time.Second)
+		})
+
+		When("the UDP answer is clean (not truncated, question matches)", func() {
+			It("returns the UDP answer and never dials TCP", func() {
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					func(req *dns.Msg) *dns.Msg {
+						// Delay UDP so a speculative TCP race (the old behavior) would win if started.
+						time.Sleep(handlerDelay)
+
+						return reply(req, "example.com. 123 IN A 1.2.3.4")
+					},
+					func(req *dns.Msg) *dns.Msg {
+						return reply(req, "example.com. 123 IN A 5.6.7.8")
+					},
+				)
+
+				sutConfig.Upstream = mockUpstream.Start()
+				sut := newUpstreamResolverUnchecked(sutConfig, nil)
+
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
+					Should(BeDNSRecord("example.com.", A, "1.2.3.4"))
+
+				Expect(mockUpstream.UDPCallCount()).Should(Equal(1))
+				Expect(mockUpstream.TCPCallCount()).Should(Equal(0))
+			})
+		})
+
+		When("the UDP answer is truncated", func() {
+			It("falls back to TCP and returns the TCP answer", func() {
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					func(req *dns.Msg) *dns.Msg {
+						resp := new(dns.Msg)
+						resp.SetReply(req)
+						resp.Truncated = true
+
+						return resp
+					},
+					func(req *dns.Msg) *dns.Msg {
+						return reply(req, "example.com. 123 IN A 5.6.7.8")
+					},
+				)
+
+				sutConfig.Upstream = mockUpstream.Start()
+				sut := newUpstreamResolverUnchecked(sutConfig, nil)
+
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
+					Should(BeDNSRecord("example.com.", A, "5.6.7.8"))
+
+				Expect(mockUpstream.UDPCallCount()).Should(Equal(1))
+				Expect(mockUpstream.TCPCallCount()).Should(Equal(1))
+			})
+		})
+
+		When("the UDP answer's question section doesn't match the request", func() {
+			It("treats it as unusable and falls back to TCP", func() {
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					func(req *dns.Msg) *dns.Msg {
+						resp := new(dns.Msg)
+						resp.SetReply(req)
+						// A mismatched question section — some buggy/limited upstreams do this over UDP.
+						resp.Question = []dns.Question{{
+							Name: "wrong.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET,
+						}}
+
+						parsed, err := dns.NewRR("wrong.example. 123 IN A 1.2.3.4")
+						Expect(err).Should(Succeed())
+						resp.Answer = []dns.RR{parsed}
+
+						return resp
+					},
+					func(req *dns.Msg) *dns.Msg {
+						// Delay TCP so the (old) racing UDP answer would win and be returned if it could.
+						time.Sleep(handlerDelay)
+
+						return reply(req, "example.com. 123 IN A 5.6.7.8")
+					},
+				)
+
+				sutConfig.Upstream = mockUpstream.Start()
+				sut := newUpstreamResolverUnchecked(sutConfig, nil)
+
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
+					Should(BeDNSRecord("example.com.", A, "5.6.7.8"))
+
+				Expect(mockUpstream.TCPCallCount()).Should(Equal(1))
+			})
+		})
+	})
+
+	Describe("EDNS0 UDP buffer floor for upstream queries", func() {
+		reply := func(req *dns.Msg, rr string) *dns.Msg {
+			resp := new(dns.Msg)
+			resp.SetReply(req)
+
+			parsed, err := dns.NewRR(rr)
+			Expect(err).Should(Succeed())
+			resp.Answer = []dns.RR{parsed}
+
+			return resp
+		}
+
+		When("the client did not request EDNS0", func() {
+			It("advertises the buffer floor upstream but returns no OPT to the client", func() {
+				var advertised atomic.Int32
+
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					func(req *dns.Msg) *dns.Msg {
+						if opt := req.IsEdns0(); opt != nil {
+							advertised.Store(int32(opt.UDPSize()))
+						}
+
+						resp := reply(req, "example.com. 123 IN A 1.2.3.4")
+						resp.SetEdns0(upstreamUDPBufferFloor, false) // a real upstream echoes EDNS0
+
+						return resp
+					},
+					func(req *dns.Msg) *dns.Msg {
+						return reply(req, "example.com. 123 IN A 5.6.7.8")
+					},
+				)
+
+				sutConfig.Upstream = mockUpstream.Start()
+				sut := newUpstreamResolverUnchecked(sutConfig, nil)
+
+				req := newRequest("example.com.", A)
+				Expect(req.Req.IsEdns0()).Should(BeNil())
+
+				resp, err := sut.Resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp).Should(BeDNSRecord("example.com.", A, "1.2.3.4"))
+
+				Expect(advertised.Load()).Should(BeNumerically(">=", int32(upstreamUDPBufferFloor)))
+				Expect(resp.Res.IsEdns0()).Should(BeNil())
+			})
+		})
+
+		When("the client requests a larger EDNS0 buffer than the floor", func() {
+			It("does not lower it to the floor", func() {
+				const clientBuffer = 4096
+
+				var advertised atomic.Int32
+
+				mockUpstream := newMockTCPUDPUpstreamServer(
+					func(req *dns.Msg) *dns.Msg {
+						if opt := req.IsEdns0(); opt != nil {
+							advertised.Store(int32(opt.UDPSize()))
+						}
+
+						return reply(req, "example.com. 123 IN A 1.2.3.4")
+					},
+					func(req *dns.Msg) *dns.Msg {
+						return reply(req, "example.com. 123 IN A 5.6.7.8")
+					},
+				)
+
+				sutConfig.Upstream = mockUpstream.Start()
+				sut := newUpstreamResolverUnchecked(sutConfig, nil)
+
+				req := newRequest("example.com.", A)
+				req.Req.SetEdns0(clientBuffer, false)
+
+				Expect(sut.Resolve(ctx, req)).Should(BeDNSRecord("example.com.", A, "1.2.3.4"))
+				Expect(advertised.Load()).Should(Equal(int32(clientBuffer)))
+			})
+		})
+	})
+
 	Describe("Using DNS over HTTPS (DoH) upstream", func() {
 		var (
 			respFn           func(request *dns.Msg) (response *dns.Msg)

--- a/resolver/upstream_resolver_test.go
+++ b/resolver/upstream_resolver_test.go
@@ -75,6 +75,21 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 
 			Expect(hook.Calls).ShouldNot(BeEmpty())
 		})
+
+		When("certificate pinning is configured", func() {
+			It("logs the number of pinned hashes", func() {
+				logger, hook := log.NewMockEntry()
+
+				cfg := newUpstreamConfig(config.Upstream{
+					Net: config.NetProtocolTcpTls, Host: "localhost",
+					CertificateFingerprints: []config.CertificateFingerprint{make([]byte, sha256.Size)},
+				}, defaultUpstreamsConfig)
+
+				cfg.LogConfig(logger)
+
+				Expect(hook.Calls).ShouldNot(BeEmpty())
+			})
+		})
 	})
 
 	Describe("Using DNS upstream", func() {
@@ -523,6 +538,19 @@ var _ = Describe("UpstreamResolver", Label("upstreamResolver"), func() {
 					ContainSubstring("http return content type should be 'application/dns-message', but was 'text'"))
 			})
 		})
+		When("Configured DoH resolver closes the connection mid-body", func() {
+			BeforeEach(func() {
+				modifyHTTPRespFn = func(w http.ResponseWriter) {
+					// declare more body bytes than the handler writes, so reading the body fails
+					w.Header().Set("Content-Length", "4096")
+				}
+			})
+			It("should return error", func() {
+				_, err := sut.Resolve(ctx, newRequest("example.com.", A))
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("can't read response body"))
+			})
+		})
 		When("Configured DoH resolver returns wrong content", func() {
 			BeforeEach(func() {
 				modifyHTTPRespFn = func(w http.ResponseWriter) {
@@ -926,6 +954,73 @@ var _ = Describe("UpstreamResolver connection pooling", Label("upstreamResolver"
 
 			_, _, err := client.callExternal(ctx, newRequest("example.com.", A).Req, "127.0.0.1:0")
 			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Describe("DoH client request building", func() {
+		When("the request message can't be packed", func() {
+			It("returns a pack error without sending anything", func() {
+				client := &httpUpstreamClient{client: http.DefaultClient, host: "example.com"}
+
+				msg := new(dns.Msg)
+				msg.Question = []dns.Question{{
+					Name: "not-fully-qualified", Qtype: dns.TypeA, Qclass: dns.ClassINET,
+				}}
+
+				_, _, err := client.callExternal(ctx, msg, "https://127.0.0.1:1/dns-query")
+				Expect(err).Should(MatchError(ContainSubstring("can't pack message")))
+			})
+		})
+
+		When("the upstream URL is invalid", func() {
+			It("returns a request creation error", func() {
+				client := &httpUpstreamClient{client: http.DefaultClient, host: "example.com"}
+
+				_, _, err := client.callExternal(ctx, newRequest("example.com.", A).Req, "ht tp://invalid")
+				Expect(err).Should(MatchError(ContainSubstring("can't create the new request")))
+			})
+		})
+	})
+
+	Describe("createUpstreamClient", func() {
+		When("a CommonName from a DNS stamp is set", func() {
+			It("uses it as the TLS server name instead of the host", func() {
+				cfg := newUpstreamConfig(config.Upstream{
+					Net: config.NetProtocolTcpTls, Host: "1.2.3.4", Port: 853, CommonName: "dot.example.com",
+				}, defaultUpstreamsConfig)
+
+				client, ok := createUpstreamClient(cfg).(*dnsUpstreamClient)
+				Expect(ok).Should(BeTrue())
+				Expect(client.tcpClient.TLSConfig.ServerName).Should(Equal("dot.example.com"))
+			})
+		})
+	})
+
+	Describe("udpRequestWithBufferFloor", func() {
+		When("the request advertises an EDNS0 buffer below the floor", func() {
+			It("raises it on a copy, keeping the DO bit and leaving the original untouched", func() {
+				msg := util.NewMsgWithQuestion("example.com.", A)
+				msg.SetEdns0(512, true)
+
+				raised := udpRequestWithBufferFloor(msg)
+
+				Expect(raised).ShouldNot(BeIdenticalTo(msg))
+				Expect(raised.IsEdns0().UDPSize()).Should(Equal(uint16(upstreamUDPBufferFloor)))
+				Expect(raised.IsEdns0().Do()).Should(BeTrue())
+				Expect(msg.IsEdns0().UDPSize()).Should(Equal(uint16(512)))
+			})
+		})
+	})
+
+	Describe("responseMatchesRequest", func() {
+		When("the response has a different number of questions than the request", func() {
+			It("doesn't match", func() {
+				req := util.NewMsgWithQuestion("example.com.", A)
+				resp := util.NewMsgWithQuestion("example.com.", A)
+				resp.Question = append(resp.Question, resp.Question[0])
+
+				Expect(responseMatchesRequest(req, resp)).Should(BeFalse())
+			})
 		})
 	})
 

--- a/server/server.go
+++ b/server/server.go
@@ -800,6 +800,12 @@ func (s *Server) resolve(ctx context.Context, request *model.Request) (response 
 
 	defer cancel()
 
+	// The resolver chain mutates request.Req in place and may add or enlarge an OPT record the
+	// client never sent (ECS, DNSSEC, the upstream EDNS0 buffer floor), so capture what the client
+	// itself asked for up front: the response is normalized against that, not the mutated request.
+	clientMaxResponseSize := getMaxResponseSize(request)
+	clientHadEdns0 := request.Req.IsEdns0() != nil
+
 	switch {
 	case len(request.Req.Question) == 0:
 		m := new(dns.Msg)
@@ -825,8 +831,13 @@ func (s *Server) resolve(ctx context.Context, request *model.Request) (response 
 
 	response.Res.RecursionAvailable = request.Req.RecursionDesired
 
+	if !clientHadEdns0 {
+		// don't return an OPT record to a client that didn't use EDNS0 (RFC 6891 section 6.1.1)
+		util.RemoveEdns0Record(response.Res)
+	}
+
 	// truncate if necessary
-	response.Res.Truncate(getMaxResponseSize(request))
+	response.Res.Truncate(clientMaxResponseSize)
 
 	// enable compression
 	response.Res.Compress = true

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1142,6 +1142,92 @@ var _ = Describe("Running DNS server", func() {
 		})
 	})
 
+	Describe("client EDNS0 normalization", func() {
+		// The resolver chain mutates request.Req in place: ECS, DNSSEC, and the upstream EDNS0
+		// buffer floor may add or enlarge an OPT record the client never sent. The response sent
+		// back must be normalized against what the client itself asked for.
+		var chainResponse *dns.Msg
+
+		newServerWithChain := func(chain func(req *model.Request) *dns.Msg) *Server {
+			m := resolver.NewMockChainedResolver(GinkgoT())
+			m.EXPECT().Resolve(mock.Anything, mock.Anything).RunAndReturn(
+				func(_ context.Context, req *model.Request) (*model.Response, error) {
+					return &model.Response{Res: chain(req), RType: model.ResponseTypeRESOLVED, Reason: "RESOLVED"}, nil
+				})
+
+			return &Server{
+				queryResolver: m,
+				cfg: &config.Config{Upstreams: config.Upstreams{
+					Timeout: config.Duration(time.Second),
+				}},
+			}
+		}
+
+		// chainAddingEdns0 simulates a chain member adding EDNS0 to the request (like DNSSEC/ECS)
+		// and an upstream echoing it in the response.
+		chainAddingEdns0 := func(req *model.Request) *dns.Msg {
+			req.Req.SetEdns0(4096, true)
+
+			chainResponse.SetReply(req.Req)
+			chainResponse.SetEdns0(4096, false)
+
+			return chainResponse
+		}
+
+		BeforeEach(func() {
+			var err error
+
+			chainResponse, err = util.NewMsgWithAnswer("example.com.", 123, A, "1.2.3.4")
+			Expect(err).Should(Succeed())
+		})
+
+		When("the client did not use EDNS0", func() {
+			It("strips the OPT record added by the resolver chain from the response", func() {
+				s := newServerWithChain(chainAddingEdns0)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP,
+					util.NewMsgWithQuestion("example.com.", A))
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.IsEdns0()).Should(BeNil())
+			})
+
+			It("truncates the response to the client's 512 byte limit, not the chain's buffer size", func() {
+				for i := range 40 {
+					rr, err := dns.NewRR(fmt.Sprintf("example.com. 123 IN A 1.2.3.%d", i))
+					Expect(err).Should(Succeed())
+					chainResponse.Answer = append(chainResponse.Answer, rr)
+				}
+
+				s := newServerWithChain(chainAddingEdns0)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP,
+					util.NewMsgWithQuestion("example.com.", A))
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.Len()).Should(BeNumerically("<=", dns.MinMsgSize))
+				Expect(resp.Res.Truncated).Should(BeTrue())
+			})
+		})
+
+		When("the client used EDNS0", func() {
+			It("keeps the OPT record in the response", func() {
+				s := newServerWithChain(chainAddingEdns0)
+
+				clientMsg := util.NewMsgWithQuestion("example.com.", A)
+				clientMsg.SetEdns0(1232, false)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP, clientMsg)
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.IsEdns0()).ShouldNot(BeNil())
+			})
+		})
+	})
+
 	Describe("secureHeadersMiddleware", func() {
 		It("should set security headers for TLS requests", func() {
 			handler := secureHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

Replaces the always-race UDP+TCP plain-DNS upstream client with a UDP-first design, and advertises an EDNS0 1232-byte buffer floor to plain upstreams.

## Why

For the default `tcp+udp` protocol, `raceClients` launched **both** a UDP and a TCP exchange on every query. UDP wins almost always (non-truncated), so a TCP SYN/dial + goroutine were spawned and thrown away on essentially every cache miss — multiplied by `parallel_best`'s fan-out (~2 UDP + 2 TCP conns + ~6 goroutines per query).

## Changes

- **UDP-first with TCP fallback** — query UDP first; fall back to TCP only when the UDP answer is truncated (TC bit) or its question section doesn't match the request. No TCP connection is opened on the common path.
- **EDNS0 1232 buffer floor** — advertise a ≥1232-byte UDP buffer to plain upstreams (the DNS flag day 2020 value), independent of what the client requested, so larger answers arrive over UDP instead of forcing the TCP fallback. It's applied to a **copy** of the query so the shared request — which also drives per-client response truncation in the server — is never mutated; the TCP fallback uses the original request; and the resulting OPT is stripped from the response when the client didn't request EDNS0, so no OPT is leaked back to a non-EDNS0 client.

## Behavior note

A hard UDP failure (timeout / network error / SERVFAIL) no longer escalates to TCP within a single upstream. `retry.Do` (3 attempts) and `parallel_best` racing other upstreams already provide loss resilience, so the per-upstream TCP race was redundant. Single-upstream configs on a lossy link now rely on the retry layer rather than an immediate in-call TCP retry.

## Tests

- New dual UDP+TCP mock upstream (`mock_tcp_udp_upstream_server_test.go`) with per-protocol call counters, so specs can assert which transport was actually used.
- UDP-first specs: a clean UDP answer never dials TCP; truncated and mismatched-question answers fall back to TCP.
- EDNS0 floor specs: a non-EDNS0 client's query advertises ≥1232 upstream while its response carries no OPT; a client's larger buffer is preserved.

`make lint` reports 0 issues; the resolver (558/558) and server suites pass.
