### PR TITLE
perf(server): let Truncate decide response compression

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -836,11 +836,10 @@ func (s *Server) resolve(ctx context.Context, request *model.Request) (response 
 		util.RemoveEdns0Record(response.Res)
 	}
 
-	// truncate if necessary
+	// truncate if necessary; Truncate also disables compression when the message already fits
+	// uncompressed and enables it when compression is needed to fit, so we let it decide rather
+	// than forcing Compress=true and paying a compression-map alloc + packing on every response.
 	response.Res.Truncate(clientMaxResponseSize)
-
-	// enable compression
-	response.Res.Compress = true
 
 	return response, nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1228,6 +1228,63 @@ var _ = Describe("Running DNS server", func() {
 		})
 	})
 
+	Describe("response compression", func() {
+		// miekg's Truncate sets Compress=false when the message already fits uncompressed
+		// ("don't waste effort compressing this message"). resolve must honor that decision
+		// instead of clobbering it by forcing Compress=true on every response.
+		newServerWithResponse := func(res *dns.Msg) *Server {
+			m := resolver.NewMockChainedResolver(GinkgoT())
+			m.EXPECT().Resolve(mock.Anything, mock.Anything).RunAndReturn(
+				func(_ context.Context, req *model.Request) (*model.Response, error) {
+					res.SetReply(req.Req)
+					return &model.Response{Res: res, RType: model.ResponseTypeRESOLVED, Reason: "RESOLVED"}, nil
+				})
+
+			return &Server{
+				queryResolver: m,
+				cfg: &config.Config{Upstreams: config.Upstreams{
+					Timeout: config.Duration(time.Second),
+				}},
+			}
+		}
+
+		When("the response fits the client buffer uncompressed", func() {
+			It("leaves compression disabled so Pack does not waste effort", func() {
+				res, err := util.NewMsgWithAnswer("example.com.", 123, A, "1.2.3.4")
+				Expect(err).Should(Succeed())
+
+				s := newServerWithResponse(res)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP,
+					util.NewMsgWithQuestion("example.com.", A))
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.Compress).Should(BeFalse())
+			})
+		})
+
+		When("the response does not fit the client buffer uncompressed", func() {
+			It("keeps compression enabled so Pack can shrink the message", func() {
+				res := new(dns.Msg)
+				for i := range 20 {
+					rr, err := dns.NewRR(fmt.Sprintf("example.com. 123 IN A 1.2.3.%d", i))
+					Expect(err).Should(Succeed())
+					res.Answer = append(res.Answer, rr)
+				}
+
+				s := newServerWithResponse(res)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP,
+					util.NewMsgWithQuestion("example.com.", A))
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.Compress).Should(BeTrue())
+			})
+		})
+	})
+
 	Describe("secureHeadersMiddleware", func() {
 		It("should set security headers for TLS requests", func() {
 			handler := secureHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1237,6 +1237,7 @@ var _ = Describe("Running DNS server", func() {
 			m.EXPECT().Resolve(mock.Anything, mock.Anything).RunAndReturn(
 				func(_ context.Context, req *model.Request) (*model.Response, error) {
 					res.SetReply(req.Req)
+
 					return &model.Response{Res: res, RType: model.ResponseTypeRESOLVED, Reason: "RESOLVED"}, nil
 				})
 
@@ -1281,6 +1282,9 @@ var _ = Describe("Running DNS server", func() {
 				resp, err := s.resolve(ctx, req)
 				Expect(err).Should(Succeed())
 				Expect(resp.Res.Compress).Should(BeTrue())
+				// guard the scenario: the message must fit *because* of compression, not by
+				// being truncated — otherwise this would also pass on the truncated path.
+				Expect(resp.Res.Truncated).Should(BeFalse())
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

`resolve()` calls `dns.Msg.Truncate()` and then unconditionally forces `response.Res.Compress = true` on **every** response.

miekg's `Truncate` already manages the `Compress` flag for us:
- it sets `Compress = false` when the message already fits uncompressed (*"don't waste effort compressing this message"*), and
- it sets `Compress = true` only when compression is actually needed to fit the client's buffer.

Forcing `Compress = true` afterwards clobbered that optimization, so `Pack` allocated a compression map and did compressed-name packing for every response — including tiny single-A answers and TCP replies that never needed it.

This PR drops the forced assignment and lets `Truncate`'s decision stand.

## Why it's safe

`Truncate` runs first and is authoritative on whether the reply fits the client's advertised size. It already enables compression itself in the branch where compression is required to fit, and disables it when the message fits as-is. So correctness (does the response fit?) is preserved in both cases; we only stop paying compression on the responses that didn't need it.

**Trade-off:** a response that fits uncompressed but would be smaller compressed (e.g. a CNAME chain) now goes out uncompressed — a few extra bytes on the wire. This is bounded: such replies are by definition already under the client's budget, and anything that needs compression to fit still gets it.

## Impact

Measured on the single-A, fits-uncompressed path (`resolve` + `Pack`): **−256 B/op, −2 allocs/op per response** (removes the compression-map alloc + compressed-name packing).

## Tests

Added two specs under `response compression` pinning the contract that `Compress` reflects `Truncate`'s decision:
- fits uncompressed → `Compress == false`
- needs compression to fit → `Compress == true`

Developed test-first (the first spec failed against the old forced-`true` code). Full `server` suite green; `go vet` and `gofmt` clean.