### PR TITLE
Batched flushing of lists

### DIFF
--- a/lists/list_cache.go
+++ b/lists/list_cache.go
@@ -314,66 +314,95 @@ func (b *ListCache) localSeedSources(dir string) map[string][]config.BytesSource
 
 // downloads file (or reads local file) and writes each line in the file to the result channel
 func (b *ListCache) parseFile(ctx context.Context, opener SourceOpener, resultCh chan<- string) error {
-	count := 0
-
-	logger := func() *logrus.Entry {
-		return logger().WithFields(logrus.Fields{
-			"source": opener.String(),
-			"count":  count,
-		})
-	}
-
-	logger().Debug("starting processing of source")
-
-	r, err := opener.Open(ctx)
-	if err != nil {
-		logger().Error("cannot open source: ", err)
-
-		return fmt.Errorf("failed to open list source %s: %w", opener, err)
-	}
-	defer r.Close()
-
-	p := parsers.AllowErrors(parsers.Hosts(r), b.cfg.MaxErrorsPerSource)
-	p.OnErr(func(err error) {
-		logger().Warnf("parse error: %s, trying to continue", err)
-	})
-
-	err = parsers.ForEach[*parsers.HostsIterator](ctx, p, func(hosts *parsers.HostsIterator) error {
-		return hosts.ForEach(func(host string) error {
-			count++
-
-			// For IPs, we want to ensure the string is the Go representation so that when
-			// we compare responses, a same IP matches, even if it was written differently
-			// in the list. The cheap MightBeIP pre-check avoids calling net.ParseIP on
-			// the vast majority of entries, which are domain names.
-			if parsers.MightBeIP(host) {
-				if ip := net.ParseIP(host); ip != nil {
-					host = ip.String()
-				}
-			}
-
-			resultCh <- host
-
-			return nil
-		})
-	})
-	if err != nil {
-		// Don't log cancelation: it was caused by another goroutine failing
-		if !errors.Is(err, context.Canceled) {
-			logger().Error("parse error: ", err)
-		}
-
-		// Only propagate the error if no entries were parsed
-		// If the file was partially parsed, we'll settle for that
-
-		if count == 0 {
-			return fmt.Errorf("failed to parse list source %s (no entries parsed): %w", opener, err)
-		}
-
-		return nil
-	}
-
-	logger().Info("import succeeded")
-
-	return nil
+    count := 0
+    
+    logger := func() *logrus.Entry {
+        return logger().WithFields(logrus.Fields{
+            "source": opener.String(),
+            "count":  count,
+        })
+    }
+    
+    logger().Debug("starting processing of source")
+    
+    r, err := opener.Open(ctx)
+    if err != nil {
+        logger().Error("cannot open source: ", err)
+        return fmt.Errorf("failed to open list source %s: %w", opener, err)
+    }
+    defer r.Close()
+    
+    p := parsers.AllowErrors(parsers.Hosts(r), b.cfg.MaxErrorsPerSource)
+    p.OnErr(func(err error) {
+        logger().Warnf("parse error: %s, trying to continue", err)
+    })
+    
+    // Batching configuration - tune based on memory vs channel overhead tradeoff
+    const batchSize = 8192
+    batch := make([]string, 0, batchSize)
+    flushBatch := func() error {
+        if len(batch) == 0 {
+            return nil
+        }
+        
+        // Send entire batch at once
+        for i := range batch {
+            select {
+            case resultCh <- batch[i]:
+                count++
+            case <-ctx.Done():
+                return ctx.Err()
+            }
+        }
+        
+        // Clear batch by truncating to zero length (reuses backing array)
+        batch = batch[:0]
+        return nil
+    }
+    
+    err = parsers.ForEach[*parsers.HostsIterator](ctx, p, func(hosts *parsers.HostsIterator) error {
+        return hosts.ForEach(func(host string) error {
+            // For IPs, normalize to Go representation
+            if parsers.MightBeIP(host) {
+                if ip := net.ParseIP(host); ip != nil {
+                    host = ip.String()
+                }
+            }
+            
+            // Add to batch
+            batch = append(batch, host)
+            
+            // Flush when batch is full
+            if len(batch) >= batchSize {
+                if err := flushBatch(); err != nil {
+                    return err
+                }
+            }
+            
+            return nil
+        })
+    })
+    
+    // Flush remaining items in the last partial batch
+    if err == nil {
+        err = flushBatch()
+    }
+    
+    if err != nil {
+        // Don't log cancelation: it was caused by another goroutine failing
+        if !errors.Is(err, context.Canceled) {
+            logger().Error("parse error: ", err)
+        }
+        
+        // Only propagate the error if no entries were parsed
+        // If the file was partially parsed, we'll settle for that
+        if count == 0 {
+            return fmt.Errorf("failed to parse list source %s (no entries parsed): %w", opener, err)
+        }
+        
+        return nil
+    }
+    
+    logger().Info("import succeeded")
+    return nil
 }


### PR DESCRIPTION
Create batches of list entries before sending them onto the channel back to the caller.

Full disclosure: This code was written with the help of an LLM (Proton Lumo in this case).

My setup loads 33 block lists with ~18M entries in total.

The function `parseFile` in `list_cache` processes each entry individually, including flushing via the channel.
Making this change reduces the startup time greatly. In my case, from 44 minutes (including some channel timeouts) down to 1 minute.
I don't think there is any negative impact here.

<details>
<summary>
Before
</summary>
<code>
Jun 16 02:07:26 opi5plus blocky[334441]: [2026-06-16 02:07:26]  INFO list_cache: import succeeded count=305292 source=https://nsfw.oisd.nl/domainswild2
Jun 16 02:09:19 opi5plus blocky[334441]: [2026-06-16 02:09:19]  INFO list_cache: import succeeded count=2409026 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/nrd35-29.txt
Jun 16 02:09:20 opi5plus blocky[334441]: [2026-06-16 02:09:20]  INFO list_cache: import succeeded count=27077 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/anti.piracy.txt
Jun 16 02:09:20 opi5plus blocky[334441]: [2026-06-16 02:09:20]  INFO list_cache: import succeeded count=2904134 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/nrd7.txt
Jun 16 02:12:24 opi5plus blocky[334441]: [2026-06-16 02:12:24]  INFO list_cache: import succeeded count=1082901 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/dga14.txt
Jun 16 02:13:08 opi5plus blocky[334441]: [2026-06-16 02:13:08]  INFO list_cache: import succeeded count=556098 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/dga7.txt
Jun 16 02:13:09 opi5plus blocky[334441]: [2026-06-16 02:13:09]  INFO list_cache: import succeeded count=17277 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/doh-vpn-proxy-bypass.txt
Jun 16 02:14:43 opi5plus blocky[334441]: [2026-06-16 02:14:43]  INFO list_cache: import succeeded count=327065 source=https://big.oisd.nl/domainswild2
Jun 16 02:14:44 opi5plus blocky[334441]: [2026-06-16 02:14:44]  INFO list_cache: import succeeded count=199 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.samsung.txt
Jun 16 02:14:47 opi5plus blocky[334441]: [2026-06-16 02:14:47]  INFO list_cache: import succeeded count=126119 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/gambling.medium.txt
Jun 16 02:14:49 opi5plus blocky[334441]: [2026-06-16 02:14:49]  INFO list_cache: import succeeded count=2377046 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/dga30.txt
Jun 16 02:14:49 opi5plus blocky[334441]: [2026-06-16 02:14:49]  INFO list_cache: import succeeded count=1228 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/hoster.txt
Jun 16 02:14:51 opi5plus blocky[334441]: [2026-06-16 02:14:51]  INFO list_cache: import succeeded count=252184 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/gambling.txt
Jun 16 02:14:57 opi5plus blocky[334441]: [2026-06-16 02:14:57]  INFO list_cache: import succeeded count=160160 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/multi.txt
Jun 16 02:15:17 opi5plus blocky[334441]: [2026-06-16 02:15:17]  INFO list_cache: import succeeded count=169307 source=https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn/hosts
Jun 16 02:15:17 opi5plus blocky[334441]: [2026-06-16 02:15:17]  INFO list_cache: import succeeded count=1228 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/hoster-onlydomains.txt
Jun 16 02:16:00 opi5plus blocky[334441]: [2026-06-16 02:16:00]  INFO list_cache: import succeeded count=250190 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.plus-onlydomains.txt
Jun 16 02:16:00 opi5plus blocky[334441]: [2026-06-16 02:16:00]  INFO list_cache: import succeeded count=1515 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/dyndns.txt
Jun 16 02:24:23 opi5plus blocky[334441]: [2026-06-16 02:24:23]  INFO list_cache: import succeeded count=1536513 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt
Jun 16 02:24:23 opi5plus blocky[334441]: [2026-06-16 02:24:23]  INFO list_cache: import succeeded count=388 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.winoffice.txt
Jun 16 02:32:53 opi5plus blocky[334441]: [2026-06-16 02:32:53] ERROR list_cache: parse error: line 2262847: failed to get next item from parser: non-resumable parse error: inner parser failed: inner parser failed: non resumable parse>
Jun 16 02:33:37 opi5plus blocky[334441]: [2026-06-16 02:33:37]  INFO list_cache: import succeeded count=84986 source=https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
Jun 16 02:33:37 opi5plus blocky[334441]: [2026-06-16 02:33:37]  INFO list_cache: import succeeded count=445 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/spam-tlds-onlydomains.txt
Jun 16 02:34:25 opi5plus blocky[334441]: [2026-06-16 02:34:25]  INFO list_cache: import succeeded count=96894 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/nsfw.txt
Jun 16 02:36:18 opi5plus blocky[334441]: [2026-06-16 02:36:18]  INFO list_cache: import succeeded count=250190 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.plus.txt
Jun 16 02:37:45 opi5plus blocky[334441]: [2026-06-16 02:37:45]  INFO list_cache: import succeeded count=232597 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.txt
Jun 16 02:39:29 opi5plus blocky[334441]: [2026-06-16 02:39:29] ERROR list_cache: parse error: line 1675272: failed to get next item from parser: non-resumable parse error: inner parser failed: inner parser failed: non resumable parse>
Jun 16 02:42:59 opi5plus blocky[334441]: [2026-06-16 02:42:59]  INFO list_cache: import succeeded count=267265 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/ultimate.txt
Jun 16 02:51:23 opi5plus blocky[334441]: [2026-06-16 02:51:23] ERROR list_cache: parse error: line 1620100: failed to get next item from parser: non-resumable parse error: inner parser failed: inner parser failed: non resumable parse>
Jun 16 02:51:23 opi5plus blocky[334441]: [2026-06-16 02:51:23]  INFO list_cache: import succeeded count=2113 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/whitelist-referral.txt
Jun 16 02:51:23 opi5plus blocky[334441]: [2026-06-16 02:51:23]  INFO list_cache: import succeeded count=346 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.xiaomi.txt
Jun 16 02:51:24 opi5plus blocky[334441]: [2026-06-16 02:51:24]  INFO list_cache: import succeeded count=3441 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/doh.txt
Jun 16 02:51:24 opi5plus blocky[334441]: [2026-06-16 02:51:24]  INFO list_cache: import succeeded count=3 source=file:///etc/dns-blocklist.txt
Jun 16 02:51:30 opi5plus blocky[334441]: [2026-06-16 02:51:30]  INFO list_cache: import succeeded count=1536513 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt
Jun 16 02:51:31 opi5plus blocky[334441]: [2026-06-16 02:51:31]  INFO list_cache: group import finished group=ads total_count=16693254
Jun 16 02:51:31 opi5plus blocky[334441]: [2026-06-16 02:51:31]  INFO list_cache: import succeeded count=16 source=file:///etc/dns-allowlist.txt
Jun 16 02:51:31 opi5plus blocky[334441]: [2026-06-16 02:51:31]  INFO list_cache: import succeeded count=980 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/spam-tlds-allow-onlydomains.txt
Jun 16 02:51:31 opi5plus blocky[334441]: [2026-06-16 02:51:31]  INFO list_cache: group import finished group=ads total_count=996
</code>
</details>

<details>
<summary>
After
</summary>
<code>
Jun 16 02:54:29 opi5plus blocky[349652]: [2026-06-16 02:54:29]  INFO list_cache: import succeeded count=346 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.xiaomi.txt
Jun 16 02:54:40 opi5plus blocky[349652]: [2026-06-16 02:54:40]  INFO list_cache: import succeeded count=1536513 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt
Jun 16 02:54:41 opi5plus blocky[349652]: [2026-06-16 02:54:41]  INFO list_cache: import succeeded count=2377046 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/dga30.txt
Jun 16 02:54:50 opi5plus blocky[349652]: [2026-06-16 02:54:50]  INFO list_cache: import succeeded count=2403061 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/nrd21-15.txt
Jun 16 02:54:50 opi5plus blocky[349652]: [2026-06-16 02:54:50]  INFO list_cache: import succeeded count=2383275 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/nrd14-8.txt
Jun 16 02:54:58 opi5plus blocky[349652]: [2026-06-16 02:54:58]  INFO list_cache: import succeeded count=2730152 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/nrd28-22.txt
Jun 16 02:55:01 opi5plus blocky[349652]: [2026-06-16 02:55:01]  INFO list_cache: import succeeded count=2409026 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/nrd35-29.txt
Jun 16 02:55:02 opi5plus blocky[349652]: [2026-06-16 02:55:02]  INFO list_cache: import succeeded count=96894 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/nsfw.txt
Jun 16 02:55:04 opi5plus blocky[349652]: [2026-06-16 02:55:04]  INFO list_cache: import succeeded count=250190 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.plus.txt
Jun 16 02:55:06 opi5plus blocky[349652]: [2026-06-16 02:55:06]  INFO list_cache: import succeeded count=232597 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.txt
Jun 16 02:55:06 opi5plus blocky[349652]: [2026-06-16 02:55:06]  INFO list_cache: import succeeded count=445 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/spam-tlds-onlydomains.txt
Jun 16 02:55:07 opi5plus blocky[349652]: [2026-06-16 02:55:07]  INFO list_cache: import succeeded count=2904134 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/nrd7.txt
Jun 16 02:55:07 opi5plus blocky[349652]: [2026-06-16 02:55:07]  INFO list_cache: import succeeded count=252184 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/gambling.txt
Jun 16 02:55:07 opi5plus blocky[349652]: [2026-06-16 02:55:07]  INFO list_cache: import succeeded count=17277 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/doh-vpn-proxy-bypass.txt
Jun 16 02:55:08 opi5plus blocky[349652]: [2026-06-16 02:55:08]  INFO list_cache: import succeeded count=1515 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/dyndns.txt
Jun 16 02:55:09 opi5plus blocky[349652]: [2026-06-16 02:55:09]  INFO list_cache: import succeeded count=126119 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/gambling.medium.txt
Jun 16 02:55:09 opi5plus blocky[349652]: [2026-06-16 02:55:09]  INFO list_cache: import succeeded count=556098 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/dga7.txt
Jun 16 02:55:09 opi5plus blocky[349652]: [2026-06-16 02:55:09]  INFO list_cache: import succeeded count=1228 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/hoster.txt
Jun 16 02:55:10 opi5plus blocky[349652]: [2026-06-16 02:55:10]  INFO list_cache: import succeeded count=160160 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/multi.txt
Jun 16 02:55:10 opi5plus blocky[349652]: [2026-06-16 02:55:10]  INFO list_cache: import succeeded count=84986 source=https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
Jun 16 02:55:10 opi5plus blocky[349652]: [2026-06-16 02:55:10]  INFO list_cache: import succeeded count=169307 source=https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn/hosts
Jun 16 02:55:12 opi5plus blocky[349652]: [2026-06-16 02:55:12]  INFO list_cache: import succeeded count=305305 source=https://nsfw.oisd.nl/domainswild2
Jun 16 02:55:12 opi5plus blocky[349652]: [2026-06-16 02:55:12]  INFO list_cache: import succeeded count=27077 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/anti.piracy.txt
Jun 16 02:55:12 opi5plus blocky[349652]: [2026-06-16 02:55:12]  INFO list_cache: import succeeded count=3441 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/doh.txt
Jun 16 02:55:12 opi5plus blocky[349652]: [2026-06-16 02:55:12]  INFO list_cache: import succeeded count=406638 source=https://big.oisd.nl/domainswild2
Jun 16 02:55:13 opi5plus blocky[349652]: [2026-06-16 02:55:13]  INFO list_cache: import succeeded count=250190 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.plus-onlydomains.txt
Jun 16 02:55:15 opi5plus blocky[349652]: [2026-06-16 02:55:15]  INFO list_cache: import succeeded count=267265 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/ultimate.txt
Jun 16 02:55:15 opi5plus blocky[349652]: [2026-06-16 02:55:15]  INFO list_cache: import succeeded count=3 source=file:///etc/dns-blocklist.txt
Jun 16 02:55:15 opi5plus blocky[349652]: [2026-06-16 02:55:15]  INFO list_cache: import succeeded count=388 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.winoffice.txt
Jun 16 02:55:20 opi5plus blocky[349652]: [2026-06-16 02:55:20]  INFO list_cache: import succeeded count=1082901 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/dga14.txt
Jun 16 02:55:20 opi5plus blocky[349652]: [2026-06-16 02:55:20]  INFO list_cache: import succeeded count=199 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.samsung.txt
Jun 16 02:55:21 opi5plus blocky[349652]: [2026-06-16 02:55:21]  INFO list_cache: import succeeded count=1228 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/hoster-onlydomains.txt
Jun 16 02:55:21 opi5plus blocky[349652]: [2026-06-16 02:55:21]  INFO list_cache: import succeeded count=2113 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/whitelist-referral.txt
Jun 16 02:55:22 opi5plus blocky[349652]: [2026-06-16 02:55:22]  INFO list_cache: import succeeded count=1536513 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt
Jun 16 02:55:33 opi5plus blocky[349652]: [2026-06-16 02:55:33]  INFO list_cache: group import finished group=ads total_count=18267621
Jun 16 02:55:33 opi5plus blocky[349652]: [2026-06-16 02:55:33]  INFO list_cache: import succeeded count=16 source=file:///etc/dns-allowlist.txt
Jun 16 02:55:33 opi5plus blocky[349652]: [2026-06-16 02:55:33]  INFO list_cache: import succeeded count=980 source=https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/spam-tlds-allow-onlydomains.txt
Jun 16 02:55:33 opi5plus blocky[349652]: [2026-06-16 02:55:33]  INFO list_cache: group import finished group=ads total_count=996
</code>
</details>