### PR TITLE
feat(config): structurally merge config folder files (#1827)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -683,12 +683,10 @@ func loadConfig(logger *logrus.Entry, path string, mandatory bool) (rCfg *Config
 		return nil, fmt.Errorf("can't read config file(s): %w", err)
 	}
 
-	data, sources, prettyPath, err := readConfigSource(path, fs)
+	data, sources, prettyPath, err := readConfigSource(logger, path, fs)
 	if err != nil {
 		return nil, err
 	}
-
-	logConfigSources(logger, sources)
 
 	cfg.CustomDNS.Zone.configPath = prettyPath
 
@@ -710,10 +708,12 @@ func loadConfig(logger *logrus.Entry, path string, mandatory bool) (rCfg *Config
 
 // readConfigSource reads the raw config bytes for path, which is either a
 // single YAML file or a directory of YAML files merged in walk order. For a
-// directory it also returns the per-file sources, so the caller can log the
-// merge order (and attribute unmarshal errors to a file). prettyPath is the
-// user-facing path used in messages.
-func readConfigSource(path string, fs os.FileInfo) (data []byte, sources []configFile, prettyPath string, err error) {
+// directory it logs the merge order (so failures still name the files), then
+// merges and returns the per-file sources for post-merge error attribution.
+// prettyPath is the user-facing path used in error messages.
+func readConfigSource(
+	logger *logrus.Entry, path string, fs os.FileInfo,
+) (data []byte, sources []configFile, prettyPath string, err error) {
 	if fs.IsDir() {
 		prettyPath = filepath.Join(path, "*")
 
@@ -721,6 +721,8 @@ func readConfigSource(path string, fs os.FileInfo) (data []byte, sources []confi
 		if err != nil {
 			return nil, nil, "", fmt.Errorf("can't read config files: %w", err)
 		}
+
+		logConfigSources(logger, sources)
 
 		data, err = mergeConfigFiles(sources)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -862,7 +862,8 @@ func unmarshalConfig(logger *logrus.Entry, data []byte, cfg *Config, sources []c
 //
 // Algorithm:
 //   - mergedFindings = schema.ValidateYAML(data)  — ground truth post-merge.
-//   - perSource[i]   = set of finding strings from schema.ValidateYAML(sources[i].data).
+//   - perSource[i]   = set of finding strings from validating sources[i],
+//     merged with itself first so multi-document files are checked in full.
 //   - For each merged finding: emit one line per matching source file, or a
 //     plain line when no source file reproduces the finding.
 //
@@ -881,9 +882,17 @@ func reconcileSchemaErrors(data []byte, sources []configFile) []string {
 	for i, src := range sources {
 		set := make(map[string]struct{})
 
-		if srcErrs, sErr2 := schema.ValidateYAML(src.data); sErr2 == nil {
-			for _, e := range srcErrs {
-				set[e.String()] = struct{}{}
+		// Validate the source the same multi-document-aware way it was merged.
+		// schema.ValidateYAML uses yaml.v2's single-document Unmarshal, so a
+		// multi-document file (---) would otherwise only have its first
+		// document checked, dropping attribution for findings introduced by a
+		// later document. Merging the file with itself collapses its documents
+		// exactly as the real merge did, so attribution sees every document.
+		if srcData, mErr := mergeConfigFiles([]configFile{src}); mErr == nil {
+			if srcErrs, sErr2 := schema.ValidateYAML(srcData); sErr2 == nil {
+				for _, e := range srcErrs {
+					set[e.String()] = struct{}{}
+				}
 			}
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -683,34 +683,12 @@ func loadConfig(logger *logrus.Entry, path string, mandatory bool) (rCfg *Config
 		return nil, fmt.Errorf("can't read config file(s): %w", err)
 	}
 
-	var (
-		data       []byte
-		sources    []configFile
-		prettyPath string
-	)
-
-	if fs.IsDir() {
-		prettyPath = filepath.Join(path, "*")
-
-		sources, err = readFromDir(path)
-		if err != nil {
-			return nil, fmt.Errorf("can't read config files: %w", err)
-		}
-
-		logConfigSources(logger, sources)
-
-		data, err = mergeConfigFiles(sources)
-		if err != nil {
-			return nil, fmt.Errorf("can't merge config files: %w", err)
-		}
-	} else {
-		prettyPath = path
-
-		data, err = os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("can't read config file: %w", err)
-		}
+	data, sources, prettyPath, err := readConfigSource(path, fs)
+	if err != nil {
+		return nil, err
 	}
+
+	logConfigSources(logger, sources)
 
 	cfg.CustomDNS.Zone.configPath = prettyPath
 
@@ -728,6 +706,38 @@ func loadConfig(logger *logrus.Entry, path string, mandatory bool) (rCfg *Config
 	cfg.Conditional.NormalizeRewrites()
 
 	return &cfg, nil
+}
+
+// readConfigSource reads the raw config bytes for path, which is either a
+// single YAML file or a directory of YAML files merged in walk order. For a
+// directory it also returns the per-file sources, so the caller can log the
+// merge order (and attribute unmarshal errors to a file). prettyPath is the
+// user-facing path used in messages.
+func readConfigSource(path string, fs os.FileInfo) (data []byte, sources []configFile, prettyPath string, err error) {
+	if fs.IsDir() {
+		prettyPath = filepath.Join(path, "*")
+
+		sources, err = readFromDir(path)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("can't read config files: %w", err)
+		}
+
+		data, err = mergeConfigFiles(sources)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("can't merge config files: %w", err)
+		}
+
+		return data, sources, prettyPath, nil
+	}
+
+	prettyPath = path
+
+	data, err = os.ReadFile(path)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("can't read config file: %w", err)
+	}
+
+	return data, sources, prettyPath, nil
 }
 
 // isYAMLFile checks if a file path has a YAML extension (.yml or .yaml)

--- a/config/config.go
+++ b/config/config.go
@@ -829,6 +829,9 @@ func unmarshalConfig(logger *logrus.Entry, data []byte, cfg *Config, sources []c
 		// keeping the underlying yaml error for detail. This never rejects a
 		// config blocky would accept: we only reach here because
 		// UnmarshalStrict already failed.
+		// In folder mode the yaml error's line numbers refer to the merged
+		// document, not any source file; the reconciled findings below carry
+		// the file attribution.
 		if lines := reconcileSchemaErrors(data, sources); len(lines) > 0 {
 			return fmt.Errorf("wrong file structure: %w\n%s", err, strings.Join(lines, "\n"))
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -685,15 +685,23 @@ func loadConfig(logger *logrus.Entry, path string, mandatory bool) (rCfg *Config
 
 	var (
 		data       []byte
+		sources    []configFile
 		prettyPath string
 	)
 
 	if fs.IsDir() {
 		prettyPath = filepath.Join(path, "*")
 
-		data, err = readFromDir(path, data)
+		sources, err = readFromDir(path)
 		if err != nil {
 			return nil, fmt.Errorf("can't read config files: %w", err)
+		}
+
+		logConfigSources(logger, sources)
+
+		data, err = mergeConfigFiles(sources)
+		if err != nil {
+			return nil, fmt.Errorf("can't merge config files: %w", err)
 		}
 	} else {
 		prettyPath = path
@@ -727,7 +735,11 @@ func isYAMLFile(filePath string) bool {
 	return strings.HasSuffix(filePath, ".yml") || strings.HasSuffix(filePath, ".yaml")
 }
 
-func readFromDir(path string, data []byte) ([]byte, error) {
+// readFromDir collects all YAML config files under path in lexical walk
+// order, which defines the merge precedence (later files win).
+func readFromDir(path string) ([]configFile, error) {
+	var files []configFile
+
 	err := filepath.WalkDir(path, func(filePath string, d os.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("error accessing %s: %w", filePath, err)
@@ -757,8 +769,7 @@ func readFromDir(path string, data []byte) ([]byte, error) {
 			return fmt.Errorf("failed to read config file %s: %w", filePath, err)
 		}
 
-		data = append(data, []byte("\n")...)
-		data = append(data, fileData...)
+		files = append(files, configFile{path: filePath, data: fileData})
 
 		return nil
 	})
@@ -766,7 +777,22 @@ func readFromDir(path string, data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to walk directory %s: %w", path, err)
 	}
 
-	return data, nil
+	return files, nil
+}
+
+// logConfigSources logs the merge order so users can tell which file wins a
+// conflict.
+func logConfigSources(logger *logrus.Entry, files []configFile) {
+	if len(files) == 0 {
+		return
+	}
+
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.path)
+	}
+
+	logger.Infof("loading config files in merge order (later files win conflicts): %s", strings.Join(paths, ", "))
 }
 
 // isRegularFile follows symlinks, so the result is `true` for a symlink to a regular file.

--- a/config/config.go
+++ b/config/config.go
@@ -694,7 +694,7 @@ func loadConfig(logger *logrus.Entry, path string, mandatory bool) (rCfg *Config
 
 	err = unmarshalConfig(logger, data, &cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config from %s: %w", prettyPath, err)
+		return nil, fmt.Errorf("failed to unmarshal config from %s: %w", prettyPath, attributeToSources(err, sources))
 	}
 
 	if err := cfg.Ports.validate(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -690,9 +690,9 @@ func loadConfig(logger *logrus.Entry, path string, mandatory bool) (rCfg *Config
 
 	cfg.CustomDNS.Zone.configPath = prettyPath
 
-	err = unmarshalConfig(logger, data, &cfg)
+	err = unmarshalConfig(logger, data, &cfg, sources)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config from %s: %w", prettyPath, attributeToSources(err, sources))
+		return nil, fmt.Errorf("failed to unmarshal config from %s: %w", prettyPath, err)
 	}
 
 	if err := cfg.Ports.validate(); err != nil {
@@ -819,15 +819,18 @@ func isRegularFile(path string) (bool, error) {
 	return isRegular, nil
 }
 
-func unmarshalConfig(logger *logrus.Entry, data []byte, cfg *Config) error {
+// unmarshalConfig decodes data into cfg. sources, when non-empty, are the
+// individual files that were merged to produce data; they are used to attribute
+// schema findings to specific source files on the error path.
+func unmarshalConfig(logger *logrus.Entry, data []byte, cfg *Config, sources []configFile) error {
 	err := yaml.UnmarshalStrict(data, cfg)
 	if err != nil {
 		// Enrich the already-failing path with field-path schema errors,
 		// keeping the underlying yaml error for detail. This never rejects a
 		// config blocky would accept: we only reach here because
 		// UnmarshalStrict already failed.
-		if schemaErrs, sErr := schema.ValidateYAML(data); sErr == nil && len(schemaErrs) > 0 {
-			return fmt.Errorf("wrong file structure: %w\n%s", err, formatSchemaErrors(schemaErrs))
+		if lines := reconcileSchemaErrors(data, sources); len(lines) > 0 {
+			return fmt.Errorf("wrong file structure: %w\n%s", err, strings.Join(lines, "\n"))
 		}
 
 		return fmt.Errorf("wrong file structure: %w", err)
@@ -851,14 +854,59 @@ func unmarshalConfig(logger *logrus.Entry, data []byte, cfg *Config) error {
 	return nil
 }
 
-// formatSchemaErrors renders schema findings as an indented bullet list.
-func formatSchemaErrors(errs []schema.Error) string {
-	lines := make([]string, 0, len(errs))
-	for _, e := range errs {
-		lines = append(lines, "  - "+e.String())
+// reconcileSchemaErrors validates the merged document and returns an indented
+// bullet list of findings attributed to their source files where possible.
+//
+// Algorithm:
+//   - mergedFindings = schema.ValidateYAML(data)  — ground truth post-merge.
+//   - perSource[i]   = set of finding strings from schema.ValidateYAML(sources[i].data).
+//   - For each merged finding: emit one line per matching source file, or a
+//     plain line when no source file reproduces the finding.
+//
+// Each merged finding appears exactly once. False per-file findings (not
+// present in the merged set) are never shown. With sources nil/empty every
+// finding is plain — byte-identical to the former single-file output.
+func reconcileSchemaErrors(data []byte, sources []configFile) []string {
+	mergedErrs, sErr := schema.ValidateYAML(data)
+	if sErr != nil || len(mergedErrs) == 0 {
+		return nil
 	}
 
-	return strings.Join(lines, "\n")
+	// Build a per-source set of finding strings for attribution.
+	perSource := make([]map[string]struct{}, len(sources))
+
+	for i, src := range sources {
+		set := make(map[string]struct{})
+
+		if srcErrs, sErr2 := schema.ValidateYAML(src.data); sErr2 == nil {
+			for _, e := range srcErrs {
+				set[e.String()] = struct{}{}
+			}
+		}
+
+		perSource[i] = set
+	}
+
+	// Emit each merged finding once, attributed to matching source files or plain.
+	lines := make([]string, 0, len(mergedErrs))
+
+	for _, f := range mergedErrs {
+		key := f.String()
+		attributed := false
+
+		for i, src := range sources {
+			if _, ok := perSource[i][key]; ok {
+				lines = append(lines, "  - "+src.path+": "+key)
+				attributed = true
+			}
+		}
+
+		if !attributed {
+			lines = append(lines, "  - "+key)
+		}
+	}
+
+	return lines
 }
 
 func (cfg *Config) migrate(logger *logrus.Entry) bool {

--- a/config/config_schema_test.go
+++ b/config/config_schema_test.go
@@ -12,7 +12,7 @@ var _ = Describe("schema-enriched config loading", func() {
 
 	When("config has an unknown key", func() {
 		It("returns a schema-enriched error naming the offending field", func() {
-			err := unmarshalConfig(logger, []byte("notARealKey: true\n"), &Config{})
+			err := unmarshalConfig(logger, []byte("notARealKey: true\n"), &Config{}, nil)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("notARealKey"))
 			// schema phrasing, not yaml's "not found in type ..."
@@ -24,7 +24,7 @@ var _ = Describe("schema-enriched config loading", func() {
 		It("loads without error and without schema warnings", func() {
 			data := []byte("upstreams:\n  groups:\n    default:\n      - 1.1.1.1\n")
 
-			err := unmarshalConfig(logger, data, &Config{})
+			err := unmarshalConfig(logger, data, &Config{}, nil)
 			Expect(err).Should(Succeed())
 			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")))
 		})
@@ -42,7 +42,7 @@ ports:
     - tls
 `)
 
-			err := unmarshalConfig(logger, data, &Config{})
+			err := unmarshalConfig(logger, data, &Config{}, nil)
 			Expect(err).Should(Succeed())
 			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")))
 		})
@@ -59,7 +59,7 @@ ports:
     - bogus
 `)
 
-			err := unmarshalConfig(logger, data, &Config{})
+			err := unmarshalConfig(logger, data, &Config{}, nil)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("proxyProtocol"))
 			Expect(err.Error()).Should(ContainSubstring("'dns', 'http', 'https', 'tls'"))
@@ -70,7 +70,7 @@ ports:
 		It("is accepted by both the parser and the schema", func() {
 			data := []byte("bootstrapDns:\n  - resolvFile: /etc/resolv.conf\n")
 
-			err := unmarshalConfig(logger, data, &Config{})
+			err := unmarshalConfig(logger, data, &Config{}, nil)
 			Expect(err).Should(Succeed())
 			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")))
 		})
@@ -87,7 +87,7 @@ ports:
 			data, err := os.ReadFile("testdata/superset_config.yml")
 			Expect(err).Should(Succeed())
 
-			err = unmarshalConfig(logger, data, &Config{})
+			err = unmarshalConfig(logger, data, &Config{}, nil)
 			Expect(err).Should(Succeed())
 			Expect(hook.Messages).ShouldNot(ContainElement(ContainSubstring("does not match schema")),
 				"every form in testdata/superset_config.yml must validate against the schema too")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -401,6 +402,43 @@ var _ = Describe("Config", func() {
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("10_typo.yaml"))
 			})
+
+			It("does not duplicate findings and never blames a valid-after-merge file", func() {
+				// 00_good.yaml sets blocking.denylists.ads to null; after merging
+				// 10_bad.yaml fills it with a real list. The merged doc is invalid
+				// only because of blocking.badkey from 10_bad.yaml.
+				// Before the reconciliation fix, 00_good.yaml was falsely blamed
+				// for a null-ads finding and the badkey line appeared twice.
+				tmpDir.CreateStringFile("00_good.yaml",
+					"blocking:",
+					"  denylists:",
+					"    ads:",
+				)
+				tmpDir.CreateStringFile("10_bad.yaml",
+					"blocking:",
+					"  denylists:",
+					"    ads:",
+					"      - http://x",
+					"  badkey: 1",
+				)
+
+				_, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(HaveOccurred())
+
+				errStr := err.Error()
+
+				// "badkey" must appear at most twice: once in the yaml unmarshal
+				// error and once in the attributed schema line. It must NOT appear
+				// three times (which would mean both an unattributed and an
+				// attributed schema line).
+				Expect(strings.Count(errStr, "badkey")).Should(BeNumerically("<=", 2))
+
+				// The good file that is only valid after merging must not be blamed.
+				Expect(errStr).ShouldNot(ContainSubstring("00_good.yaml"))
+
+				// The bad file that introduced the unknown key must be blamed.
+				Expect(errStr).Should(ContainSubstring("10_bad.yaml"))
+			})
 		})
 		When("a single config file contains duplicate keys", func() {
 			It("keeps the single-file error shape, proving the merge path is not used", func() {
@@ -439,7 +477,7 @@ var _ = Describe("Config", func() {
 blocking:
   loading:
     refreshPeriod: wrongduration`
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("invalid duration \"wrongduration\""))
 			})
@@ -450,7 +488,7 @@ blocking:
 				data := `customDNS:
   mapping:
     someDomain: 192.168.178.WRONG`
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("invalid IP address '192.168.178.WRONG'"))
 			})
@@ -461,7 +499,7 @@ blocking:
 				data := `customDNS:
   mapping:
     someDomain: 2001:MALFORMED:IP:ADDRESS:0000:8a2e:0370:7334`
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("invalid IP address '2001:MALFORMED:IP:ADDRESS:0000:8a2e:0370:7334'"))
 			})
@@ -472,7 +510,7 @@ blocking:
 				data := `conditional:
   mapping:
     multiple.resolvers: 192.168.178.1,wrongprotocol:4.4.4.4:53`
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("wrong host name 'wrongprotocol:4.4.4.4:53'"))
 			})
@@ -485,7 +523,7 @@ blocking:
     - 8.8.8.8
     - wrongprotocol:8.8.4.4
     - 1.1.1.1`
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("can't convert upstream 'wrongprotocol:8.8.4.4'"))
 			})
@@ -497,7 +535,7 @@ blocking:
   queryTypes:
     - invalidqtype
 `
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("unknown DNS query type: 'invalidqtype'"))
 			})
@@ -508,7 +546,7 @@ blocking:
 				cfg := Config{}
 				data := "bootstrapDns: 0.0.0.0"
 
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(Succeed())
 				Expect(cfg.BootstrapDNS[0].Upstream.Host).Should(Equal("0.0.0.0"))
 			})
@@ -520,7 +558,7 @@ bootstrapDns:
   ips:
     - 0.0.0.0
 `
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(Succeed())
 				Expect(cfg.BootstrapDNS[0].Upstream.Host).Should(Equal("dns.example.com"))
 				Expect(cfg.BootstrapDNS[0].IPs).Should(HaveLen(1))
@@ -534,7 +572,7 @@ bootstrapDns:
       - 0.0.0.0
   - upstream: 1.2.3.4
 `
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(Succeed())
 				Expect(cfg.BootstrapDNS).Should(HaveLen(2))
 				Expect(cfg.BootstrapDNS[0].Upstream.Host).Should(Equal("dns.example.com"))
@@ -549,7 +587,7 @@ bootstrapDns:
 			It("should return error", func() {
 				cfg := Config{}
 				data := `///`
-				err := unmarshalConfig(logger, []byte(data), &cfg)
+				err := unmarshalConfig(logger, []byte(data), &cfg, nil)
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("cannot unmarshal !!str `///`"))
 			})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -403,6 +403,27 @@ var _ = Describe("Config", func() {
 				Expect(err.Error()).Should(ContainSubstring("10_typo.yaml"))
 			})
 
+			It("attributes an unknown key introduced by a non-first document of a multi-doc file", func() {
+				// The bad key lives in the SECOND document of the file. Schema
+				// attribution must read every document of the source, not just
+				// the first one, so the file is still named (issue: yaml.v2's
+				// single-document Unmarshal in schema.ValidateYAML).
+				tmpDir.CreateStringFile("00_good.yaml", "log:", "  level: debug")
+				tmpDir.CreateStringFile("10_multidoc.yaml",
+					"upstreams:",
+					"  groups:",
+					"    default:",
+					"      - 8.8.8.8",
+					"---",
+					"blocing:",
+					"  blockType: zeroIp",
+				)
+
+				_, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("10_multidoc.yaml"))
+			})
+
 			It("does not duplicate findings and never blames a valid-after-merge file", func() {
 				// 00_good.yaml sets blocking.denylists.ads to null; after merging
 				// 10_bad.yaml fills it with a real list. The merged doc is invalid

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -392,6 +392,15 @@ var _ = Describe("Config", func() {
 				Expect(err).Should(Succeed())
 				Expect(c.MinTLSServeVer).Should(Equal(TLSVersion12))
 			})
+
+			It("attributes an unknown key to its source file", func() {
+				tmpDir.CreateStringFile("00_good.yaml", "log:", "  level: debug")
+				tmpDir.CreateStringFile("10_typo.yaml", "blocing:", "  blockType: zeroIp")
+
+				_, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("10_typo.yaml"))
+			})
 		})
 		When("a single config file contains duplicate keys", func() {
 			It("keeps the single-file error shape, proving the merge path is not used", func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -378,6 +378,20 @@ var _ = Describe("Config", func() {
 				Expect(err).Should(Succeed())
 				Expect(c.Log.Level).Should(Equal(logrus.DebugLevel))
 			})
+
+			It("preserves scalar literals so minTlsServeVersion: 1.0 still loads (issue #1827)", func() {
+				// Folder merging used to re-marshal scalars through a generic
+				// map, collapsing `1.0` to `1` and breaking startup. Node-tree
+				// merging keeps the literal, so this loads just like a single
+				// file (which accepts 1.0 and bumps it to the secure default).
+				tmpDir.CreateStringFile("00_tls.yaml",
+					"minTlsServeVersion: 1.0",
+				)
+
+				c, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(Succeed())
+				Expect(c.MinTLSServeVer).Should(Equal(TLSVersion12))
+			})
 		})
 		When("a single config file contains duplicate keys", func() {
 			It("keeps the single-file error shape, proving the merge path is not used", func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -285,6 +285,115 @@ var _ = Describe("Config", func() {
 				Expect(err).Should(Succeed())
 			})
 		})
+		When("multiple config files share keys", func() {
+			It("merges maps across files (issue #1827)", func() {
+				tmpDir.CreateStringFile("00_default.yaml",
+					"upstreams:",
+					"  groups:",
+					"    default:",
+					"      - 8.8.8.8",
+				)
+				tmpDir.CreateStringFile("10_local.yaml",
+					"upstreams:",
+					"  groups:",
+					"    192.168.0.0/16:",
+					"      - 1.1.1.1",
+				)
+
+				c, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(Succeed())
+				Expect(c.Upstreams.Groups).Should(HaveLen(2))
+				Expect(c.Upstreams.Groups).Should(HaveKey("default"))
+				Expect(c.Upstreams.Groups).Should(HaveKey("192.168.0.0/16"))
+			})
+
+			It("lets the last file win scalar and list conflicts", func() {
+				tmpDir.CreateStringFile("00_default.yaml",
+					"upstreams:",
+					"  groups:",
+					"    default:",
+					"      - 8.8.8.8",
+					"      - 8.8.4.4",
+					"log:",
+					"  level: info",
+				)
+				tmpDir.CreateStringFile("10_local.yaml",
+					"upstreams:",
+					"  groups:",
+					"    default:",
+					"      - 1.1.1.1",
+					"log:",
+					"  level: debug",
+				)
+
+				c, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(Succeed())
+				Expect(c.Upstreams.Groups["default"]).Should(HaveLen(1))
+				Expect(c.Log.Level).Should(Equal(logrus.DebugLevel))
+			})
+
+			It("still rejects duplicate keys within one file, naming the file", func() {
+				tmpDir.CreateStringFile("bad.yaml",
+					"log:",
+					"  level: debug",
+					"log:",
+					"  level: info",
+				)
+
+				_, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("bad.yaml"))
+				Expect(err.Error()).Should(ContainSubstring("already set in map"))
+			})
+
+			It("rejects a file whose top level is not a mapping, naming the file", func() {
+				tmpDir.CreateStringFile("list.yaml", "- not", "- a", "- mapping")
+
+				_, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("list.yaml"))
+				Expect(err.Error()).Should(ContainSubstring("must be a mapping"))
+			})
+
+			It("skips empty and comment-only files", func() {
+				tmpDir.CreateStringFile("00_real.yaml", "log:", "  level: debug")
+				tmpDir.CreateEmptyFile("10_empty.yaml")
+				tmpDir.CreateStringFile("20_comments.yaml", "# overlay placeholder")
+
+				c, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(Succeed())
+				Expect(c.Log.Level).Should(Equal(logrus.DebugLevel))
+			})
+
+			It("merges multi-document files in document order", func() {
+				tmpDir.CreateStringFile("multi.yaml",
+					"log:",
+					"  level: info",
+					"---",
+					"log:",
+					"  level: debug",
+				)
+
+				c, err := LoadConfig(tmpDir.Path, true)
+				Expect(err).Should(Succeed())
+				Expect(c.Log.Level).Should(Equal(logrus.DebugLevel))
+			})
+		})
+		When("a single config file contains duplicate keys", func() {
+			It("keeps the single-file error shape, proving the merge path is not used", func() {
+				cfgFile := tmpDir.CreateStringFile("config.yml",
+					"log:",
+					"  level: debug",
+					"log:",
+					"  level: info",
+				)
+
+				_, err := LoadConfig(cfgFile.Path, true)
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("wrong file structure"))
+				Expect(err.Error()).ShouldNot(ContainSubstring("can't parse config file"))
+			})
+		})
 		When("Config folder does not exist", func() {
 			It("should fail", func() {
 				_, err := LoadConfig(tmpDir.JoinPath("does-not-exist-config/"), true)

--- a/config/merge.go
+++ b/config/merge.go
@@ -1,0 +1,26 @@
+package config
+
+// mergeMaps deep-merges src into dst and returns the result: keys whose
+// values are mappings on both sides merge recursively; any other collision
+// (scalar, list, explicit null, or type mismatch) resolves to the src value
+// (last wins). dst is modified in place; pass nil to start fresh.
+func mergeMaps(dst, src map[interface{}]interface{}) map[interface{}]interface{} {
+	if dst == nil {
+		dst = make(map[interface{}]interface{}, len(src))
+	}
+
+	for key, srcVal := range src {
+		dstMap, dstIsMap := dst[key].(map[interface{}]interface{})
+		srcMap, srcIsMap := srcVal.(map[interface{}]interface{})
+
+		if dstIsMap && srcIsMap {
+			dst[key] = mergeMaps(dstMap, srcMap)
+
+			continue
+		}
+
+		dst[key] = srcVal
+	}
+
+	return dst
+}

--- a/config/merge.go
+++ b/config/merge.go
@@ -13,6 +13,7 @@ import (
 // values are mappings on both sides merge recursively; any other collision
 // (scalar, list, explicit null, or type mismatch) resolves to the src value
 // (last wins). dst is modified in place; pass nil to start fresh.
+// Nested src maps are shared by reference into dst; safe here because callers never reuse a decoded document.
 func mergeMaps(dst, src map[interface{}]interface{}) map[interface{}]interface{} {
 	if dst == nil {
 		dst = make(map[interface{}]interface{}, len(src))

--- a/config/merge.go
+++ b/config/merge.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/0xERR0R/blocky/config/schema"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -270,4 +272,26 @@ func nodeKindName(node *yaml.Node) string {
 	default:
 		return "unknown"
 	}
+}
+
+// attributeToSources maps a post-merge unmarshal failure back to the source
+// files using per-file schema validation, so the error names the offending
+// file instead of the merged document the user never sees. It only ever adds
+// information; the original error is always kept.
+func attributeToSources(err error, sources []configFile) error {
+	var lines []string
+
+	for _, src := range sources {
+		if schemaErrs, sErr := schema.ValidateYAML(src.data); sErr == nil && len(schemaErrs) > 0 {
+			for _, e := range schemaErrs {
+				lines = append(lines, fmt.Sprintf("  - %s: %s", src.path, e.String()))
+			}
+		}
+	}
+
+	if len(lines) == 0 {
+		return err
+	}
+
+	return fmt.Errorf("%w\nfindings per source file:\n%s", err, strings.Join(lines, "\n"))
 }

--- a/config/merge.go
+++ b/config/merge.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
-	"github.com/0xERR0R/blocky/config/schema"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -289,26 +287,4 @@ func nodeKindName(node *yaml.Node) string {
 	default:
 		return "unknown"
 	}
-}
-
-// attributeToSources maps a post-merge unmarshal failure back to the source
-// files using per-file schema validation, so the error names the offending
-// file instead of the merged document the user never sees. It only ever adds
-// information; the original error is always kept.
-func attributeToSources(err error, sources []configFile) error {
-	var lines []string
-
-	for _, src := range sources {
-		if schemaErrs, sErr := schema.ValidateYAML(src.data); sErr == nil && len(schemaErrs) > 0 {
-			for _, e := range schemaErrs {
-				lines = append(lines, fmt.Sprintf("  - %s: %s", src.path, e.String()))
-			}
-		}
-	}
-
-	if len(lines) == 0 {
-		return err
-	}
-
-	return fmt.Errorf("%w\nfindings per source file:\n%s", err, strings.Join(lines, "\n"))
 }

--- a/config/merge.go
+++ b/config/merge.go
@@ -6,71 +6,8 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
-
-// mergeMaps deep-merges src into dst and returns the result: keys whose
-// values are mappings on both sides merge recursively; any other collision
-// (scalar, list, explicit null, or type mismatch) resolves to the src value
-// (last wins). dst is modified in place; pass nil to start fresh.
-// Nested src maps are shared by reference into dst; safe here because callers never reuse a decoded document.
-func mergeMaps(dst, src map[interface{}]interface{}) map[interface{}]interface{} {
-	if dst == nil {
-		dst = make(map[interface{}]interface{}, len(src))
-	}
-
-	for key, srcVal := range src {
-		dstMap, dstIsMap := dst[key].(map[interface{}]interface{})
-		srcMap, srcIsMap := srcVal.(map[interface{}]interface{})
-
-		if dstIsMap && srcIsMap {
-			dst[key] = mergeMaps(dstMap, srcMap)
-
-			continue
-		}
-
-		dst[key] = srcVal
-	}
-
-	return dst
-}
-
-// decodeYAMLDocuments strict-decodes every YAML document in data into a
-// generic map. Strict mode keeps duplicate keys within a single document an
-// error. Empty documents (e.g. comment-only files) are skipped.
-func decodeYAMLDocuments(data []byte) ([]map[interface{}]interface{}, error) {
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.SetStrict(true)
-
-	var docs []map[interface{}]interface{}
-
-	for {
-		var raw interface{}
-
-		err := decoder.Decode(&raw)
-		if errors.Is(err, io.EOF) {
-			break
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		if raw == nil {
-			// empty document
-			continue
-		}
-
-		doc, ok := raw.(map[interface{}]interface{})
-		if !ok {
-			return nil, fmt.Errorf("top level of a config document must be a mapping, got %T", raw)
-		}
-
-		docs = append(docs, doc)
-	}
-
-	return docs, nil
-}
 
 // configFile is one YAML file collected from a config folder.
 type configFile struct {
@@ -81,8 +18,14 @@ type configFile struct {
 // mergeConfigFiles structurally merges config files in the given order and
 // returns the merged document marshaled back to YAML. Returns nil when no
 // file contains any document.
+//
+// Files are parsed into yaml.v3 node trees, which preserve each scalar's
+// literal text and quoting style. The merged tree is re-encoded and handed to
+// the strict yaml.v2 config unmarshal unchanged, so a folder config decodes a
+// scalar exactly as a single-file config would (e.g. `1.0` stays `1.0`, not
+// `1`; `yes` stays plain `yes`; `0700` stays `0700`).
 func mergeConfigFiles(files []configFile) ([]byte, error) {
-	var merged map[interface{}]interface{}
+	var merged *yaml.Node
 
 	for _, file := range files {
 		docs, err := decodeYAMLDocuments(file.data)
@@ -91,7 +34,13 @@ func mergeConfigFiles(files []configFile) ([]byte, error) {
 		}
 
 		for _, doc := range docs {
-			merged = mergeMaps(merged, doc)
+			if merged == nil {
+				merged = doc
+
+				continue
+			}
+
+			merged = mergeMappingNodes(merged, doc)
 		}
 	}
 
@@ -105,4 +54,220 @@ func mergeConfigFiles(files []configFile) ([]byte, error) {
 	}
 
 	return out, nil
+}
+
+// decodeYAMLDocuments decodes every YAML document in data into a yaml.v3 node
+// tree and returns each document's top-level mapping node. Per document it
+// expands within-file anchors/aliases (stripping anchor names so none survive
+// into the merged document), rejects duplicate keys at every level, and
+// rejects a non-mapping top level. Empty and null documents (comment-only
+// files, bare `---`) are skipped.
+func decodeYAMLDocuments(data []byte) ([]*yaml.Node, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+
+	var docs []*yaml.Node
+
+	for {
+		var doc yaml.Node
+
+		err := decoder.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			// e.g. yaml.v3 reports `unknown anchor 'x' referenced` here.
+			return nil, err
+		}
+
+		// A document node wraps its single root in Content. An empty document
+		// (comment-only file) has no content at all.
+		if len(doc.Content) == 0 {
+			continue
+		}
+
+		root, err := expandAliases(doc.Content[0])
+		if err != nil {
+			return nil, err
+		}
+
+		// Skip null documents (bare `---` or an explicit `null`).
+		if root.Tag == nullTag {
+			continue
+		}
+
+		if root.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("top level of a config document must be a mapping, got %s", nodeKindName(root))
+		}
+
+		if err := checkDuplicateKeys(root); err != nil {
+			return nil, err
+		}
+
+		docs = append(docs, root)
+	}
+
+	return docs, nil
+}
+
+const nullTag = "!!null"
+
+// expandAliases returns a deep, alias-free, anchor-free copy of node: every
+// alias is replaced by a copy of its anchor target and every Anchor field is
+// cleared. This bakes within-file anchor semantics into the tree before
+// merging, so no anchor name can survive to collide across files.
+//
+// It is cycle-safe: re-entering a node already on the resolution stack (a
+// self- or mutually-referential anchor such as `a: &x [*x]`) is reported as an
+// error instead of recursing forever.
+func expandAliases(node *yaml.Node) (*yaml.Node, error) {
+	return resolveNode(node, map[*yaml.Node]bool{})
+}
+
+func resolveNode(node *yaml.Node, onStack map[*yaml.Node]bool) (*yaml.Node, error) {
+	if node.Kind == yaml.AliasNode {
+		if node.Alias == nil {
+			return nil, fmt.Errorf("alias %q has no anchor target", node.Value)
+		}
+
+		return resolveNode(node.Alias, onStack)
+	}
+
+	if onStack[node] {
+		name := node.Anchor
+		if name == "" {
+			name = node.Value
+		}
+
+		return nil, fmt.Errorf("anchor cycle detected at %q", name)
+	}
+
+	onStack[node] = true
+	defer delete(onStack, node)
+
+	clone := *node
+	clone.Anchor = ""
+	clone.Alias = nil
+
+	if node.Content != nil {
+		clone.Content = make([]*yaml.Node, len(node.Content))
+
+		for i, child := range node.Content {
+			resolved, err := resolveNode(child, onStack)
+			if err != nil {
+				return nil, err
+			}
+
+			clone.Content[i] = resolved
+		}
+	}
+
+	return &clone, nil
+}
+
+// checkDuplicateKeys rejects duplicate scalar keys within any mapping in the
+// tree, mirroring yaml.v2's strict-mode wording. yaml.v2 no longer sees the
+// raw documents (it only parses the re-encoded merge), so this restores that
+// safety net. Non-scalar keys (legal YAML, absent from blocky configs) are not
+// matched.
+func checkDuplicateKeys(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.MappingNode:
+		seen := make(map[string]bool, len(node.Content)/2)
+
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+
+			if key.Kind == yaml.ScalarNode {
+				if seen[key.Value] {
+					return fmt.Errorf("line %d: key %q already set in map", key.Line, key.Value)
+				}
+
+				seen[key.Value] = true
+			}
+
+			if err := checkDuplicateKeys(value); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if err := checkDuplicateKeys(child); err != nil {
+				return err
+			}
+		}
+	case yaml.DocumentNode, yaml.ScalarNode, yaml.AliasNode:
+		// Leaves and document wrappers carry no nested mapping to inspect; the
+		// resolved tree has no aliases left anyway.
+	}
+
+	return nil
+}
+
+// mergeMappingNodes deep-merges src into dst and returns the result: keys
+// matched by scalar key value whose values are mappings on both sides merge
+// recursively; any other collision (scalar, sequence, explicit null, or kind
+// mismatch) resolves to the src value (last wins). Keys present in only one
+// side are kept; new src keys are appended after dst's, preserving first-seen
+// key order. dst is modified in place.
+func mergeMappingNodes(dst, src *yaml.Node) *yaml.Node {
+	for i := 0; i+1 < len(src.Content); i += 2 {
+		srcKey := src.Content[i]
+		srcVal := src.Content[i+1]
+
+		dstValIdx := mappingValueIndex(dst, srcKey)
+		if dstValIdx < 0 {
+			dst.Content = append(dst.Content, srcKey, srcVal)
+
+			continue
+		}
+
+		dstVal := dst.Content[dstValIdx]
+		if dstVal.Kind == yaml.MappingNode && srcVal.Kind == yaml.MappingNode {
+			dst.Content[dstValIdx] = mergeMappingNodes(dstVal, srcVal)
+
+			continue
+		}
+
+		dst.Content[dstValIdx] = srcVal
+	}
+
+	return dst
+}
+
+// mappingValueIndex returns the index of the value node in mapping whose key
+// matches the given scalar key by value, or -1. Non-scalar keys never match.
+func mappingValueIndex(mapping, key *yaml.Node) int {
+	if key.Kind != yaml.ScalarNode {
+		return -1
+	}
+
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		candidate := mapping.Content[i]
+		if candidate.Kind == yaml.ScalarNode && candidate.Value == key.Value {
+			return i + 1
+		}
+	}
+
+	return -1
+}
+
+// nodeKindName gives a human-readable name for a node's kind, used in the
+// non-mapping top-level error.
+func nodeKindName(node *yaml.Node) string {
+	switch node.Kind {
+	case yaml.DocumentNode:
+		return "document"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.AliasNode:
+		return "alias"
+	default:
+		return "unknown"
+	}
 }

--- a/config/merge.go
+++ b/config/merge.go
@@ -1,5 +1,14 @@
 package config
 
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v2"
+)
+
 // mergeMaps deep-merges src into dst and returns the result: keys whose
 // values are mappings on both sides merge recursively; any other collision
 // (scalar, list, explicit null, or type mismatch) resolves to the src value
@@ -23,4 +32,41 @@ func mergeMaps(dst, src map[interface{}]interface{}) map[interface{}]interface{}
 	}
 
 	return dst
+}
+
+// decodeYAMLDocuments strict-decodes every YAML document in data into a
+// generic map. Strict mode keeps duplicate keys within a single document an
+// error. Empty documents (e.g. comment-only files) are skipped.
+func decodeYAMLDocuments(data []byte) ([]map[interface{}]interface{}, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.SetStrict(true)
+
+	var docs []map[interface{}]interface{}
+
+	for {
+		var raw interface{}
+
+		err := decoder.Decode(&raw)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if raw == nil {
+			// empty document
+			continue
+		}
+
+		doc, ok := raw.(map[interface{}]interface{})
+		if !ok {
+			return nil, fmt.Errorf("top level of a config document must be a mapping, got %T", raw)
+		}
+
+		docs = append(docs, doc)
+	}
+
+	return docs, nil
 }

--- a/config/merge.go
+++ b/config/merge.go
@@ -70,3 +70,38 @@ func decodeYAMLDocuments(data []byte) ([]map[interface{}]interface{}, error) {
 
 	return docs, nil
 }
+
+// configFile is one YAML file collected from a config folder.
+type configFile struct {
+	path string
+	data []byte
+}
+
+// mergeConfigFiles structurally merges config files in the given order and
+// returns the merged document marshaled back to YAML. Returns nil when no
+// file contains any document.
+func mergeConfigFiles(files []configFile) ([]byte, error) {
+	var merged map[interface{}]interface{}
+
+	for _, file := range files {
+		docs, err := decodeYAMLDocuments(file.data)
+		if err != nil {
+			return nil, fmt.Errorf("can't parse config file %s: %w", file.path, err)
+		}
+
+		for _, doc := range docs {
+			merged = mergeMaps(merged, doc)
+		}
+	}
+
+	if merged == nil {
+		return nil, nil
+	}
+
+	out, err := yaml.Marshal(merged)
+	if err != nil {
+		return nil, fmt.Errorf("can't marshal merged config: %w", err)
+	}
+
+	return out, nil
+}

--- a/config/merge.go
+++ b/config/merge.go
@@ -114,6 +114,18 @@ func decodeYAMLDocuments(data []byte) ([]*yaml.Node, error) {
 
 const nullTag = "!!null"
 
+// maxExpandedNodes caps total nodes produced when expanding anchors/aliases
+// within a single document. Config dirs are admin-controlled, so a simple
+// count suffices to guard against nested-anchor bombs without complexity.
+const maxExpandedNodes = 1_000_000
+
+// resolveState carries shared expansion context across resolveNode calls:
+// the cycle-detection stack and a cumulative node count for the expansion cap.
+type resolveState struct {
+	onStack map[*yaml.Node]bool
+	count   int
+}
+
 // expandAliases returns a deep, alias-free, anchor-free copy of node: every
 // alias is replaced by a copy of its anchor target and every Anchor field is
 // cleared. This bakes within-file anchor semantics into the tree before
@@ -123,19 +135,24 @@ const nullTag = "!!null"
 // self- or mutually-referential anchor such as `a: &x [*x]`) is reported as an
 // error instead of recursing forever.
 func expandAliases(node *yaml.Node) (*yaml.Node, error) {
-	return resolveNode(node, map[*yaml.Node]bool{})
+	return resolveNode(node, &resolveState{onStack: map[*yaml.Node]bool{}})
 }
 
-func resolveNode(node *yaml.Node, onStack map[*yaml.Node]bool) (*yaml.Node, error) {
+func resolveNode(node *yaml.Node, state *resolveState) (*yaml.Node, error) {
+	state.count++
+	if state.count > maxExpandedNodes {
+		return nil, fmt.Errorf("alias expansion limit (%d nodes) exceeded", maxExpandedNodes)
+	}
+
 	if node.Kind == yaml.AliasNode {
 		if node.Alias == nil {
 			return nil, fmt.Errorf("alias %q has no anchor target", node.Value)
 		}
 
-		return resolveNode(node.Alias, onStack)
+		return resolveNode(node.Alias, state)
 	}
 
-	if onStack[node] {
+	if state.onStack[node] {
 		name := node.Anchor
 		if name == "" {
 			name = node.Value
@@ -144,8 +161,8 @@ func resolveNode(node *yaml.Node, onStack map[*yaml.Node]bool) (*yaml.Node, erro
 		return nil, fmt.Errorf("anchor cycle detected at %q", name)
 	}
 
-	onStack[node] = true
-	defer delete(onStack, node)
+	state.onStack[node] = true
+	defer delete(state.onStack, node)
 
 	clone := *node
 	clone.Anchor = ""
@@ -155,7 +172,7 @@ func resolveNode(node *yaml.Node, onStack map[*yaml.Node]bool) (*yaml.Node, erro
 		clone.Content = make([]*yaml.Node, len(node.Content))
 
 		for i, child := range node.Content {
-			resolved, err := resolveNode(child, onStack)
+			resolved, err := resolveNode(child, state)
 			if err != nil {
 				return nil, err
 			}

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -112,4 +112,63 @@ var _ = Describe("Config file merging", func() {
 			Expect(err.Error()).Should(ContainSubstring("unknown anchor"))
 		})
 	})
+
+	Describe("mergeConfigFiles", func() {
+		roundtrip := func(data []byte) map[interface{}]interface{} {
+			var m map[interface{}]interface{}
+
+			Expect(yaml.Unmarshal(data, &m)).Should(Succeed())
+
+			return m
+		}
+
+		It("merges the issue #1827 example: disjoint upstream groups", func() {
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "00_default.yaml", data: []byte("upstreams:\n  groups:\n    default: [8.8.8.8]\n  strategy: parallel_best\n")},
+				{path: "10_local.yaml", data: []byte("upstreams:\n  groups:\n    192.168.0.0/16: [1.1.1.1]\n")},
+			})
+
+			Expect(err).Should(Succeed())
+			Expect(roundtrip(merged)).Should(Equal(yamlMap(
+				"upstreams: {groups: {default: [8.8.8.8], 192.168.0.0/16: [1.1.1.1]}, strategy: parallel_best}")))
+		})
+
+		It("applies files in the given order: later file wins", func() {
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "a.yaml", data: []byte("log: {level: info}")},
+				{path: "b.yaml", data: []byte("log: {level: debug}")},
+			})
+
+			Expect(err).Should(Succeed())
+			Expect(roundtrip(merged)).Should(Equal(yamlMap("log: {level: debug}")))
+		})
+
+		It("merges documents within one file in order, like separate files", func() {
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "multi.yaml", data: []byte("log: {level: info}\n---\nlog: {level: debug}\n")},
+			})
+
+			Expect(err).Should(Succeed())
+			Expect(roundtrip(merged)).Should(Equal(yamlMap("log: {level: debug}")))
+		})
+
+		It("returns nil when no file contains a document", func() {
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "empty.yaml", data: []byte("")},
+			})
+
+			Expect(err).Should(Succeed())
+			Expect(merged).Should(BeNil())
+		})
+
+		It("names the offending file on parse errors", func() {
+			_, err := mergeConfigFiles([]configFile{
+				{path: "good.yaml", data: []byte("a: 1")},
+				{path: "bad.yaml", data: []byte("a: 1\na: 2\n")},
+			})
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("bad.yaml"))
+		})
+	})
 })

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -3,60 +3,99 @@ package config
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v2"
+	yamlv2 "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // yamlMap builds a generic YAML map from a literal, keeping specs readable.
-func yamlMap(doc string) map[interface{}]interface{} {
-	var m map[interface{}]interface{}
+func yamlMap(doc string) map[any]any {
+	var m map[any]any
 
-	Expect(yaml.Unmarshal([]byte(doc), &m)).Should(Succeed())
+	Expect(yamlv2.Unmarshal([]byte(doc), &m)).Should(Succeed())
+
+	return m
+}
+
+// nodeToMap re-encodes a merged yaml.v3 node and decodes it with yaml.v2, the
+// way the real config pipeline does, so node specs can compare semantics.
+func nodeToMap(node *yaml.Node) map[any]any {
+	out, err := yaml.Marshal(node)
+	Expect(err).Should(Succeed())
+
+	var m map[any]any
+
+	Expect(yamlv2.Unmarshal(out, &m)).Should(Succeed())
 
 	return m
 }
 
 var _ = Describe("Config file merging", func() {
-	Describe("mergeMaps", func() {
-		It("unions disjoint keys", func() {
-			merged := mergeMaps(yamlMap("a: 1"), yamlMap("b: 2"))
+	// roundtrip decodes merged bytes with yaml.v2 (the real config decoder) so
+	// merge specs compare semantics rather than byte layout.
+	roundtrip := func(data []byte) map[any]any {
+		var m map[any]any
 
-			Expect(merged).Should(Equal(yamlMap("{a: 1, b: 2}")))
+		Expect(yamlv2.Unmarshal(data, &m)).Should(Succeed())
+
+		return m
+	}
+
+	// merge2 merges two single-document files in order and returns the decoded
+	// result. It re-homes the old mergeMaps unit specs at the public boundary.
+	merge2 := func(first, second string) map[any]any {
+		merged, err := mergeConfigFiles([]configFile{
+			{path: "00_first.yaml", data: []byte(first)},
+			{path: "10_second.yaml", data: []byte(second)},
+		})
+
+		Expect(err).Should(Succeed())
+
+		return roundtrip(merged)
+	}
+
+	Describe("merge semantics", func() {
+		It("unions disjoint keys", func() {
+			Expect(merge2("a: 1", "b: 2")).Should(Equal(yamlMap("{a: 1, b: 2}")))
 		})
 
 		It("merges nested mappings recursively", func() {
-			dst := yamlMap("upstreams: {groups: {default: [8.8.8.8]}}")
-			src := yamlMap("upstreams: {groups: {special: [1.1.1.1]}}")
-
-			Expect(mergeMaps(dst, src)).Should(Equal(
-				yamlMap("upstreams: {groups: {default: [8.8.8.8], special: [1.1.1.1]}}")))
+			Expect(merge2(
+				"upstreams: {groups: {default: [8.8.8.8]}}",
+				"upstreams: {groups: {special: [1.1.1.1]}}",
+			)).Should(Equal(yamlMap("upstreams: {groups: {default: [8.8.8.8], special: [1.1.1.1]}}")))
 		})
 
 		It("replaces lists wholesale instead of concatenating", func() {
-			dst := yamlMap("ports: {dns: [53, 5353]}")
-			src := yamlMap("ports: {dns: [1053]}")
-
-			Expect(mergeMaps(dst, src)).Should(Equal(yamlMap("ports: {dns: [1053]}")))
+			Expect(merge2("ports: {dns: [53, 5353]}", "ports: {dns: [1053]}")).
+				Should(Equal(yamlMap("ports: {dns: [1053]}")))
 		})
 
 		It("replaces scalars, last wins", func() {
-			Expect(mergeMaps(yamlMap("log: {level: info}"), yamlMap("log: {level: debug}"))).
+			Expect(merge2("log: {level: info}", "log: {level: debug}")).
 				Should(Equal(yamlMap("log: {level: debug}")))
 		})
 
 		It("lets an explicit null win", func() {
-			Expect(mergeMaps(yamlMap("blocking: {blockType: zeroIp}"), yamlMap("blocking: null"))).
+			Expect(merge2("blocking: {blockType: zeroIp}", "blocking: null")).
 				Should(Equal(yamlMap("blocking: null")))
 		})
 
-		It("replaces on type mismatch (map then scalar, scalar then map)", func() {
-			Expect(mergeMaps(yamlMap("a: {b: 1}"), yamlMap("a: 5"))).
-				Should(Equal(yamlMap("a: 5")))
-			Expect(mergeMaps(yamlMap("a: 5"), yamlMap("a: {b: 1}"))).
-				Should(Equal(yamlMap("a: {b: 1}")))
+		It("replaces on type mismatch (map then scalar)", func() {
+			Expect(merge2("a: {b: 1}", "a: 5")).Should(Equal(yamlMap("a: 5")))
 		})
 
-		It("accepts a nil destination", func() {
-			Expect(mergeMaps(nil, yamlMap("a: 1"))).Should(Equal(yamlMap("a: 1")))
+		It("replaces on type mismatch (scalar then map)", func() {
+			Expect(merge2("a: 5", "a: {b: 1}")).Should(Equal(yamlMap("a: {b: 1}")))
+		})
+
+		It("keeps first-seen key order, appending new keys at the end", func() {
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "00_first.yaml", data: []byte("a: 1\nb: 2\n")},
+				{path: "10_second.yaml", data: []byte("c: 3\na: 9\n")},
+			})
+
+			Expect(err).Should(Succeed())
+			Expect(string(merged)).Should(Equal("a: 9\nb: 2\nc: 3\n"))
 		})
 	})
 
@@ -66,7 +105,8 @@ var _ = Describe("Config file merging", func() {
 
 			Expect(err).Should(Succeed())
 			Expect(docs).Should(HaveLen(1))
-			Expect(docs[0]).Should(Equal(yamlMap("log: {level: debug}")))
+			Expect(docs[0].Kind).Should(Equal(yaml.MappingNode))
+			Expect(nodeToMap(docs[0])).Should(Equal(yamlMap("log: {level: debug}")))
 		})
 
 		It("decodes multiple documents separated by ---", func() {
@@ -85,6 +125,13 @@ var _ = Describe("Config file merging", func() {
 
 		It("returns no documents for comment-only data", func() {
 			docs, err := decodeYAMLDocuments([]byte("# nothing to see here\n"))
+
+			Expect(err).Should(Succeed())
+			Expect(docs).Should(BeEmpty())
+		})
+
+		It("skips a bare null document", func() {
+			docs, err := decodeYAMLDocuments([]byte("---\nnull\n"))
 
 			Expect(err).Should(Succeed())
 			Expect(docs).Should(BeEmpty())
@@ -118,17 +165,16 @@ var _ = Describe("Config file merging", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("unknown anchor"))
 		})
+
+		It("rejects a self-referential anchor cycle instead of hanging", func() {
+			_, err := decodeYAMLDocuments([]byte("a: &x [*x]\n"))
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("cycle"))
+		})
 	})
 
 	Describe("mergeConfigFiles", func() {
-		roundtrip := func(data []byte) map[interface{}]interface{} {
-			var m map[interface{}]interface{}
-
-			Expect(yaml.Unmarshal(data, &m)).Should(Succeed())
-
-			return m
-		}
-
 		It("merges the issue #1827 example: disjoint upstream groups", func() {
 			merged, err := mergeConfigFiles([]configFile{
 				{path: "00_default.yaml", data: []byte("upstreams:\n  groups:\n    default: [8.8.8.8]\n  strategy: parallel_best\n")},
@@ -176,6 +222,90 @@ var _ = Describe("Config file merging", func() {
 
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("bad.yaml"))
+		})
+
+		It("expands a within-file anchor before merging", func() {
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "a.yaml", data: []byte("base: &b\n  a: 1\nderived: *b\n")},
+			})
+
+			Expect(err).Should(Succeed())
+
+			m := roundtrip(merged)
+			derived, ok := m["derived"].(map[any]any)
+			Expect(ok).Should(BeTrue())
+			Expect(derived["a"]).Should(Equal(1))
+			// No anchor name survives into the merged document.
+			Expect(string(merged)).ShouldNot(ContainSubstring("&b"))
+			Expect(string(merged)).ShouldNot(ContainSubstring("*b"))
+		})
+
+		It("resolves a within-file merge key (<<) end to end under strict decoding", func() {
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "a.yaml", data: []byte("base: &base\n  a: 1\n  b: 2\nderived:\n  <<: *base\n  c: 3\n")},
+			})
+
+			Expect(err).Should(Succeed())
+
+			// The real config decoder is yaml.v2 strict; it must resolve the
+			// expanded merge key without complaint.
+			var strict map[any]any
+			Expect(yamlv2.UnmarshalStrict(merged, &strict)).Should(Succeed())
+
+			derived, ok := strict["derived"].(map[any]any)
+			Expect(ok).Should(BeTrue())
+			Expect(derived["a"]).Should(Equal(1))
+			Expect(derived["b"]).Should(Equal(2))
+			Expect(derived["c"]).Should(Equal(3))
+		})
+
+		Describe("scalar fidelity (issue #1827 pivot)", func() {
+			It("keeps an unquoted decimal like 1.0 instead of collapsing to 1", func() {
+				merged, err := mergeConfigFiles([]configFile{
+					{path: "a.yaml", data: []byte("minTlsServeVersion: 1.0\n")},
+				})
+
+				Expect(err).Should(Succeed())
+				Expect(string(merged)).Should(ContainSubstring("minTlsServeVersion: 1.0"))
+			})
+
+			It("keeps a plain unquoted yes instead of rewriting it to true", func() {
+				merged, err := mergeConfigFiles([]configFile{
+					{path: "a.yaml", data: []byte("someKey: yes\n")},
+				})
+
+				Expect(err).Should(Succeed())
+				Expect(string(merged)).Should(ContainSubstring("someKey: yes"))
+			})
+
+			It("keeps an octal literal like 0700 instead of decimal 448", func() {
+				merged, err := mergeConfigFiles([]configFile{
+					{path: "a.yaml", data: []byte("mode: 0700\n")},
+				})
+
+				Expect(err).Should(Succeed())
+				Expect(string(merged)).Should(ContainSubstring("0700"))
+				Expect(string(merged)).ShouldNot(ContainSubstring("448"))
+			})
+
+			It("keeps a quoted string like \"1.0\" quoted", func() {
+				merged, err := mergeConfigFiles([]configFile{
+					{path: "a.yaml", data: []byte("version: \"1.0\"\n")},
+				})
+
+				Expect(err).Should(Succeed())
+				Expect(string(merged)).Should(ContainSubstring("\"1.0\""))
+			})
+
+			It("keeps a sexagesimal-looking value like 1:30 instead of 90", func() {
+				merged, err := mergeConfigFiles([]configFile{
+					{path: "a.yaml", data: []byte("window: 1:30\n")},
+				})
+
+				Expect(err).Should(Succeed())
+				Expect(string(merged)).Should(ContainSubstring("1:30"))
+				Expect(string(merged)).ShouldNot(ContainSubstring("window: 90"))
+			})
 		})
 	})
 })

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -59,4 +59,57 @@ var _ = Describe("Config file merging", func() {
 			Expect(mergeMaps(nil, yamlMap("a: 1"))).Should(Equal(yamlMap("a: 1")))
 		})
 	})
+
+	Describe("decodeYAMLDocuments", func() {
+		It("decodes a single document", func() {
+			docs, err := decodeYAMLDocuments([]byte("log:\n  level: debug\n"))
+
+			Expect(err).Should(Succeed())
+			Expect(docs).Should(HaveLen(1))
+			Expect(docs[0]).Should(Equal(yamlMap("log: {level: debug}")))
+		})
+
+		It("decodes multiple documents separated by ---", func() {
+			docs, err := decodeYAMLDocuments([]byte("a: 1\n---\nb: 2\n"))
+
+			Expect(err).Should(Succeed())
+			Expect(docs).Should(HaveLen(2))
+		})
+
+		It("returns no documents for empty data", func() {
+			docs, err := decodeYAMLDocuments([]byte(""))
+
+			Expect(err).Should(Succeed())
+			Expect(docs).Should(BeEmpty())
+		})
+
+		It("returns no documents for comment-only data", func() {
+			docs, err := decodeYAMLDocuments([]byte("# nothing to see here\n"))
+
+			Expect(err).Should(Succeed())
+			Expect(docs).Should(BeEmpty())
+		})
+
+		It("rejects duplicate keys within one document", func() {
+			_, err := decodeYAMLDocuments([]byte("a: 1\na: 2\n"))
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("already set in map"))
+		})
+
+		It("rejects a non-mapping top level", func() {
+			_, err := decodeYAMLDocuments([]byte("- just\n- a list\n"))
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("must be a mapping"))
+		})
+
+		It("rejects an alias to an anchor from another file", func() {
+			// anchors only live within one document/file now — pin the error
+			_, err := decodeYAMLDocuments([]byte("a: *missing\n"))
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("unknown anchor"))
+		})
+	})
 })

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	yamlv2 "gopkg.in/yaml.v2"
@@ -172,6 +175,44 @@ var _ = Describe("Config file merging", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("cycle"))
 		})
+
+		It("rejects a nested-anchor bomb before exhausting memory (2b)", func() {
+			// Build a YAML billion-laughs bomb: 7 levels of 10× amplification.
+			// l0 is a sequence of 10 scalars; each subsequent level holds 10
+			// aliases to the previous. Total expanded nodes ≈ 10^7, well above
+			// the 1M cap, so expansion must fail without allocating all of it.
+			var sb strings.Builder
+
+			sb.WriteString("l0: &l0 [0,0,0,0,0,0,0,0,0,0]\n")
+
+			for i := 1; i <= 7; i++ {
+				line := fmt.Sprintf("l%d: &l%d [*l%d,*l%d,*l%d,*l%d,*l%d,*l%d,*l%d,*l%d,*l%d,*l%d]\n",
+					i, i, i-1, i-1, i-1, i-1, i-1, i-1, i-1, i-1, i-1, i-1)
+				sb.WriteString(line)
+			}
+
+			_, err := decodeYAMLDocuments([]byte(sb.String()))
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("alias expansion"))
+			Expect(err.Error()).Should(ContainSubstring("limit"))
+		})
+
+		It("anchor on a map key round-trips through decodeYAMLDocuments without error (2c)", func() {
+			// yaml.v3 preserves the anchor on the key node; expandAliases clears
+			// it from the clone. Verify the key is accessible and no error occurs.
+			docs, err := decodeYAMLDocuments([]byte("? &k keyname\n: 1\n"))
+
+			Expect(err).Should(Succeed())
+			Expect(docs).Should(HaveLen(1))
+			Expect(nodeToMap(docs[0])).Should(HaveKeyWithValue("keyname", 1))
+		})
+
+		It("rejects a duplicate key inside a sequence-nested mapping (2c)", func() {
+			_, err := decodeYAMLDocuments([]byte("list:\n  - b: 1\n    b: 2\n"))
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("already set in map"))
+		})
 	})
 
 	Describe("mergeConfigFiles", func() {
@@ -257,6 +298,46 @@ var _ = Describe("Config file merging", func() {
 			Expect(derived["a"]).Should(Equal(1))
 			Expect(derived["b"]).Should(Equal(2))
 			Expect(derived["c"]).Should(Equal(3))
+		})
+
+		It("diamond alias: overriding one reference does not corrupt the other (2c)", func() {
+			// base: &b {a: 1}; lhs: *b; rhs: *b — expandAliases deep-copies
+			// the anchor target for every reference, so lhs and rhs are
+			// independent nodes. File B overrides lhs.a: 2; rhs.a must remain
+			// 1 (no shared-subtree mutation). Key names avoid yaml 1.1 booleans
+			// (y/n/yes/no etc.) which yaml.v2 would reinterpret.
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "a.yaml", data: []byte("base: &b {a: 1}\nlhs: *b\nrhs: *b\n")},
+				{path: "b.yaml", data: []byte("lhs: {a: 2}\n")},
+			})
+
+			Expect(err).Should(Succeed())
+
+			m := roundtrip(merged)
+			lhs, ok := m["lhs"].(map[any]any)
+			Expect(ok).Should(BeTrue())
+			rhs, ok := m["rhs"].(map[any]any)
+			Expect(ok).Should(BeTrue())
+			Expect(lhs["a"]).Should(Equal(2))
+			Expect(rhs["a"]).Should(Equal(1), "shared anchor must not be mutated by merging lhs")
+		})
+
+		It("merge across alias-expanded file: non-overridden sibling keys are kept (2c)", func() {
+			// File A: base: &b {a: 1, b: 2}; x: *b — after alias expansion
+			// x holds an independent copy {a: 1, b: 2}. File B sets x.a: 99;
+			// the recursive map merge keeps x.b == 2 from file A.
+			merged, err := mergeConfigFiles([]configFile{
+				{path: "a.yaml", data: []byte("base: &b {a: 1, b: 2}\nx: *b\n")},
+				{path: "b.yaml", data: []byte("x: {a: 99}\n")},
+			})
+
+			Expect(err).Should(Succeed())
+
+			m := roundtrip(merged)
+			x, ok := m["x"].(map[any]any)
+			Expect(ok).Should(BeTrue())
+			Expect(x["a"]).Should(Equal(99))
+			Expect(x["b"]).Should(Equal(2))
 		})
 
 		Describe("scalar fidelity (issue #1827 pivot)", func() {

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -97,6 +97,13 @@ var _ = Describe("Config file merging", func() {
 			Expect(err.Error()).Should(ContainSubstring("already set in map"))
 		})
 
+		It("rejects duplicate keys at nested levels too", func() {
+			_, err := decodeYAMLDocuments([]byte("a:\n  b: 1\n  b: 2\n"))
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("already set in map"))
+		})
+
 		It("rejects a non-mapping top level", func() {
 			_, err := decodeYAMLDocuments([]byte("- just\n- a list\n"))
 

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+)
+
+// yamlMap builds a generic YAML map from a literal, keeping specs readable.
+func yamlMap(doc string) map[interface{}]interface{} {
+	var m map[interface{}]interface{}
+
+	Expect(yaml.Unmarshal([]byte(doc), &m)).Should(Succeed())
+
+	return m
+}
+
+var _ = Describe("Config file merging", func() {
+	Describe("mergeMaps", func() {
+		It("unions disjoint keys", func() {
+			merged := mergeMaps(yamlMap("a: 1"), yamlMap("b: 2"))
+
+			Expect(merged).Should(Equal(yamlMap("{a: 1, b: 2}")))
+		})
+
+		It("merges nested mappings recursively", func() {
+			dst := yamlMap("upstreams: {groups: {default: [8.8.8.8]}}")
+			src := yamlMap("upstreams: {groups: {special: [1.1.1.1]}}")
+
+			Expect(mergeMaps(dst, src)).Should(Equal(
+				yamlMap("upstreams: {groups: {default: [8.8.8.8], special: [1.1.1.1]}}")))
+		})
+
+		It("replaces lists wholesale instead of concatenating", func() {
+			dst := yamlMap("ports: {dns: [53, 5353]}")
+			src := yamlMap("ports: {dns: [1053]}")
+
+			Expect(mergeMaps(dst, src)).Should(Equal(yamlMap("ports: {dns: [1053]}")))
+		})
+
+		It("replaces scalars, last wins", func() {
+			Expect(mergeMaps(yamlMap("log: {level: info}"), yamlMap("log: {level: debug}"))).
+				Should(Equal(yamlMap("log: {level: debug}")))
+		})
+
+		It("lets an explicit null win", func() {
+			Expect(mergeMaps(yamlMap("blocking: {blockType: zeroIp}"), yamlMap("blocking: null"))).
+				Should(Equal(yamlMap("blocking: null")))
+		})
+
+		It("replaces on type mismatch (map then scalar, scalar then map)", func() {
+			Expect(mergeMaps(yamlMap("a: {b: 1}"), yamlMap("a: 5"))).
+				Should(Equal(yamlMap("a: 5")))
+			Expect(mergeMaps(yamlMap("a: 5"), yamlMap("a: {b: 1}"))).
+				Should(Equal(yamlMap("a: {b: 1}")))
+		})
+
+		It("accepts a nil destination", func() {
+			Expect(mergeMaps(nil, yamlMap("a: 1"))).Should(Equal(yamlMap("a: 1")))
+		})
+	})
+})

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -191,8 +191,12 @@ var _ = Describe("Config file merging", func() {
 				sb.WriteString(line)
 			}
 
-			_, err := decodeYAMLDocuments([]byte(sb.String()))
+			// Go through mergeConfigFiles so the file-name wrapping of the cap
+			// error is pinned ("can't parse config file ...") in addition to
+			// the expansion-limit message.
+			_, err := mergeConfigFiles([]configFile{{path: "bomb.yaml", data: []byte(sb.String())}})
 			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("can't parse config file"))
 			Expect(err.Error()).Should(ContainSubstring("alias expansion"))
 			Expect(err.Error()).Should(ContainSubstring("limit"))
 		})

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,54 @@ invalid values with their field path. Schema validation is a structural
 first pass; blocky still performs its full semantic checks when loading the
 configuration.
 
+## Multiple configuration files
+
+Instead of a single file, `--config` can point to a **folder**. Blocky then loads every `*.yml` and `*.yaml`
+file in that folder (subfolders included) and merges them into one configuration:
+
+- Files are applied in **lexical (alphabetical) path order** — use number prefixes like `00_base.yml`,
+  `10_local.yml` to make the order explicit. Blocky logs the merge order at startup.
+- **Mappings merge recursively**: keys from later files are added; keys present on both sides merge field by
+  field.
+- **Everything else is replaced**: when several files set the same scalar or list, the last file wins,
+  wholesale. Lists are never concatenated.
+- Duplicate keys *within one file* are still an error, and each file must be valid YAML on its own
+  (YAML anchors and aliases work within a file, but not across files). A file may contain multiple
+  `---`-separated documents; they merge in document order, like separate files.
+
+!!! example
+
+    `config/00_base.yml` — checked into your repo:
+
+    ```yaml
+    upstreams:
+      groups:
+        default:
+          - 9.9.9.9
+      strategy: parallel_best
+    ```
+
+    `config/10_local.yml` — host-specific overlay:
+
+    ```yaml
+    upstreams:
+      groups:
+        192.168.0.0/16:
+          - 1.1.1.1
+    ```
+
+    Effective configuration:
+
+    ```yaml
+    upstreams:
+      groups:
+        default:
+          - 9.9.9.9
+        192.168.0.0/16:
+          - 1.1.1.1
+      strategy: parallel_best
+    ```
+
 ## Basic configuration
 
 | Parameter          | Type                | Mandatory | Default value | Description                                                                                                |

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	golang.org/x/sys v0.46.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
@@ -193,7 +194,6 @@ require (
 	golang.org/x/tools v0.45.0 // indirect
 	golang.org/x/tools/cmd/cover v0.1.0-deprecated // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect


### PR DESCRIPTION
Closes #1827.

## What

When `--config` points to a folder, blocky now **structurally merges** the YAML files instead of concatenating their bytes (which made any key occurring in two files a startup error):

- Files apply in lexical (alphabetical) path order — `00_base.yml` before `10_local.yml`; the merge order is logged at startup.
- Mappings merge recursively; scalars and lists are replaced wholesale (last file wins).
- Duplicate keys within one file remain an error, now naming the file.
- Multi-document files (`---`) merge in document order.
- Post-merge config errors (e.g. unknown keys) are attributed to the source file that contains them.

## Implementation

Each file is parsed into yaml.v3 `*Node` trees (preserves scalar literal text — an earlier generic-map prototype rewrote `1.0`→`1`, unquoted `yes`→`true`, `0700`→`448`), aliases are expanded per document (cycle-safe, capped against billion-laughs bombs), node trees are merged and re-encoded, and the result feeds the existing strict yaml.v2 unmarshal — so unknown-key detection, schema enrichment, deprecation migration, and validation are unchanged. `gopkg.in/yaml.v3` moves from indirect to direct dependency (pure Go; the CGO_ENABLED=0 mips/BSD release matrix is unaffected — spot-checked freebsd/arm64 + linux/mips).

## Behavior changes

Overlapping keys across files previously caused a startup error, so working setups are unaffected. Two edge cases change:

1. **YAML anchors referenced across files** (worked via concatenation) now fail at startup with an `unknown anchor` error naming the file. Anchors + aliases *within* one file keep working. Fix: move anchor and alias into the same file.
2. **Content after a `---` separator** was previously **silently ignored** (verified: yaml.v2 `UnmarshalStrict` decodes only the first document of the concatenated stream); every document now takes effect, later documents winning conflicts.

## Test Plan

- [x] `make all` (build + full test suite + lint): pass, 0 lint issues
- [x] `make e2e-test`: 144/144 specs pass
- [x] Cross-compile spot check (CGO_ENABLED=0): freebsd/arm64 all packages, linux/mips config package
- [x] 523 config-package specs incl. scalar-fidelity, alias/anchor, merge-key, and adversarial merge invariants
- [x] Manual: base+overlay folder via `blocky validate` (merge order logged, overrides applied, errors name the offending file)