### PR TITLE
fix(resolver): eliminate recursive RLock deadlock in blocking group resolution

### DIFF
--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -73,7 +73,10 @@ func createBlockHandler(cfg config.Blocking) (blockHandler, error) {
 type status struct {
 	// true: blocking of all groups is enabled
 	// false: blocking is disabled. Either all groups or only particular
-	enabled        bool
+	enabled bool
+	// disabledGroups must only ever be reassigned wholesale (never appended to
+	// in place): groupsToCheckForClient snapshots the slice header under a brief
+	// read lock and reads it after releasing the lock.
 	disabledGroups []string
 	enableTimer    *time.Timer
 	disableEnd     time.Time
@@ -471,17 +474,17 @@ func extractEntryToCheckFromResponse(rr dns.RR) (entryToCheck, tName string) {
 	return entryToCheck, tName
 }
 
-func (r *BlockingResolver) isGroupDisabled(group string) bool {
-	r.status.lock.RLock()
-	defer r.status.lock.RUnlock()
-
-	return slices.Contains(r.status.disabledGroups, group)
-}
-
 // returns groups which should be checked for client's request
 func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) []string {
+	// Snapshot disabledGroups under the lock, then release it before the
+	// (lock-free) group collection and filtering below. Writers always reassign
+	// status.disabledGroups instead of mutating it in place, so the captured
+	// slice stays a stable view. Re-locking inside the loop (the former
+	// isGroupDisabled helper) recursively read-locked status.lock, which Go's
+	// RWMutex forbids and which deadlocks against a concurrent writer.
 	r.status.lock.RLock()
-	defer r.status.lock.RUnlock()
+	disabledGroups := r.status.disabledGroups
+	r.status.lock.RUnlock()
 
 	groups := r.collectGroupsForClient(request)
 
@@ -495,7 +498,7 @@ func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) []stri
 	var result []string
 
 	for _, sg := range groups {
-		if r.isGroupDisabled(sg.group) {
+		if slices.Contains(disabledGroups, sg.group) {
 			continue
 		}
 

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -74,9 +74,11 @@ type status struct {
 	// true: blocking of all groups is enabled
 	// false: blocking is disabled. Either all groups or only particular
 	enabled bool
-	// disabledGroups must only ever be reassigned wholesale (never appended to
-	// in place): groupsToCheckForClient snapshots the slice header under a brief
-	// read lock and reads it after releasing the lock.
+	// disabledGroups must only ever be reassigned wholesale, never mutated in
+	// place (no in-place append, no element writes): groupsToCheckForClient
+	// snapshots the slice header under a brief read lock and then reads the
+	// backing array after releasing the lock, so any in-place mutation would be
+	// an unsynchronized write racing that lock-free read.
 	disabledGroups []string
 	enableTimer    *time.Timer
 	disableEnd     time.Time
@@ -297,7 +299,10 @@ func (r *BlockingResolver) internalDisableBlocking(ctx context.Context, duration
 			}
 		}
 
-		s.disabledGroups = disableGroups
+		// Clone so status owns the backing array: the caller keeps a reference to
+		// disableGroups, and groupsToCheckForClient reads s.disabledGroups
+		// lock-free, so an external in-place mutation must not be able to race it.
+		s.disabledGroups = slices.Clone(disableGroups)
 	}
 
 	s.enabled = false
@@ -476,12 +481,12 @@ func extractEntryToCheckFromResponse(rr dns.RR) (entryToCheck, tName string) {
 
 // returns groups which should be checked for client's request
 func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) []string {
-	// Snapshot disabledGroups under the lock, then release it before the
-	// (lock-free) group collection and filtering below. Writers always reassign
-	// status.disabledGroups instead of mutating it in place, so the captured
-	// slice stays a stable view. Re-locking inside the loop (the former
-	// isGroupDisabled helper) recursively read-locked status.lock, which Go's
-	// RWMutex forbids and which deadlocks against a concurrent writer.
+	// Snapshot disabledGroups under a brief read lock, then release it before the
+	// (lock-free) group collection and filtering below. The field's invariant
+	// (reassigned wholesale, never mutated in place) is what keeps the captured
+	// slice a stable view without holding the lock across the loop. Do not
+	// re-acquire status.lock inside the loop: that recursive RLock deadlocks
+	// against a pending writer, which Go's RWMutex forbids.
 	r.status.lock.RLock()
 	disabledGroups := r.status.disabledGroups
 	r.status.lock.RUnlock()

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -72,7 +72,8 @@ func createBlockHandler(cfg config.Blocking) (blockHandler, error) {
 
 type status struct {
 	// true: blocking of all groups is enabled
-	// false: blocking is disabled. Either all groups or only particular
+	// false: blocking is disabled, either for all groups or only for the
+	// particular groups listed in disabledGroups
 	enabled bool
 	// disabledGroups must only ever be reassigned wholesale, never mutated in
 	// place (no in-place append, no element writes): groupsToCheckForClient
@@ -337,8 +338,11 @@ func (r *BlockingResolver) BlockingStatus() api.BlockingStatus {
 	}
 
 	return api.BlockingStatus{
-		Enabled:         r.status.enabled,
-		DisabledGroups:  r.status.disabledGroups,
+		Enabled: r.status.enabled,
+		// Clone so callers cannot mutate status.disabledGroups in place: it is
+		// read lock-free in groupsToCheckForClient, so handing out the live slice
+		// would let an external write race that read.
+		DisabledGroups:  slices.Clone(r.status.disabledGroups),
 		AutoEnableInSec: int(autoEnableDuration.Seconds()),
 	}
 }

--- a/resolver/blocking_resolver_concurrency_test.go
+++ b/resolver/blocking_resolver_concurrency_test.go
@@ -1,0 +1,106 @@
+package resolver
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/0xERR0R/blocky/config"
+
+	. "github.com/0xERR0R/blocky/helpertest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BlockingResolver concurrency", Label("blockingResolver"), func() {
+	var (
+		sut       *BlockingResolver
+		sutConfig config.Blocking
+		ctx       context.Context
+		cancelFn  context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		ctx, cancelFn = context.WithCancel(context.Background())
+		DeferCleanup(cancelFn)
+
+		sutConfig = config.Blocking{
+			BlockType: "ZEROIP",
+			BlockTTL:  config.Duration(time.Minute),
+			Denylists: map[string][]config.BytesSource{
+				"gr1": config.NewBytesSources(group1File.Path),
+				"gr2": config.NewBytesSources(group2File.Path),
+			},
+			ClientGroupsBlock: map[string][]string{
+				"default": {"gr1", "gr2"},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		var err error
+
+		sut, err = NewBlockingResolver(ctx, sutConfig, systemResolverBootstrap)
+		Expect(err).Should(Succeed())
+	})
+
+	// Regression test for the recursive status.lock.RLock() in
+	// groupsToCheckForClient -> isGroupDisabled. Go's RWMutex forbids recursive
+	// read-locking: if a writer (DisableBlocking/EnableBlocking/timer) acquires
+	// the write lock between the outer read lock and the inner one, the inner
+	// RLock blocks forever and the goroutine deadlocks. This stresses exactly
+	// that interleaving; before the fix it hangs and the spec times out.
+	It("does not deadlock when blocking is toggled concurrently with group resolution", func() {
+		const (
+			readers    = 8
+			iterations = 20000
+		)
+
+		request := newRequestWithClient("example.com.", A, "1.2.1.2", "someclient")
+
+		done := make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+
+			var wg sync.WaitGroup
+
+			// writer: continuously flips the blocking state, taking the write lock.
+			wg.Add(1)
+
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				for range iterations {
+					_ = sut.DisableBlocking(ctx, 0, []string{})
+					sut.EnableBlocking(ctx)
+				}
+			}()
+
+			// readers: resolve the per-client group set, which read-locks twice.
+			for range readers {
+				wg.Add(1)
+
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+
+					for range iterations {
+						sut.groupsToCheckForClient(request)
+					}
+				}()
+			}
+
+			wg.Wait()
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			Fail("groupsToCheckForClient deadlocked: recursive status.lock.RLock " +
+				"under concurrent blocking toggling")
+		}
+	})
+})

--- a/resolver/blocking_resolver_concurrency_test.go
+++ b/resolver/blocking_resolver_concurrency_test.go
@@ -98,9 +98,12 @@ var _ = Describe("BlockingResolver concurrency", Label("blockingResolver"), func
 			wg.Wait()
 		}()
 
+		timeout := time.NewTimer(15 * time.Second)
+		defer timeout.Stop()
+
 		select {
 		case <-done:
-		case <-time.After(15 * time.Second):
+		case <-timeout.C:
 			Fail("groupsToCheckForClient deadlocked: recursive status.lock.RLock " +
 				"under concurrent blocking toggling")
 		}

--- a/resolver/blocking_resolver_concurrency_test.go
+++ b/resolver/blocking_resolver_concurrency_test.go
@@ -79,7 +79,9 @@ var _ = Describe("BlockingResolver concurrency", Label("blockingResolver"), func
 				}
 			}()
 
-			// readers: resolve the per-client group set, which read-locks twice.
+			// readers: resolve the per-client group set, which snapshots
+			// disabledGroups under a brief read lock (the path that previously
+			// recursively read-locked and deadlocked).
 			for range readers {
 				wg.Add(1)
 


### PR DESCRIPTION
## Problem

`groupsToCheckForClient` held `status.lock.RLock()` for the whole function and then called `isGroupDisabled`, which took `status.lock.RLock()` **again**:

```go
func (r *BlockingResolver) groupsToCheckForClient(...) []string {
    r.status.lock.RLock()
    defer r.status.lock.RUnlock()
    ...
    for _, sg := range groups {
        if r.isGroupDisabled(sg.group) { // <- RLock() again, recursive
```

Go's `sync.RWMutex` **forbids recursive read-locking**. The deadlock interleaving:

1. A query goroutine acquires the outer `RLock`.
2. A writer — `DisableBlocking`/`EnableBlocking` (REST API) **or the `enableTimer` callback firing when a timed disable expires** — calls `Lock()`. It blocks waiting for the reader, and the mutex now records a pending writer.
3. The query goroutine reaches `isGroupDisabled` and calls `RLock()` again. To prevent writer starvation, a new reader blocks while a writer is pending.
4. Reader waits for writer, writer waits for reader → **permanent deadlock**. The write-intent then blocks every subsequent query too, wedging the blocking resolver until restart.

`groupsToCheckForClient` runs on **every query** (blocking precedes the cache), and the `enableTimer` path makes it self-triggering — a timed disable expiring is enough. Go's runtime deadlock detector won't catch it (other server goroutines stay runnable), so it presents as a silent hang.

This was flagged as finding #9 in a performance/correctness analysis of the resolver hot path.

## Fix

The outer lock exists **only** to guard the `disabledGroups` reads — `collectGroupsForClient` touches just the immutable `clientGroupsBlock` and the self-locking `fqdnIPCache`. So snapshot `disabledGroups` under a brief read lock, release it, then collect and filter groups lock-free:

```go
r.status.lock.RLock()
disabledGroups := r.status.disabledGroups
r.status.lock.RUnlock()
...
if slices.Contains(disabledGroups, sg.group) { ... }
```

The snapshot is safe because all writers **reassign** `disabledGroups` wholesale rather than mutating it in place (a comment on the field now documents that invariant). This also shrinks the per-query critical section from the full map scan down to a single slice-header read. The now-single-caller `isGroupDisabled` is removed.

Behavior is unchanged: the snapshot is a coherent view and the result is still `sort.Strings`-ordered.

## Testing

Adds a concurrency regression test that stresses the reader/writer interleaving (8 readers resolving groups + a writer flipping the blocking state):

- **Before the fix:** deadlocks → spec times out (FAIL).
- **After the fix:** full `blockingResolver` suite passes in ~1.5s; the regression test passes **race-clean** under `-race`.

`go build ./...`, `go vet ./resolver/`, and `gofmt` are all clean.