### PR TITLE
fix(server): answer browser CORS preflights for custom headers and Private Network Access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/creasty/defaults v1.8.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-chi/chi/v5 v5.3.0
-	github.com/go-chi/cors v1.2.2
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -32,6 +31,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/quic-go/quic-go v0.60.0
 	github.com/ramr/go-reaper v0.3.1
+	github.com/rs/cors v1.11.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,6 @@ github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GM
 github.com/glebarez/sqlite v1.11.0/go.mod h1:h8/o8j5wiAsqSPoWELDUdJXhjAhsVliSn7bWZjOhrgQ=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
 github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
-github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
-github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -360,6 +358,8 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/server/http.go
+++ b/server/http.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/0xERR0R/blocky/config"
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/cors"
+	"github.com/rs/cors"
 )
 
 type httpServer struct {
@@ -93,8 +93,12 @@ func newCORSMiddleware() httpMiddleware {
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		AllowedMethods:   []string{"GET", "POST"},
 		AllowedOrigins:   []string{"*"},
-		ExposedHeaders:   []string{"Link"},
-		MaxAge:           int(corsMaxAge.Seconds()),
+		// Allow Chromium's Private Network Access preflights, sent when a
+		// public site addresses a private IP (e.g. a hosted Grafana
+		// dashboard calling the blocky API on a LAN)
+		AllowPrivateNetwork: true,
+		ExposedHeaders:      []string{"Link"},
+		MaxAge:              int(corsMaxAge.Seconds()),
 	}
 
 	return cors.New(options).Handler

--- a/server/http.go
+++ b/server/http.go
@@ -90,9 +90,15 @@ func newCORSMiddleware() httpMiddleware {
 
 	options := cors.Options{
 		AllowCredentials: true,
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
-		AllowedMethods:   []string{"GET", "POST"},
-		AllowedOrigins:   []string{"*"},
+		// Allow all request headers: web UIs send tool-specific headers
+		// (e.g. Grafana action buttons always add 'X-Grafana-Action') and a
+		// disallowed header makes the preflight fail. The API attaches no
+		// security semantics to request headers, and rs/cors answers a
+		// wildcard by echoing the requested headers, which is spec-compliant
+		// also for 'Authorization'.
+		AllowedHeaders: []string{"*"},
+		AllowedMethods: []string{"GET", "POST"},
+		AllowedOrigins: []string{"*"},
 		// Allow Chromium's Private Network Access preflights, sent when a
 		// public site addresses a private IP (e.g. a hosted Grafana
 		// dashboard calling the blocky API on a LAN)

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -40,6 +40,20 @@ var _ = Describe("HTTP middleware", func() {
 			Expect(res.Header.Get("Access-Control-Allow-Methods")).Should(ContainSubstring(http.MethodGet))
 		})
 
+		It("should allow preflights requesting arbitrary headers", func() {
+			// Web UIs send tool-specific headers, e.g. Grafana action buttons
+			// always add 'X-Grafana-Action'. A disallowed header makes the
+			// middleware answer the preflight without any CORS headers, so the
+			// browser blocks the request.
+			res := preflight(map[string]string{
+				"Access-Control-Request-Headers": "content-type,x-grafana-action",
+			})
+
+			Expect(res.Header.Get("Access-Control-Allow-Origin")).Should(Equal("*"))
+			// rs/cors answers a wildcard allowlist by echoing the requested headers
+			Expect(res.Header.Get("Access-Control-Allow-Headers")).Should(ContainSubstring("x-grafana-action"))
+		})
+
 		It("should allow Private Network Access preflights", func() {
 			// Chromium sends this header when a public site addresses a private IP,
 			// e.g. a hosted Grafana dashboard calling the blocky API on a LAN.

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HTTP middleware", func() {
+	var handler http.Handler
+
+	BeforeEach(func() {
+		handler = withCommonMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	})
+
+	Describe("CORS", func() {
+		preflight := func(headers map[string]string) *http.Response {
+			req := httptest.NewRequest(http.MethodOptions, "/api/blocking/disable", nil)
+			req.Header.Set("Origin", "https://grafana.example.com")
+			req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+
+			for k, v := range headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			return rec.Result()
+		}
+
+		It("should answer a cross-origin preflight", func() {
+			res := preflight(nil)
+
+			Expect(res.Header.Get("Access-Control-Allow-Origin")).Should(Equal("*"))
+			Expect(res.Header.Get("Access-Control-Allow-Methods")).Should(ContainSubstring(http.MethodGet))
+		})
+
+		It("should allow Private Network Access preflights", func() {
+			// Chromium sends this header when a public site addresses a private IP,
+			// e.g. a hosted Grafana dashboard calling the blocky API on a LAN.
+			res := preflight(map[string]string{"Access-Control-Request-Private-Network": "true"})
+
+			Expect(res.Header.Get("Access-Control-Allow-Private-Network")).Should(Equal("true"))
+		})
+	})
+})


### PR DESCRIPTION
## Problem

Browser calls to the blocky API from web dashboards (e.g. Grafana action/canvas buttons calling `/api/blocking/...`) fail with CORS errors. Two independent causes:

**1. Disallowed request headers (all browsers, all origins).** Grafana always attaches an `X-Grafana-Action: 1` header to action API calls. That header is not in the CORS `AllowedHeaders` allowlist, and a preflight requesting a disallowed header is answered **without any CORS headers** (HTTP 200, only `Vary`) — the browser then reports *"No 'Access-Control-Allow-Origin' header is present"*. Reproduced against stock v0.31.0:

```
curl -i -X OPTIONS 'http://blocky:4000/api/blocking/disable?duration=5m' \
  -H 'Origin: https://grafana.example.com' \
  -H 'Access-Control-Request-Method: GET' \
  -H 'Access-Control-Request-Headers: content-type,x-grafana-action'
HTTP/1.1 200 OK        <- no Access-Control-Allow-Origin
```

**2. Private Network Access (Chromium, public→private only).** Chromium adds `Access-Control-Request-Private-Network: true` to preflights when a public website addresses a private IP (hosted Grafana → blocky on the LAN). `go-chi/cors` has no support for answering it.

## Change

- Replace `github.com/go-chi/cors` with `github.com/rs/cors` v1.11.1 (go-chi/cors is a fork; `Options`/`Handler` are drop-in compatible) and enable `AllowPrivateNetwork`.
- `AllowedHeaders: ["*"]` — the API attaches no security semantics to request headers; rs/cors answers a wildcard by echoing the requested headers, which is spec-compliant also for `Authorization`.
- Ginkgo specs for the middleware: standard preflight (guards behavior across the dependency swap), preflight with custom headers, PNA preflight. All written first and watched fail.

## Verification

- Unit specs in `server/http_test.go`; full `server` suite green; `go vet`/`gofmt` clean
- End-to-end: built binary answers a Grafana-style preflight with `Access-Control-Allow-Origin: *`, echoed `Access-Control-Allow-Headers`, and `Access-Control-Allow-Private-Network: true`
- rs/cors is pure Go: cross-compiled with `CGO_ENABLED=0` for `linux/mips`, `freebsd/arm`, `openbsd/amd64`, `netbsd/arm64`