### PR TITLE
fix(stats): populate allow/denylist counts in /api/stats at startup

### DIFF
--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -126,6 +126,17 @@ func (b *ListCache) Refresh(ctx context.Context) error {
 	return b.refresh(ctx)
 }
 
+// PublishGroupCounts re-emits a BlockingCacheGroupChanged event with the current
+// element count for every configured group. The initial counts are emitted while
+// the lists load during construction, before later-constructed subscribers (such
+// as the stats resolver) attach to the bus; re-publishing lets those subscribers
+// pick up the point-in-time counts without waiting for the next list refresh.
+func (b *ListCache) PublishGroupCounts() {
+	for group := range b.groupSources {
+		evt.Bus().Publish(evt.BlockingCacheGroupChanged, b.listType, group, b.groupedCache.ElementCount(group))
+	}
+}
+
 func (b *ListCache) refresh(ctx context.Context) error {
 	unlimitedGrp, _ := jobgroup.WithContext(ctx)
 	defer unlimitedGrp.Close()

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -247,7 +247,17 @@ func NewBlockingResolver(ctx context.Context,
 
 func (r *BlockingResolver) subscribeEvents(ctx context.Context) error {
 	err := evt.Bus().SubscribeOnce(evt.ApplicationStarted, func(_ ...string) {
-		go r.initFQDNIPCache(ctx)
+		// Run off the publish path: the event bus holds a global lock while
+		// invoking handlers, so publishing from within a handler would deadlock.
+		go func() {
+			// Re-emit the current list counts now that the whole resolver chain is
+			// wired: the counts published while lists loaded during construction were
+			// missed by subscribers built after this resolver (e.g. the stats resolver).
+			r.denylistMatcher.PublishGroupCounts()
+			r.allowlistMatcher.PublishGroupCounts()
+
+			r.initFQDNIPCache(ctx)
+		}()
 	})
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to ApplicationStarted event: %w", err)

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -2,6 +2,8 @@ package resolver
 
 import (
 	"context"
+	"maps"
+	"sync"
 	"time"
 
 	"github.com/0xERR0R/blocky/config"
@@ -120,8 +122,19 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				// sut is already built in JustBeforeEach, so the load-time
 				// BlockingCacheGroupChanged events have fired and a subscriber that
 				// registers now (like the later-built stats resolver) has missed them.
+				// The re-publish runs in a goroutine, so guard the map: the handler
+				// writes it concurrently with the Eventually poll that reads it.
+				var mu sync.Mutex
 				groupCnt := make(map[string]int)
-				handler := func(listType lists.ListCacheType, group string, cnt int) {
+				snapshot := func() map[string]int {
+					mu.Lock()
+					defer mu.Unlock()
+
+					return maps.Clone(groupCnt)
+				}
+				handler := func(_ lists.ListCacheType, group string, cnt int) {
+					mu.Lock()
+					defer mu.Unlock()
 					groupCnt[group] = cnt
 				}
 				Expect(Bus().Subscribe(BlockingCacheGroupChanged, handler)).Should(Succeed())
@@ -130,11 +143,11 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				})
 
 				// the late subscriber has not seen any counts yet
-				Expect(groupCnt).Should(BeEmpty())
+				Expect(snapshot()).Should(BeEmpty())
 
 				Bus().Publish(ApplicationStarted, "version", "buildtime")
 
-				Eventually(groupCnt, "1s").Should(SatisfyAll(
+				Eventually(snapshot, "1s").Should(SatisfyAll(
 					HaveKeyWithValue("gr1", 1),
 					HaveKeyWithValue("gr2", 1),
 				))

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -115,6 +115,31 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				Eventually(groupCnt, "1s").Should(HaveLen(2))
 			})
 		})
+		When("a subscriber registers after the initial list load", func() {
+			It("receives the current list counts again on ApplicationStarted", func() {
+				// sut is already built in JustBeforeEach, so the load-time
+				// BlockingCacheGroupChanged events have fired and a subscriber that
+				// registers now (like the later-built stats resolver) has missed them.
+				groupCnt := make(map[string]int)
+				handler := func(listType lists.ListCacheType, group string, cnt int) {
+					groupCnt[group] = cnt
+				}
+				Expect(Bus().Subscribe(BlockingCacheGroupChanged, handler)).Should(Succeed())
+				DeferCleanup(func() {
+					_ = Bus().Unsubscribe(BlockingCacheGroupChanged, handler)
+				})
+
+				// the late subscriber has not seen any counts yet
+				Expect(groupCnt).Should(BeEmpty())
+
+				Bus().Publish(ApplicationStarted, "version", "buildtime")
+
+				Eventually(groupCnt, "1s").Should(SatisfyAll(
+					HaveKeyWithValue("gr1", 1),
+					HaveKeyWithValue("gr2", 1),
+				))
+			})
+		})
 	})
 
 	Describe("Resolving FQDN client identifiers", func() {


### PR DESCRIPTION
## Summary
- `/api/stats` reported empty `lists.allowlist` / `lists.denylist` until the first list refresh (manual or periodic).
- **Root cause:** the stats resolver populates those counts only from the `BlockingCacheGroupChanged` event. That event is emitted once while the lists load inside `NewBlockingResolver` (server.go:495) — *before* `NewStatsResolver` subscribes to the bus (server.go:527) — so the stats resolver never saw the initial counts. The cache-entries gauge isn't affected because `CachingResultCacheChanged` re-fires continuously as queries flow in; list counts only change on refresh.
- **Fix:** re-emit the current per-group counts on `ApplicationStarted`, which fires after the full resolver chain is wired and every subscriber is attached. Reuses the existing event path, so the metrics gauges (which use `.Set()`) stay consistent and idempotent.
- The re-publish runs in a goroutine: `EventBus.Publish` holds a global lock for the duration of handler invocation, so publishing synchronously from within a handler deadlocks. This matches how the existing handler already defers `initFQDNIPCache`.

## Changes
- `lists/list_cache.go`: new `ListCache.PublishGroupCounts()` that re-emits `BlockingCacheGroupChanged` with each group's current `ElementCount`.
- `resolver/blocking_resolver.go`: the existing `ApplicationStarted` handler now calls it for both matchers (off the publish path).
- `resolver/blocking_resolver_test.go`: regression test — a subscriber that registers after the initial load receives the counts again on `ApplicationStarted`.

## Test Plan
- [x] New regression test fails before the fix, passes after.
- [x] `go test ./resolver/ ./lists/ ./stats/` all green.
- [x] `go build ./...` and `go vet` clean.
- [ ] Manual: start blocky with lists configured, call `/api/stats` immediately — `lists.allowlist`/`denylist` are populated without a manual refresh.