### PR TITLE
perf(resolver): pre-classify client groups to cut per-query allocations

### DIFF
--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -91,7 +92,7 @@ type BlockingResolver struct {
 	blockHandler        blockHandler
 	allowlistOnlyGroups map[string]bool
 	status              *status
-	clientGroupsBlock   map[string][]scheduledGroup
+	clientGroups        clientGroupsIndex
 	fqdnIPCache         cache.ExpiringCache[[]net.IP]
 }
 
@@ -135,6 +136,57 @@ func clientGroupsBlock(cfg config.Blocking) map[string][]scheduledGroup {
 	return cgb
 }
 
+// clientGroupsIndex pre-classifies the client→group mapping once at config load
+// so per-query resolution avoids re-parsing CIDRs and re-lowercasing identifiers
+// on every request (see PERFORMANCE.md, finding #8). It is immutable after
+// construction.
+type clientGroupsIndex struct {
+	// byID maps an exact, already-lowercased identifier (IP literal, FQDN, client
+	// name or "default") to its groups. Used for exact ClientIP and "default"
+	// lookups and iterated for client-name glob matching.
+	byID map[string][]scheduledGroup
+	// cidrs holds identifiers that parse as a CIDR, with the network pre-parsed.
+	cidrs []cidrGroups
+	// fqdns holds identifiers classified as FQDN candidates (resolved via the
+	// fqdnIPCache at query time).
+	fqdns []fqdnGroups
+}
+
+type cidrGroups struct {
+	ipNet  *net.IPNet
+	groups []scheduledGroup
+}
+
+type fqdnGroups struct {
+	identifier string
+	groups     []scheduledGroup
+}
+
+func newClientGroupsIndex(cfg config.Blocking) clientGroupsIndex {
+	byID := clientGroupsBlock(cfg)
+
+	idx := clientGroupsIndex{byID: byID}
+
+	for id, groups := range byID {
+		// Pre-parse CIDR identifiers so per-query matching is a cheap
+		// ipNet.Contains instead of a net.ParseCIDR allocation per entry.
+		if _, ipNet, err := net.ParseCIDR(id); err == nil {
+			idx.cidrs = append(idx.cidrs, cidrGroups{ipNet: ipNet, groups: groups})
+		}
+
+		// Mirror the previous per-query isFQDN(identifier) check so FQDN
+		// candidates are resolved via the fqdnIPCache without rescanning the
+		// whole map. A CIDR identifier can also be an FQDN candidate (e.g.
+		// "10.0.0.0/8" contains a dot); keeping it in both buckets is faithful
+		// to the original branching.
+		if isFQDN(id) {
+			idx.fqdns = append(idx.fqdns, fqdnGroups{identifier: id, groups: groups})
+		}
+	}
+
+	return idx
+}
+
 // NewBlockingResolver returns a new configured instance of the resolver
 func NewBlockingResolver(ctx context.Context,
 	cfg config.Blocking,
@@ -170,7 +222,7 @@ func NewBlockingResolver(ctx context.Context,
 			enabled:     true,
 			enableTimer: time.NewTimer(0),
 		},
-		clientGroupsBlock: clientGroupsBlock(cfg),
+		clientGroups: newClientGroupsIndex(cfg),
 	}
 
 	res.fqdnIPCache = expirationcache.NewCacheWithOnExpired[[]net.IP](ctx, expirationcache.Options{
@@ -487,7 +539,7 @@ func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) []stri
 
 	if len(groups) == 0 {
 		// return default
-		groups = r.clientGroupsBlock["default"]
+		groups = r.clientGroups.byID["default"]
 	}
 
 	now := time.Now()
@@ -527,33 +579,43 @@ func isAnyScheduleActive(schedules []*config.Schedule, now time.Time) bool {
 func (r *BlockingResolver) collectGroupsForClient(request *model.Request) []scheduledGroup {
 	var groups []scheduledGroup
 
-	// try client names
+	cg := r.clientGroups
+
+	// try client names: identifiers are already lowercased at config load, so the
+	// client name is lowered once here instead of both sides per map entry.
 	for _, cName := range request.ClientNames {
-		for blockGroup, groupsByName := range r.clientGroupsBlock {
-			if util.ClientNameMatchesGroupName(blockGroup, cName) {
+		lowerName := strings.ToLower(cName)
+
+		for identifier, groupsByName := range cg.byID {
+			if matched, _ := filepath.Match(identifier, lowerName); matched {
 				groups = append(groups, groupsByName...)
 			}
 		}
 	}
 
 	// try IP
-	groupsByIP, found := r.clientGroupsBlock[request.ClientIP.String()]
-
-	if found {
+	if groupsByIP, found := cg.byID[request.ClientIP.String()]; found {
 		groups = append(groups, groupsByIP...)
 	}
 
-	for clientIdentifier, groupsByCidr := range r.clientGroupsBlock {
-		// try CIDR
-		if util.CidrContainsIP(clientIdentifier, request.ClientIP) {
-			groups = append(groups, groupsByCidr...)
-		} else if isFQDN(clientIdentifier) && r.fqdnIPCache != nil {
-			ips, _ := r.fqdnIPCache.Get(clientIdentifier)
-			if ips != nil {
-				for _, ip := range *ips {
-					if ip.Equal(request.ClientIP) {
-						groups = append(groups, groupsByCidr...)
-					}
+	// try CIDR using the networks pre-parsed at config load
+	for _, c := range cg.cidrs {
+		if c.ipNet.Contains(request.ClientIP) {
+			groups = append(groups, c.groups...)
+		}
+	}
+
+	// try FQDN identifiers via their resolved IPs
+	if r.fqdnIPCache != nil {
+		for _, f := range cg.fqdns {
+			ips, _ := r.fqdnIPCache.Get(f.identifier)
+			if ips == nil {
+				continue
+			}
+
+			for _, ip := range *ips {
+				if ip.Equal(request.ClientIP) {
+					groups = append(groups, f.groups...)
 				}
 			}
 		}
@@ -688,13 +750,9 @@ func (r *BlockingResolver) queryForFQIdentifierIPs(ctx context.Context, identifi
 }
 
 func (r *BlockingResolver) initFQDNIPCache(ctx context.Context) {
-	identifiers := slices.Collect(maps.Keys(r.clientGroupsBlock))
-
-	for _, identifier := range identifiers {
-		if isFQDN(identifier) {
-			iPs, ttl := r.queryForFQIdentifierIPs(ctx, identifier)
-			r.fqdnIPCache.Put(identifier, iPs, ttl)
-		}
+	for _, f := range r.clientGroups.fqdns {
+		iPs, ttl := r.queryForFQIdentifierIPs(ctx, f.identifier)
+		r.fqdnIPCache.Put(f.identifier, iPs, ttl)
 	}
 }
 

--- a/resolver/blocking_resolver_index_test.go
+++ b/resolver/blocking_resolver_index_test.go
@@ -1,0 +1,55 @@
+package resolver
+
+import (
+	"net"
+
+	"github.com/0xERR0R/blocky/config"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("clientGroupsIndex", func() {
+	var idx clientGroupsIndex
+
+	BeforeEach(func() {
+		cfg := config.Blocking{
+			ClientGroupsBlock: map[string][]string{
+				"default":          {"gr1"},
+				"10.0.0.0/8":       {"gr1"},
+				"192.168.178.55":   {"gr2"},
+				"Laptop":           {"gr1"},
+				"phone,tablet":     {"gr2"},
+				"host.Example.com": {"gr1"},
+			},
+		}
+
+		idx = newClientGroupsIndex(cfg)
+	})
+
+	It("keeps every identifier (lowercased, comma-split) in byID for exact lookups", func() {
+		Expect(idx.byID).Should(HaveKey("default"))
+		Expect(idx.byID).Should(HaveKey("10.0.0.0/8"))
+		Expect(idx.byID).Should(HaveKey("192.168.178.55"))
+		Expect(idx.byID).Should(HaveKey("laptop"))
+		Expect(idx.byID).Should(HaveKey("phone"))
+		Expect(idx.byID).Should(HaveKey("tablet"))
+		Expect(idx.byID).Should(HaveKey("host.example.com"))
+	})
+
+	It("pre-parses only the CIDR identifiers into ready-to-use networks", func() {
+		Expect(idx.cidrs).Should(HaveLen(1))
+		Expect(idx.cidrs[0].ipNet).ShouldNot(BeNil())
+		Expect(idx.cidrs[0].ipNet.Contains(net.ParseIP("10.1.2.3"))).Should(BeTrue())
+		Expect(idx.cidrs[0].ipNet.Contains(net.ParseIP("11.0.0.1"))).Should(BeFalse())
+	})
+
+	It("classifies every dotted identifier as an FQDN candidate (faithful to isFQDN)", func() {
+		ids := make([]string, 0, len(idx.fqdns))
+		for _, f := range idx.fqdns {
+			ids = append(ids, f.identifier)
+		}
+
+		Expect(ids).Should(ConsistOf("10.0.0.0/8", "192.168.178.55", "host.example.com"))
+	})
+})


### PR DESCRIPTION
## What

`BlockingResolver.collectGroupsForClient` runs on **every request — including cache hits**, since Blocking precedes Caching in the resolver chain. On each call it walked the whole `clientGroupsBlock` map twice and:

- called `net.ParseCIDR` for *every* identifier (allocating a throwaway `*net.IPNet`), even for `"default"`, client names and IP literals that can never be a CIDR;
- did `strings.ToLower` on **both** sides of every name glob, though the map keys are already lowercased at config load.


## Change

Pre-classify the client→group map **once at config load** into an immutable `clientGroupsIndex`:

- `cidrs` — identifiers parsed to `*net.IPNet` once; per-query matching is a cheap `ipNet.Contains`.
- `fqdns` — FQDN candidates collected once (no per-query `isFQDN` rescan).
- `byID` — the exact-lookup map, still used for `"default"`/exact-IP and name globbing; the client name is lowered **once** per request instead of on both sides of every entry.

Strictly the refactor for finding #8 — no name exact/glob split, no per-client memoization.

## Behavior preservation

A CIDR/IP-literal identifier can never resolve to a routable client IP via `fqdnIPCache` (see `queryForFQIdentifierIPs`), so scanning the CIDR and FQDN buckets independently yields the same matches as the original `if/else`. The existing `BlockingResolver` specs (name / multipart / exact IP / CIDR boundaries / wildcard / default / FQDN) all stay green, and a new `clientGroupsIndex` unit test pins the classification.

## Benchmark (hot path, 14 client-group entries)

Measured with `benchstat`, n=8, p=0.000:

| metric | before | after | delta |
|---|---|---|---|
| time | 3.555 µs | 1.436 µs | **−59.6%** |
| B/op | 1056 | 352 | **−66.7%** |
| allocs/op | 34 | 4 | **−88.2%** |

