### PR TITLE
fix(dnssec): close DNSSEC validation bypass & cache-scope pollution (GHSA-x845-2f78-7v36)

### DIFF
--- a/e2e/dnssec_test.go
+++ b/e2e/dnssec_test.go
@@ -406,6 +406,59 @@ var _ = Describe("DNSSEC validation", Label("dnssec"), func() {
 					})
 			})
 
+			When("upstream returns an unsigned answer for a signed public domain under only the default root anchor", func() {
+				// GHSA-x845-2f78-7v36 finding 1 + 2: the documented basic configuration is just
+				// `dnssec: {validate: true}` with no custom trustAnchors, so only the implicit IANA
+				// root anchor is present. A malicious/compromised upstream that returns an unsigned
+				// forged answer for a DNSSEC-signed public name (and cannot supply an authenticated
+				// insecure-delegation proof) must NOT have that answer accepted or replayed.
+				var mokka testcontainers.Container
+
+				BeforeEach(func(ctx context.Context) {
+					// Forged unsigned A for cloudflare.com (a signed public domain), no RRSIG, and
+					// no DS/NSEC proofs for the auxiliary chain queries.
+					mokka, err = createDNSMokkaContainer(ctx, "moka-root-bypass", e2eNet,
+						`A cloudflare.com/NOERROR("A 203.0.113.77 300")`)
+					Expect(err).Should(Succeed())
+
+					blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(`
+						upstreams:
+						  groups:
+						    default:
+						      - moka-root-bypass
+						dnssec:
+						  validate: true
+						caching:
+						  minTime: 5m
+						log:
+						  level: debug
+						`))
+					Expect(err).Should(Succeed())
+				})
+
+				It("rejects the forged answer and does not replay it from cache after the upstream is gone",
+					func(ctx context.Context) {
+						msg := util.NewMsgWithQuestion("cloudflare.com.", A)
+						msg.SetEdns0(4096, true) // DO bit
+
+						resp, err := doDNSRequest(ctx, blocky, msg)
+						Expect(err).Should(Succeed())
+						Expect(resp.Rcode).Should(Equal(dns.RcodeServerFailure),
+							"forged unsigned answer accepted under the default root anchor")
+						Expect(resp.Answer).ShouldNot(ContainElement(
+							BeDNSRecord("cloudflare.com.", A, "203.0.113.77")))
+
+						// The malicious upstream disappears; any later answer comes from the cache.
+						Expect(mokka.Terminate(ctx)).Should(Succeed())
+
+						resp, err = doDNSRequest(ctx, blocky, msg)
+						Expect(err).Should(Succeed())
+						Expect(resp.Answer).ShouldNot(ContainElement(
+							BeDNSRecord("cloudflare.com.", A, "203.0.113.77")),
+							"forged unsigned answer replayed from cache after upstream shutdown")
+					})
+			})
+
 			When("DNSSEC validation is disabled", func() {
 				BeforeEach(func(ctx context.Context) {
 					// Note: Using .example TLD instead of .test (SUDN resolver blocks .test)

--- a/e2e/dnssec_test.go
+++ b/e2e/dnssec_test.go
@@ -307,6 +307,105 @@ var _ = Describe("DNSSEC validation", Label("dnssec"), func() {
 				})
 			})
 
+			When("upstream returns an unsigned answer for a DNSSEC-signed zone", func() {
+				var signed *DNSSECTestData
+
+				BeforeEach(func(ctx context.Context) {
+					// example. is a DNSSEC-signed zone; its KSK is installed as a trust
+					// anchor so blocky knows the zone is signed. An unsigned answer below
+					// it must therefore be treated as bogus, not insecure.
+					var genErr error
+					signed, genErr = GenerateValidDNSSEC("example.", "www.example.", "192.0.2.10")
+					Expect(genErr).Should(Succeed())
+
+					// Upstream returns a forged A record with no RRSIG.
+					_, err = createDNSMokkaContainer(ctx, "moka-unsigned", e2eNet,
+						`A www.example/NOERROR("A 203.0.113.77 300")`)
+					Expect(err).Should(Succeed())
+
+					blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(`
+						upstreams:
+						  groups:
+						    default:
+						      - moka-unsigned
+						dnssec:
+						  validate: true
+						  trustAnchors:
+						    - "`+signed.DNSKEY.String()+`"
+						log:
+						  level: debug
+						`))
+					Expect(err).Should(Succeed())
+				})
+
+				It("should reject the unsigned answer and return SERVFAIL", func(ctx context.Context) {
+					msg := util.NewMsgWithQuestion("www.example.", A)
+					msg.SetEdns0(4096, true) // DO bit
+
+					resp, err := doDNSRequest(ctx, blocky, msg)
+					Expect(err).Should(Succeed())
+
+					Expect(resp.Rcode).Should(Equal(dns.RcodeServerFailure),
+						"unsigned answer accepted for a DNSSEC-signed zone")
+					Expect(resp.AuthenticatedData).Should(BeFalse())
+					Expect(resp.Answer).ShouldNot(ContainElement(
+						BeDNSRecord("www.example.", A, "203.0.113.77")))
+				})
+			})
+
+			When("an unsigned answer for a signed zone has been cached", func() {
+				var (
+					signed *DNSSECTestData
+					mokka  testcontainers.Container
+				)
+
+				BeforeEach(func(ctx context.Context) {
+					var genErr error
+					signed, genErr = GenerateValidDNSSEC("example.", "www.example.", "192.0.2.10")
+					Expect(genErr).Should(Succeed())
+
+					mokka, err = createDNSMokkaContainer(ctx, "moka-cache", e2eNet,
+						`A www.example/NOERROR("A 203.0.113.77 300")`)
+					Expect(err).Should(Succeed())
+
+					blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(`
+						upstreams:
+						  groups:
+						    default:
+						      - moka-cache
+						dnssec:
+						  validate: true
+						  trustAnchors:
+						    - "`+signed.DNSKEY.String()+`"
+						caching:
+						  minTime: 5m
+						log:
+						  level: debug
+						`))
+					Expect(err).Should(Succeed())
+				})
+
+				It("should not serve the unsigned answer from cache after the upstream is gone",
+					func(ctx context.Context) {
+						msg := util.NewMsgWithQuestion("www.example.", A)
+						msg.SetEdns0(4096, true) // DO bit
+
+						// First query populates the cache.
+						_, err := doDNSRequest(ctx, blocky, msg)
+						Expect(err).Should(Succeed())
+
+						// The upstream disappears; any later answer comes from the cache.
+						Expect(mokka.Terminate(ctx)).Should(Succeed())
+
+						resp, err := doDNSRequest(ctx, blocky, msg)
+						Expect(err).Should(Succeed())
+
+						Expect(resp.Answer).ShouldNot(ContainElement(
+							BeDNSRecord("www.example.", A, "203.0.113.77")),
+							"forged unsigned answer replayed from cache after upstream shutdown")
+					})
+			})
+
 			When("DNSSEC validation is disabled", func() {
 				BeforeEach(func(ctx context.Context) {
 					// Note: Using .example TLD instead of .test (SUDN resolver blocks .test)

--- a/resolver/dnssec/chain.go
+++ b/resolver/dnssec/chain.go
@@ -581,10 +581,10 @@ func (v *Validator) validateDSAbsenceProof(domain string, dsResponse *dns.Msg, h
 }
 
 // nsecProvesInsecureDelegation reports whether an NSEC RR matching domain asserts an insecure
-// delegation per RFC 6840 §4.4: to prove DS absence for a delegation the matching NSEC MUST
-// have the NS bit set and MUST NOT have the SOA or DS bits set. This distinguishes a genuine
-// unsigned delegation from an ordinary name inside a signed zone (NS bit clear) or the apex of
-// a signed zone (SOA bit set), neither of which may be treated as an insecure delegation.
+// delegation per RFC 6840 §4.4 (the NS-set/SOA-clear/DS-clear rule shared with NSEC3 via
+// assertsInsecureDelegation). This distinguishes a genuine unsigned delegation from an ordinary
+// name inside a signed zone or the apex of a signed zone, neither of which may be treated as an
+// insecure delegation when proving DS absence.
 func (v *Validator) nsecProvesInsecureDelegation(nsecRecords []*dns.NSEC, domain string) bool {
 	domain = dns.Fqdn(domain)
 	for _, nsec := range nsecRecords {
@@ -592,11 +592,7 @@ func (v *Validator) nsecProvesInsecureDelegation(nsecRecords []*dns.NSEC, domain
 			continue
 		}
 
-		hasNS := slices.Contains(nsec.TypeBitMap, dns.TypeNS)
-		hasSOA := slices.Contains(nsec.TypeBitMap, dns.TypeSOA)
-		hasDS := slices.Contains(nsec.TypeBitMap, dns.TypeDS)
-
-		return hasNS && !hasSOA && !hasDS
+		return assertsInsecureDelegation(nsec.TypeBitMap)
 	}
 
 	return false

--- a/resolver/dnssec/chain.go
+++ b/resolver/dnssec/chain.go
@@ -13,9 +13,31 @@ import (
 	"github.com/miekg/dns"
 )
 
-// getCachedValidation retrieves a cached validation result
-func (v *Validator) getCachedValidation(domain string) (ValidationResult, bool) {
-	result, _ := v.validationCache.Get(domain)
+// validationCacheKey scopes a cached validation result to the originating client's view
+// (the same identity that selects the upstream group for DS/DNSKEY sub-queries). Per
+// GHSA-x845-2f78-7v36 finding 3 the cache must NOT be keyed by bare domain name: a status
+// established for one view (conditional-forwarding branch, split-horizon, or upstream group)
+// must not be reused for another. Requests without a client context share the empty scope.
+func validationCacheKey(ctx context.Context, domain string) string {
+	domain = dns.Fqdn(domain)
+
+	cc, ok := clientContextFrom(ctx)
+	if !ok {
+		return "\x00" + domain
+	}
+
+	var ip string
+	if cc.ip != nil {
+		ip = cc.ip.String()
+	}
+
+	return cc.clientID + "\x00" + strings.Join(cc.names, ",") + "\x00" + ip + "\x00" + domain
+}
+
+// getCachedValidation retrieves a cached validation result for the domain within the
+// originating client's view (see validationCacheKey).
+func (v *Validator) getCachedValidation(ctx context.Context, domain string) (ValidationResult, bool) {
+	result, _ := v.validationCache.Get(validationCacheKey(ctx, domain))
 	if result == nil {
 		return ValidationResultIndeterminate, false
 	}
@@ -26,9 +48,10 @@ func (v *Validator) getCachedValidation(domain string) (ValidationResult, bool) 
 	return *result, true
 }
 
-// setCachedValidation stores a validation result in the cache
-func (v *Validator) setCachedValidation(domain string, result ValidationResult) {
-	v.validationCache.Put(domain, &result, v.cacheExpiration)
+// setCachedValidation stores a validation result in the cache, scoped to the originating
+// client's view (see validationCacheKey).
+func (v *Validator) setCachedValidation(ctx context.Context, domain string, result ValidationResult) {
+	v.validationCache.Put(validationCacheKey(ctx, domain), &result, v.cacheExpiration)
 }
 
 // walkChainOfTrust walks the chain of trust from root to target domain
@@ -37,7 +60,7 @@ func (v *Validator) walkChainOfTrust(ctx context.Context, domain string) Validat
 	domain = dns.Fqdn(domain)
 
 	// Check cache first
-	if cached, found := v.getCachedValidation(domain); found {
+	if cached, found := v.getCachedValidation(ctx, domain); found {
 		v.logger.Debugf("Using cached validation result for %s: %s", domain, cached.String())
 
 		return cached
@@ -52,7 +75,7 @@ func (v *Validator) walkChainOfTrust(ctx context.Context, domain string) Validat
 		v.logger.Warnf("Domain %s exceeds maximum chain depth (%d labels > %d max), rejecting",
 			domain, len(labels), v.maxChainDepth)
 		result := ValidationResultBogus
-		v.setCachedValidation(domain, result)
+		v.setCachedValidation(ctx, domain, result)
 
 		return result
 	}
@@ -60,7 +83,7 @@ func (v *Validator) walkChainOfTrust(ctx context.Context, domain string) Validat
 	// If this is the root, verify against trust anchors
 	if domain == "." {
 		result := v.verifyAgainstTrustAnchors(ctx)
-		v.setCachedValidation(domain, result)
+		v.setCachedValidation(ctx, domain, result)
 
 		return result
 	}
@@ -81,7 +104,7 @@ func (v *Validator) walkChainOfTrust(ctx context.Context, domain string) Validat
 			// Trust anchor found - verify that actual DNSKEY from DNS matches the trust anchor
 			result := v.verifyDomainAgainstTrustAnchor(ctx, currentDomain)
 			if result != ValidationResultSecure {
-				v.setCachedValidation(domain, result)
+				v.setCachedValidation(ctx, domain, result)
 
 				return result
 			}
@@ -92,14 +115,14 @@ func (v *Validator) walkChainOfTrust(ctx context.Context, domain string) Validat
 		// Validate this level of the chain
 		result := v.validateDomainLevel(ctx, currentDomain)
 		if result != ValidationResultSecure {
-			v.setCachedValidation(domain, result)
+			v.setCachedValidation(ctx, domain, result)
 
 			return result
 		}
 	}
 
 	// Cache successful validation
-	v.setCachedValidation(domain, ValidationResultSecure)
+	v.setCachedValidation(ctx, domain, ValidationResultSecure)
 
 	return ValidationResultSecure
 }
@@ -538,11 +561,45 @@ func (v *Validator) validateDSAbsenceProof(domain string, dsResponse *dns.Msg, h
 		// Validate NSEC proof of DS absence (NODATA proof)
 		nsecRecords := extractNSECRecords(dsResponse.Ns)
 
+		// A DS-absence NODATA proof only proves an INSECURE DELEGATION if the matching NSEC
+		// asserts a delegation: NS bit set, SOA and DS bits clear (RFC 6840 §4.4, RFC 4035
+		// §5.2). An NSEC for an ordinary in-zone name (NS bit clear) or a zone apex (SOA bit
+		// set) does not - the name lives inside the signed zone, so a missing-signature answer
+		// for it is bogus, not insecure (GHSA-x845-2f78-7v36 finding 4).
+		if !v.nsecProvesInsecureDelegation(nsecRecords, domain) {
+			v.logger.Warnf("NSEC DS-absence proof for %s does not assert an insecure delegation "+
+				"(NS bit clear or SOA/DS bit set) - not an unsigned delegation", domain)
+
+			return ValidationResultBogus
+		}
+
 		return v.validateNSECNODATA(nsecRecords, domain, dns.TypeDS)
 	}
 
 	// Validate NSEC3 proof of DS absence (NODATA proof)
 	return v.validateNSEC3DenialOfExistence(dsResponse, dsQuestion)
+}
+
+// nsecProvesInsecureDelegation reports whether an NSEC RR matching domain asserts an insecure
+// delegation per RFC 6840 §4.4: to prove DS absence for a delegation the matching NSEC MUST
+// have the NS bit set and MUST NOT have the SOA or DS bits set. This distinguishes a genuine
+// unsigned delegation from an ordinary name inside a signed zone (NS bit clear) or the apex of
+// a signed zone (SOA bit set), neither of which may be treated as an insecure delegation.
+func (v *Validator) nsecProvesInsecureDelegation(nsecRecords []*dns.NSEC, domain string) bool {
+	domain = dns.Fqdn(domain)
+	for _, nsec := range nsecRecords {
+		if dns.Fqdn(nsec.Header().Name) != domain {
+			continue
+		}
+
+		hasNS := slices.Contains(nsec.TypeBitMap, dns.TypeNS)
+		hasSOA := slices.Contains(nsec.TypeBitMap, dns.TypeSOA)
+		hasDS := slices.Contains(nsec.TypeBitMap, dns.TypeDS)
+
+		return hasNS && !hasSOA && !hasDS
+	}
+
+	return false
 }
 
 // findDSRRSIG finds the RRSIG for DS records in the response

--- a/resolver/dnssec/chain_test.go
+++ b/resolver/dnssec/chain_test.go
@@ -38,33 +38,33 @@ var _ = Describe("Chain of trust validation", func() {
 			domain := "example.com."
 			expectedResult := ValidationResultSecure
 
-			sut.setCachedValidation(domain, expectedResult)
+			sut.setCachedValidation(ctx, domain, expectedResult)
 
-			result, found := sut.getCachedValidation(domain)
+			result, found := sut.getCachedValidation(ctx, domain)
 			Expect(found).Should(BeTrue())
 			Expect(result).Should(Equal(expectedResult))
 		})
 
 		It("should return false when not cached", func() {
-			result, found := sut.getCachedValidation("notcached.com.")
+			result, found := sut.getCachedValidation(ctx, "notcached.com.")
 			Expect(found).Should(BeFalse())
 			Expect(result).Should(Equal(ValidationResultIndeterminate))
 		})
 
 		It("should cache different results for different domains", func() {
-			sut.setCachedValidation("secure.com.", ValidationResultSecure)
-			sut.setCachedValidation("insecure.com.", ValidationResultInsecure)
-			sut.setCachedValidation("bogus.com.", ValidationResultBogus)
+			sut.setCachedValidation(ctx, "secure.com.", ValidationResultSecure)
+			sut.setCachedValidation(ctx, "insecure.com.", ValidationResultInsecure)
+			sut.setCachedValidation(ctx, "bogus.com.", ValidationResultBogus)
 
-			result1, found1 := sut.getCachedValidation("secure.com.")
+			result1, found1 := sut.getCachedValidation(ctx, "secure.com.")
 			Expect(found1).Should(BeTrue())
 			Expect(result1).Should(Equal(ValidationResultSecure))
 
-			result2, found2 := sut.getCachedValidation("insecure.com.")
+			result2, found2 := sut.getCachedValidation(ctx, "insecure.com.")
 			Expect(found2).Should(BeTrue())
 			Expect(result2).Should(Equal(ValidationResultInsecure))
 
-			result3, found3 := sut.getCachedValidation("bogus.com.")
+			result3, found3 := sut.getCachedValidation(ctx, "bogus.com.")
 			Expect(found3).Should(BeTrue())
 			Expect(result3).Should(Equal(ValidationResultBogus))
 		})
@@ -75,9 +75,9 @@ var _ = Describe("Chain of trust validation", func() {
 			domain := "example.com."
 			result := ValidationResultSecure
 
-			sut.setCachedValidation(domain, result)
+			sut.setCachedValidation(ctx, domain, result)
 
-			cached, found := sut.getCachedValidation(domain)
+			cached, found := sut.getCachedValidation(ctx, domain)
 			Expect(found).Should(BeTrue())
 			Expect(cached).Should(Equal(result))
 		})
@@ -85,10 +85,10 @@ var _ = Describe("Chain of trust validation", func() {
 		It("should overwrite existing cache entries", func() {
 			domain := "example.com."
 
-			sut.setCachedValidation(domain, ValidationResultSecure)
-			sut.setCachedValidation(domain, ValidationResultBogus)
+			sut.setCachedValidation(ctx, domain, ValidationResultSecure)
+			sut.setCachedValidation(ctx, domain, ValidationResultBogus)
 
-			cached, found := sut.getCachedValidation(domain)
+			cached, found := sut.getCachedValidation(ctx, domain)
 			Expect(found).Should(BeTrue())
 			Expect(cached).Should(Equal(ValidationResultBogus))
 		})
@@ -479,7 +479,7 @@ var _ = Describe("Chain of trust validation", func() {
 	Describe("walkChainOfTrust", func() {
 		It("should return cached result if available", func() {
 			domain := "example.com."
-			sut.setCachedValidation(domain, ValidationResultSecure)
+			sut.setCachedValidation(ctx, domain, ValidationResultSecure)
 
 			result := sut.walkChainOfTrust(ctx, domain)
 			Expect(result).Should(Equal(ValidationResultSecure))
@@ -498,7 +498,7 @@ var _ = Describe("Chain of trust validation", func() {
 
 		It("should normalize domain to FQDN", func() {
 			domain := "example.com"
-			sut.setCachedValidation("example.com.", ValidationResultSecure)
+			sut.setCachedValidation(ctx, "example.com.", ValidationResultSecure)
 
 			result := sut.walkChainOfTrust(ctx, domain)
 			Expect(result).Should(Equal(ValidationResultSecure))

--- a/resolver/dnssec/nsec3.go
+++ b/resolver/dnssec/nsec3.go
@@ -260,12 +260,23 @@ func (v *Validator) checkDirectNSEC3Match(nsec3Records []*dns.NSEC3, qname, qnam
 	return ValidationResultIndeterminate
 }
 
+// assertsInsecureDelegation reports whether an NSEC/NSEC3 type bitmap proves an insecure
+// delegation per RFC 6840 §4.4 / RFC 5155 §8.9: the NS bit MUST be set and the SOA and DS
+// bits MUST be clear. This single rule distinguishes a genuine unsigned delegation from an
+// ordinary name inside a signed zone (NS bit clear) or the apex of a signed zone (SOA bit
+// set), neither of which may be treated as an insecure delegation when proving DS absence.
+// It is the shared core of nsec3AssertsDelegation and nsecProvesInsecureDelegation so the
+// rule cannot drift between the NSEC and NSEC3 code paths (GHSA-x845-2f78-7v36 finding 4).
+func assertsInsecureDelegation(typeBitMap []uint16) bool {
+	return slices.Contains(typeBitMap, dns.TypeNS) &&
+		!slices.Contains(typeBitMap, dns.TypeSOA) &&
+		!slices.Contains(typeBitMap, dns.TypeDS)
+}
+
 // nsec3AssertsDelegation reports whether an NSEC3 RR asserts an insecure delegation per
-// RFC 5155 §8.9: the NS bit MUST be set and the SOA and DS bits MUST be clear.
+// RFC 5155 §8.9 (see assertsInsecureDelegation).
 func nsec3AssertsDelegation(nsec3 *dns.NSEC3) bool {
-	return slices.Contains(nsec3.TypeBitMap, dns.TypeNS) &&
-		!slices.Contains(nsec3.TypeBitMap, dns.TypeSOA) &&
-		!slices.Contains(nsec3.TypeBitMap, dns.TypeDS)
+	return assertsInsecureDelegation(nsec3.TypeBitMap)
 }
 
 // checkWildcardNSEC3Match checks for wildcard NODATA proof
@@ -302,6 +313,17 @@ func (v *Validator) checkWildcardNSEC3Match(nsec3Records []*dns.NSEC3, qname str
 		if len(labels) > 0 && strings.EqualFold(labels[0], wildcardHash) {
 			// Found wildcard NSEC3 - check type bitmap
 			if slices.Contains(nsec3.TypeBitMap, qtype) {
+				return ValidationResultBogus
+			}
+
+			// RFC 5155 §8.9: as with a direct match (see checkDirectNSEC3Match), a wildcard
+			// NODATA proof only proves an insecure delegation when the NSEC3 asserts a
+			// delegation - NS bit set, SOA and DS bits clear. Without it, a missing-DS answer
+			// for an in-zone name is bogus, not insecure (GHSA-x845-2f78-7v36 finding 4).
+			if qtype == dns.TypeDS && !nsec3AssertsDelegation(nsec3) {
+				v.logger.Warnf("NSEC3 wildcard DS-absence proof for %s does not assert an insecure "+
+					"delegation (NS bit clear or SOA bit set)", qname)
+
 				return ValidationResultBogus
 			}
 

--- a/resolver/dnssec/nsec3.go
+++ b/resolver/dnssec/nsec3.go
@@ -239,6 +239,17 @@ func (v *Validator) checkDirectNSEC3Match(nsec3Records []*dns.NSEC3, qname, qnam
 				return ValidationResultBogus
 			}
 
+			// RFC 5155 §8.9: a matching NSEC3 proves an insecure delegation (DS absence) only
+			// if it asserts a delegation - NS bit set, SOA and DS bits clear. An NSEC3 for an
+			// in-zone name (NS clear) or a zone apex (SOA set) must not be read as an unsigned
+			// delegation (GHSA-x845-2f78-7v36 finding 4).
+			if qtype == dns.TypeDS && !nsec3AssertsDelegation(nsec3) {
+				v.logger.Warnf("NSEC3 DS-absence proof for %s does not assert an insecure delegation "+
+					"(NS bit clear or SOA bit set)", qname)
+
+				return ValidationResultBogus
+			}
+
 			// Matching NSEC3 found and type not in bitmap - valid NODATA
 			v.logger.Debugf("NSEC3 NODATA proof validated for %s type %d", qname, qtype)
 
@@ -247,6 +258,14 @@ func (v *Validator) checkDirectNSEC3Match(nsec3Records []*dns.NSEC3, qname, qnam
 	}
 
 	return ValidationResultIndeterminate
+}
+
+// nsec3AssertsDelegation reports whether an NSEC3 RR asserts an insecure delegation per
+// RFC 5155 §8.9: the NS bit MUST be set and the SOA and DS bits MUST be clear.
+func nsec3AssertsDelegation(nsec3 *dns.NSEC3) bool {
+	return slices.Contains(nsec3.TypeBitMap, dns.TypeNS) &&
+		!slices.Contains(nsec3.TypeBitMap, dns.TypeSOA) &&
+		!slices.Contains(nsec3.TypeBitMap, dns.TypeDS)
 }
 
 // checkWildcardNSEC3Match checks for wildcard NODATA proof

--- a/resolver/dnssec/nsec3_test.go
+++ b/resolver/dnssec/nsec3_test.go
@@ -2146,6 +2146,91 @@ var _ = Describe("NSEC3 validation", func() {
 			// Should return Bogus when no wildcard found and it's not DS with opt-out
 			Expect(result).Should(Equal(ValidationResultBogus))
 		})
+
+		It("rejects a DS-absence wildcard NODATA proof that does not assert a delegation", func() {
+			// GHSA-x845-2f78-7v36 finding 4 (residual): the matching-NSEC3 guard in
+			// checkDirectNSEC3Match must apply equally to the wildcard NODATA path. A wildcard
+			// NSEC3 whose bitmap lacks the DS type proves DS-absence, but only proves an
+			// INSECURE DELEGATION if it asserts a delegation (NS set, SOA/DS clear). With the
+			// NS bit clear it is an ordinary in-zone name, so a DS query answered via this
+			// wildcard match must be Bogus, not Secure.
+			zoneName := "example.com."
+			qname := "wild.example.com."
+
+			hashZone, err := sut.computeNSEC3Hash(zoneName, dns.SHA1, "", 0)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			hashWildcard, err := sut.computeNSEC3Hash("*.example.com.", dns.SHA1, "", 0)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			hashQuery, err := sut.computeNSEC3Hash(qname, dns.SHA1, "", 0)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// NSEC3 for the zone apex (closest encloser).
+			nsec3Zone := &dns.NSEC3{
+				Hdr:        dns.RR_Header{Name: hashZone + ".example.com.", Rrtype: dns.TypeNSEC3},
+				Hash:       dns.SHA1,
+				Salt:       "",
+				Iterations: 0,
+			}
+
+			// Wildcard NSEC3 without the DS type AND without the NS bit: it does not assert a
+			// delegation, so it must not be read as proof of an insecure delegation.
+			nsec3Wildcard := &dns.NSEC3{
+				Hdr:        dns.RR_Header{Name: hashWildcard + ".example.com.", Rrtype: dns.TypeNSEC3},
+				Hash:       dns.SHA1,
+				Salt:       "",
+				Iterations: 0,
+				TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG}, // in-zone name: NS bit absent
+			}
+
+			result := sut.checkWildcardNSEC3Match(
+				[]*dns.NSEC3{nsec3Zone, nsec3Wildcard}, qname, dns.TypeDS,
+				zoneName, dns.SHA1, "", 0, hashQuery,
+			)
+
+			Expect(result).ShouldNot(Equal(ValidationResultSecure),
+				"wildcard NSEC3 without the NS bit was accepted as proof of an insecure delegation")
+		})
+
+		It("accepts a DS-absence wildcard NODATA proof that asserts a delegation", func() {
+			// The guard above must not over-reject: a wildcard NSEC3 with the NS bit set and
+			// the SOA/DS bits clear is a valid insecure-delegation proof and must still validate.
+			zoneName := "example.com."
+			qname := "wild.example.com."
+
+			hashZone, err := sut.computeNSEC3Hash(zoneName, dns.SHA1, "", 0)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			hashWildcard, err := sut.computeNSEC3Hash("*.example.com.", dns.SHA1, "", 0)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			hashQuery, err := sut.computeNSEC3Hash(qname, dns.SHA1, "", 0)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			nsec3Zone := &dns.NSEC3{
+				Hdr:        dns.RR_Header{Name: hashZone + ".example.com.", Rrtype: dns.TypeNSEC3},
+				Hash:       dns.SHA1,
+				Salt:       "",
+				Iterations: 0,
+			}
+
+			nsec3Wildcard := &dns.NSEC3{
+				Hdr:        dns.RR_Header{Name: hashWildcard + ".example.com.", Rrtype: dns.TypeNSEC3},
+				Hash:       dns.SHA1,
+				Salt:       "",
+				Iterations: 0,
+				TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG}, // delegation present, DS absent
+			}
+
+			result := sut.checkWildcardNSEC3Match(
+				[]*dns.NSEC3{nsec3Zone, nsec3Wildcard}, qname, dns.TypeDS,
+				zoneName, dns.SHA1, "", 0, hashQuery,
+			)
+
+			Expect(result).Should(Equal(ValidationResultSecure),
+				"valid insecure-delegation wildcard NSEC3 was wrongly rejected as a DS-absence proof")
+		})
 	})
 
 	Describe("validateNSEC3NXDOMAIN - extended error paths", func() {

--- a/resolver/dnssec/query.go
+++ b/resolver/dnssec/query.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/0xERR0R/blocky/model"
 	"github.com/miekg/dns"
@@ -13,6 +14,32 @@ import (
 
 // queryBudgetKey is the context key for tracking upstream query budget
 type queryBudgetKey struct{}
+
+// clientContextKey is the context key carrying the originating client's identity so
+// that DNSSEC auxiliary (DS/DNSKEY) sub-queries resolve from the same upstream view
+// as the user-facing answer.
+type clientContextKey struct{}
+
+// clientContext holds the originating client's identity for DNSSEC sub-queries.
+type clientContext struct {
+	ip       net.IP
+	names    []string
+	clientID string
+}
+
+// WithClientContext returns a context carrying the originating client's identity so
+// DNSSEC auxiliary queries issued during validation preserve it. Called by the DNSSEC
+// resolver before validating a response.
+func WithClientContext(ctx context.Context, ip net.IP, names []string, clientID string) context.Context {
+	return context.WithValue(ctx, clientContextKey{}, clientContext{ip: ip, names: names, clientID: clientID})
+}
+
+// clientContextFrom extracts the originating client's identity from the context.
+func clientContextFrom(ctx context.Context) (clientContext, bool) {
+	cc, ok := ctx.Value(clientContextKey{}).(clientContext)
+
+	return cc, ok
+}
 
 // consumeQueryBudget decrements the query budget and returns error if budget is exhausted
 // This provides DoS protection by limiting the number of upstream queries per validation
@@ -59,10 +86,16 @@ func (v *Validator) queryRecords(
 	msg.SetQuestion(domain, qtype)
 	msg.SetEdns0(ednsUDPSize, true) // Set DO bit for DNSSEC
 
-	// Create model request
+	// Create model request, preserving the originating client's identity so the
+	// upstream tree selects the same group/view as the user-facing answer.
 	req := &model.Request{
 		Req:      msg,
 		Protocol: model.RequestProtocolUDP,
+	}
+	if cc, ok := clientContextFrom(ctx); ok {
+		req.ClientIP = cc.ip
+		req.ClientNames = cc.names
+		req.RequestClientID = cc.clientID
 	}
 
 	// Query upstream

--- a/resolver/dnssec/trust_anchor.go
+++ b/resolver/dnssec/trust_anchor.go
@@ -66,12 +66,6 @@ type TrustAnchor struct {
 // TrustAnchorStore manages DNSSEC trust anchors
 type TrustAnchorStore struct {
 	anchors map[string][]*TrustAnchor // keyed by domain name
-	// configured holds the domains for which the operator explicitly supplied a trust
-	// anchor. It deliberately excludes the implicit default root anchor: an operator
-	// anchor is an assertion "this specific zone is signed" (so unsigned answers for it
-	// can be rejected), whereas the default root anchor covers the whole namespace -
-	// most of which is legitimately unsigned - and must not trigger fail-closed behavior.
-	configured map[string]struct{}
 }
 
 // NewTrustAnchorStore creates a new trust anchor store with the given trust anchors.
@@ -89,22 +83,19 @@ type TrustAnchorStore struct {
 // Returns a configured trust anchor store or an error if any anchor is invalid.
 func NewTrustAnchorStore(customAnchors []string) (*TrustAnchorStore, error) {
 	store := &TrustAnchorStore{
-		anchors:    make(map[string][]*TrustAnchor),
-		configured: make(map[string]struct{}),
+		anchors: make(map[string][]*TrustAnchor),
 	}
 
-	// Load custom trust anchors if provided, otherwise use defaults. Only operator-supplied
-	// anchors are recorded as "configured"; the implicit default root anchor is not, so it
-	// does not make every name appear to live under a trust anchor (see HasConfiguredTrustAnchor).
-	operatorConfigured := len(customAnchors) > 0
-
+	// Load custom trust anchors if provided, otherwise use the default IANA root KSK. Both
+	// kinds are secure entry points: any name below a trust anchor (the root anchor included)
+	// is presumed secure until an authenticated insecure-delegation proof says otherwise.
 	anchors := customAnchors
 	if len(anchors) == 0 {
 		anchors = getDefaultRootTrustAnchors()
 	}
 
 	for _, anchor := range anchors {
-		if err := store.addTrustAnchor(anchor, operatorConfigured); err != nil {
+		if err := store.AddTrustAnchor(anchor); err != nil {
 			return nil, fmt.Errorf("failed to load trust anchor: %w", err)
 		}
 	}
@@ -112,14 +103,8 @@ func NewTrustAnchorStore(customAnchors []string) (*TrustAnchorStore, error) {
 	return store, nil
 }
 
-// AddTrustAnchor adds an operator-configured trust anchor from a DNSKEY record string.
+// AddTrustAnchor adds a trust anchor from a DNSKEY record string.
 func (s *TrustAnchorStore) AddTrustAnchor(anchorStr string) error {
-	return s.addTrustAnchor(anchorStr, true)
-}
-
-// addTrustAnchor adds a trust anchor; configured marks it as operator-supplied (as opposed
-// to the implicit default root anchor) for HasConfiguredTrustAnchor.
-func (s *TrustAnchorStore) addTrustAnchor(anchorStr string, configured bool) error {
 	// Parse the DNSKEY record
 	rr, err := dns.NewRR(anchorStr)
 	if err != nil {
@@ -145,24 +130,8 @@ func (s *TrustAnchorStore) addTrustAnchor(anchorStr string, configured bool) err
 	}
 
 	s.anchors[domain] = append(s.anchors[domain], anchor)
-	if configured {
-		if s.configured == nil {
-			s.configured = make(map[string]struct{})
-		}
-		s.configured[domain] = struct{}{}
-	}
 
 	return nil
-}
-
-// HasConfiguredTrustAnchor reports whether the operator explicitly configured a trust
-// anchor for the domain. Unlike HasTrustAnchor it excludes the implicit default root
-// anchor, so it answers "did the operator assert that this specific zone is signed?".
-func (s *TrustAnchorStore) HasConfiguredTrustAnchor(domain string) bool {
-	domain = strings.ToLower(dns.Fqdn(domain))
-	_, ok := s.configured[domain]
-
-	return ok
 }
 
 // GetTrustAnchors returns trust anchors for a domain

--- a/resolver/dnssec/trust_anchor.go
+++ b/resolver/dnssec/trust_anchor.go
@@ -66,6 +66,12 @@ type TrustAnchor struct {
 // TrustAnchorStore manages DNSSEC trust anchors
 type TrustAnchorStore struct {
 	anchors map[string][]*TrustAnchor // keyed by domain name
+	// configured holds the domains for which the operator explicitly supplied a trust
+	// anchor. It deliberately excludes the implicit default root anchor: an operator
+	// anchor is an assertion "this specific zone is signed" (so unsigned answers for it
+	// can be rejected), whereas the default root anchor covers the whole namespace -
+	// most of which is legitimately unsigned - and must not trigger fail-closed behavior.
+	configured map[string]struct{}
 }
 
 // NewTrustAnchorStore creates a new trust anchor store with the given trust anchors.
@@ -83,17 +89,22 @@ type TrustAnchorStore struct {
 // Returns a configured trust anchor store or an error if any anchor is invalid.
 func NewTrustAnchorStore(customAnchors []string) (*TrustAnchorStore, error) {
 	store := &TrustAnchorStore{
-		anchors: make(map[string][]*TrustAnchor),
+		anchors:    make(map[string][]*TrustAnchor),
+		configured: make(map[string]struct{}),
 	}
 
-	// Load custom trust anchors if provided, otherwise use defaults
+	// Load custom trust anchors if provided, otherwise use defaults. Only operator-supplied
+	// anchors are recorded as "configured"; the implicit default root anchor is not, so it
+	// does not make every name appear to live under a trust anchor (see HasConfiguredTrustAnchor).
+	operatorConfigured := len(customAnchors) > 0
+
 	anchors := customAnchors
 	if len(anchors) == 0 {
 		anchors = getDefaultRootTrustAnchors()
 	}
 
 	for _, anchor := range anchors {
-		if err := store.AddTrustAnchor(anchor); err != nil {
+		if err := store.addTrustAnchor(anchor, operatorConfigured); err != nil {
 			return nil, fmt.Errorf("failed to load trust anchor: %w", err)
 		}
 	}
@@ -101,8 +112,14 @@ func NewTrustAnchorStore(customAnchors []string) (*TrustAnchorStore, error) {
 	return store, nil
 }
 
-// AddTrustAnchor adds a trust anchor from a DNSKEY record string
+// AddTrustAnchor adds an operator-configured trust anchor from a DNSKEY record string.
 func (s *TrustAnchorStore) AddTrustAnchor(anchorStr string) error {
+	return s.addTrustAnchor(anchorStr, true)
+}
+
+// addTrustAnchor adds a trust anchor; configured marks it as operator-supplied (as opposed
+// to the implicit default root anchor) for HasConfiguredTrustAnchor.
+func (s *TrustAnchorStore) addTrustAnchor(anchorStr string, configured bool) error {
 	// Parse the DNSKEY record
 	rr, err := dns.NewRR(anchorStr)
 	if err != nil {
@@ -128,8 +145,24 @@ func (s *TrustAnchorStore) AddTrustAnchor(anchorStr string) error {
 	}
 
 	s.anchors[domain] = append(s.anchors[domain], anchor)
+	if configured {
+		if s.configured == nil {
+			s.configured = make(map[string]struct{})
+		}
+		s.configured[domain] = struct{}{}
+	}
 
 	return nil
+}
+
+// HasConfiguredTrustAnchor reports whether the operator explicitly configured a trust
+// anchor for the domain. Unlike HasTrustAnchor it excludes the implicit default root
+// anchor, so it answers "did the operator assert that this specific zone is signed?".
+func (s *TrustAnchorStore) HasConfiguredTrustAnchor(domain string) bool {
+	domain = strings.ToLower(dns.Fqdn(domain))
+	_, ok := s.configured[domain]
+
+	return ok
 }
 
 // GetTrustAnchors returns trust anchors for a domain

--- a/resolver/dnssec/validator.go
+++ b/resolver/dnssec/validator.go
@@ -657,7 +657,7 @@ func (v *Validator) checkZoneSecurityStatus(ctx context.Context, domain string) 
 	domain = dns.Fqdn(domain)
 
 	// Check cache first - we may have already validated this zone
-	if cached, found := v.getCachedValidation(domain); found {
+	if cached, found := v.getCachedValidation(ctx, domain); found {
 		v.logger.Debugf("Using cached security status for %s: %s", domain, cached.String())
 
 		return cached
@@ -724,14 +724,17 @@ func (v *Validator) checkZoneSecurityStatus(ctx context.Context, domain string) 
 	return ValidationResultSecure
 }
 
-// isUnderConfiguredTrustAnchor reports whether domain, or any of its ancestors, has an
-// operator-configured trust anchor - i.e. the operator explicitly asserted this hierarchy
-// is DNSSEC-secured. The implicit default root anchor is deliberately excluded: it covers
-// the entire namespace (most of which is legitimately unsigned), so treating every name as
-// "under a trust anchor" would fail closed for the whole unsigned Internet.
-func (v *Validator) isUnderConfiguredTrustAnchor(domain string) bool {
+// isUnderTrustAnchor reports whether domain, or any of its ancestors, has a trust anchor -
+// including the implicit IANA root anchor installed by default. Because a validating
+// resolver must hold a secure entry point to validate at all, any name below a trust anchor
+// is presumed secure until an AUTHENTICATED proof of an insecure delegation (a signed
+// NSEC/NSEC3 DS denial) says otherwise. Under the default configuration the root anchor is
+// present, so this is true for the whole namespace - which is exactly what closes the
+// unsigned-answer bypass (GHSA-x845-2f78-7v36 finding 1): a forged unsigned answer can no
+// longer pass merely because the attacker also strips the DS/DNSKEY chain.
+func (v *Validator) isUnderTrustAnchor(domain string) bool {
 	for d := dns.Fqdn(domain); d != ""; d = v.getParentDomain(d) {
-		if v.trustAnchors.HasConfiguredTrustAnchor(d) {
+		if v.trustAnchors.HasTrustAnchor(d) {
 			return true
 		}
 	}
@@ -741,19 +744,20 @@ func (v *Validator) isUnderConfiguredTrustAnchor(domain string) bool {
 
 // classifyUndetermined decides the security status when the chain status cannot be
 // established (no authenticated DS proof). It fails closed - Secure, so an unsigned answer
-// becomes bogus - only for names under an operator-configured trust anchor, where the
-// operator has asserted the hierarchy is signed. Otherwise it stays Indeterminate (the
-// answer passes through) so that an unreachable upstream or a stripped proof does not turn
-// ordinary unsigned domains into SERVFAIL. This is NOT cached: it is not derived from an
-// authenticated proof.
+// becomes bogus - for any name under a trust anchor (including the default root anchor),
+// because a name below a secure entry point must be proven insecure by an AUTHENTICATED
+// denial of existence before its unsigned answer may be trusted. Only names with no trust
+// anchor anywhere in their hierarchy stay Indeterminate (the answer passes through). This is
+// NOT cached: it is not derived from an authenticated proof, so a later reachable upstream
+// can still establish the real status.
 func (v *Validator) classifyUndetermined(domain string) ValidationResult {
-	if v.isUnderConfiguredTrustAnchor(domain) {
-		v.logger.Debugf("Zone %s status undetermined but under a configured trust anchor - secure (fail closed)", domain)
+	if v.isUnderTrustAnchor(domain) {
+		v.logger.Debugf("Zone %s status undetermined but under a trust anchor - secure (fail closed)", domain)
 
 		return ValidationResultSecure
 	}
 
-	v.logger.Debugf("Zone %s status indeterminate (no configured trust anchor in hierarchy)", domain)
+	v.logger.Debugf("Zone %s status indeterminate (no trust anchor in hierarchy)", domain)
 
 	return ValidationResultIndeterminate
 }
@@ -773,7 +777,7 @@ func (v *Validator) handleNoDSRecords(
 			// Authenticated proof that no DS exists: genuine insecure delegation.
 			v.logger.Debugf("Zone %s is insecure (authenticated NSEC/NSEC3 DS denial)", domain)
 			result := ValidationResultInsecure
-			v.setCachedValidation(domain, result)
+			v.setCachedValidation(ctx, domain, result)
 
 			return result
 		}
@@ -792,7 +796,7 @@ func (v *Validator) handleNoDSRecords(
 			// Below an insecure delegation - this name is also unsigned.
 			v.logger.Debugf("Parent zone %s is insecure, so %s is also insecure", parentDomain, domain)
 			result := ValidationResultInsecure
-			v.setCachedValidation(domain, result)
+			v.setCachedValidation(ctx, domain, result)
 
 			return result
 		}

--- a/resolver/dnssec/validator.go
+++ b/resolver/dnssec/validator.go
@@ -711,7 +711,8 @@ func (v *Validator) checkZoneSecurityStatus(ctx context.Context, domain string) 
 		return v.classifyUndetermined(domain)
 	}
 
-	if res := v.validateDSRecordSignature(ctx, domain, parentDomain, convertDSToRRset(dsRecords), dsRRSIG); res != ValidationResultSecure {
+	res := v.validateDSRecordSignature(ctx, domain, parentDomain, convertDSToRRset(dsRecords), dsRRSIG)
+	if res != ValidationResultSecure {
 		v.logger.Warnf("DS RRSIG for %s failed validation (%s) - not treating zone as secure", domain, res.String())
 
 		return v.classifyUndetermined(domain)
@@ -807,7 +808,7 @@ func (v *Validator) handleNoDSRecords(
 			// forged unsigned answer), so defer to the trust-anchor-aware default: fail
 			// closed only when the operator explicitly anchored this hierarchy, otherwise
 			// stay indeterminate. Do NOT cache - not derived from an authenticated proof.
-			v.logger.Debugf("Parent zone %s is secure but %s has no authenticated DS denial - undetermined", parentDomain, domain)
+			v.logger.Debugf("Parent zone %s secure but %s has no authenticated DS denial - undetermined", parentDomain, domain)
 
 			return v.classifyUndetermined(domain)
 		}
@@ -837,10 +838,7 @@ func (v *Validator) isAuthenticatedDSDenial(ctx context.Context, domain string, 
 	// unsigned children, so rejecting the Insecure result would wrongly treat the bulk of
 	// the unsigned Internet as bogus.
 	hasNSEC := len(extractNSECRecords(dsResponse.Ns)) > 0
-	switch v.validateDSAbsenceProof(domain, dsResponse, hasNSEC) {
-	case ValidationResultSecure, ValidationResultInsecure:
-		return true
-	default:
-		return false
-	}
+	proof := v.validateDSAbsenceProof(domain, dsResponse, hasNSEC)
+
+	return proof == ValidationResultSecure || proof == ValidationResultInsecure
 }

--- a/resolver/dnssec/validator.go
+++ b/resolver/dnssec/validator.go
@@ -224,8 +224,10 @@ func (v *Validator) ValidateResponse(
 	// Dispatch to appropriate validator based on response type
 	switch {
 	case !v.hasAnySignatures(response):
-		v.logger.Debugf("No RRSIG records found for %s - zone is unsigned", question.Name)
-		result = ValidationResultInsecure
+		// A response with no RRSIGs does NOT automatically mean the zone is unsigned.
+		// Determine the zone's security status first: if the zone is signed (chains to
+		// a trust anchor) then a missing-signature answer is forged, not insecure.
+		result = v.classifyUnsignedResponse(ctx, question)
 	case len(response.Answer) > 0:
 		result = v.validateAnswer(ctx, response, question)
 	case v.isNegativeResponse(response):
@@ -246,6 +248,25 @@ func (v *Validator) hasAnySignatures(response *dns.Msg) bool {
 	return len(extractRRSIGs(response.Answer)) > 0 ||
 		len(extractRRSIGs(response.Ns)) > 0 ||
 		len(extractRRSIGs(response.Extra)) > 0
+}
+
+// classifyUnsignedResponse determines the validation result for a response that
+// carries no RRSIG records. Per RFC 4035 §5.2 the absence of signatures only means
+// "insecure" if the queried name is provably below an insecure delegation. If the
+// enclosing zone is secure (chains to a trust anchor) with no authenticated proof of
+// an insecure delegation, an unsigned answer is bogus, not insecure.
+func (v *Validator) classifyUnsignedResponse(ctx context.Context, question dns.Question) ValidationResult {
+	status := v.checkZoneSecurityStatus(ctx, question.Name)
+	if status == ValidationResultSecure {
+		v.logger.Warnf("No RRSIG for %s but zone is secure - treating unsigned answer as bogus", question.Name)
+
+		return ValidationResultBogus
+	}
+
+	// Insecure (genuinely unsigned zone) or Indeterminate (cannot determine).
+	v.logger.Debugf("No RRSIG for %s - zone status %s", question.Name, status.String())
+
+	return status
 }
 
 // validateAnswer validates the answer section of a response
@@ -642,22 +663,34 @@ func (v *Validator) checkZoneSecurityStatus(ctx context.Context, domain string) 
 		return cached
 	}
 
+	// A configured trust anchor is an operator-asserted secure entry point: by
+	// definition the zone is signed. This covers both the IANA root anchor and any
+	// custom anchor, and is what lets us reject unsigned answers for a signed zone.
+	if v.trustAnchors.HasTrustAnchor(domain) {
+		v.logger.Debugf("Domain %s has a configured trust anchor - secure", domain)
+
+		return ValidationResultSecure
+	}
+
 	// Get parent domain to query for DS records
 	parentDomain := v.getParentDomain(domain)
 	if parentDomain == "" {
-		// Root or TLD with no parent - treat as insecure for this check
-		// (actual validation would go through trust anchors)
-		v.logger.Debugf("Domain %s has no parent for DS lookup", domain)
+		// Reached the root without a configured trust anchor: security status cannot be
+		// established from the chain.
+		v.logger.Debugf("Domain %s has no parent and no trust anchor", domain)
 
-		return ValidationResultInsecure
+		return v.classifyUndetermined(domain)
 	}
 
 	// Query DS records for this domain from the parent zone
 	ctx, dsResponse, err := v.queryRecords(ctx, domain, dns.TypeDS)
 	if err != nil {
+		// Could not reach the upstream (e.g. answering from cache after the upstream is
+		// gone). Fail closed if the name lives under a trust anchor; we must not serve an
+		// unsigned answer for a secured hierarchy just because we cannot reach a resolver.
 		v.logger.Debugf("DS query failed for %s: %v", domain, err)
 
-		return ValidationResultIndeterminate
+		return v.classifyUndetermined(domain)
 	}
 
 	// Check if DS records exist
@@ -675,51 +708,94 @@ func (v *Validator) checkZoneSecurityStatus(ctx context.Context, domain string) 
 	return ValidationResultSecure
 }
 
-// handleNoDSRecords determines zone security status when no DS records are found
+// isUnderTrustAnchor reports whether domain, or any of its ancestors, has a configured
+// trust anchor - i.e. the name lives inside a hierarchy the operator expects to be
+// DNSSEC-secured.
+func (v *Validator) isUnderTrustAnchor(domain string) bool {
+	for d := dns.Fqdn(domain); d != ""; d = v.getParentDomain(d) {
+		if v.trustAnchors.HasTrustAnchor(d) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// classifyUndetermined decides the security status when the chain status cannot be
+// established (no reachable DS proof). It fails closed - Secure, so an unsigned answer
+// becomes bogus - for names under a trust anchor, and is otherwise Indeterminate. This
+// is NOT cached: it is not derived from an authenticated proof.
+func (v *Validator) classifyUndetermined(domain string) ValidationResult {
+	if v.isUnderTrustAnchor(domain) {
+		v.logger.Debugf("Zone %s status undetermined but under a trust anchor - secure (fail closed)", domain)
+
+		return ValidationResultSecure
+	}
+
+	v.logger.Debugf("Zone %s status indeterminate (no trust anchor in hierarchy)", domain)
+
+	return ValidationResultIndeterminate
+}
+
+// handleNoDSRecords determines zone security status when no DS records are found.
+// A DS NODATA response can only downgrade a zone to insecure if it carries an
+// AUTHENTICATED denial of the DS type (a signed NSEC/NSEC3 that chains to a trust
+// anchor); the mere presence of NSEC/NSEC3 records is not proof.
 func (v *Validator) handleNoDSRecords(
 	ctx context.Context, domain, parentDomain string, dsResponse *dns.Msg,
 ) ValidationResult {
-	// Check for NSEC/NSEC3 proof of absence
 	hasNSEC := len(extractNSECRecords(dsResponse.Ns)) > 0
 	hasNSEC3 := len(extractNSEC3Records(dsResponse.Ns)) > 0
 
 	if hasNSEC || hasNSEC3 {
-		// Authenticated denial of DS existence - zone is insecure (unsigned)
-		v.logger.Debugf("Zone %s is insecure (no DS, with NSEC/NSEC3 proof)", domain)
-		result := ValidationResultInsecure
-		v.setCachedValidation(domain, result)
+		if v.isAuthenticatedDSDenial(ctx, domain, dsResponse) {
+			// Authenticated proof that no DS exists: genuine insecure delegation.
+			v.logger.Debugf("Zone %s is insecure (authenticated NSEC/NSEC3 DS denial)", domain)
+			result := ValidationResultInsecure
+			v.setCachedValidation(domain, result)
 
-		return result
+			return result
+		}
+
+		// Unauthenticated/forged denial - must NOT be trusted, and must NOT be cached.
+		// Fall through and determine status from the parent zone instead.
+		v.logger.Warnf("Unauthenticated NSEC/NSEC3 in DS response for %s - ignoring as DS denial", domain)
 	}
 
-	// No DS and no proof - this might be a non-delegation (e.g., subdomain in parent zone)
-	// Try walking up to parent zone
-	v.logger.Debugf("No DS or proof for %s, checking parent zone", domain)
+	// No DS and no authenticated proof of absence. Determine status from the parent.
+	v.logger.Debugf("No authenticated DS-absence proof for %s, checking parent zone", domain)
 
 	if parentDomain != "" {
-		parentResult := v.checkZoneSecurityStatus(ctx, parentDomain)
-		if parentResult == ValidationResultInsecure {
-			// Parent zone is unsigned, so this name is also unsigned
+		parentStatus := v.checkZoneSecurityStatus(ctx, parentDomain)
+		if parentStatus == ValidationResultInsecure {
+			// Below an insecure delegation - this name is also unsigned.
 			v.logger.Debugf("Parent zone %s is insecure, so %s is also insecure", parentDomain, domain)
 			result := ValidationResultInsecure
 			v.setCachedValidation(domain, result)
 
 			return result
 		}
-		if parentResult == ValidationResultSecure {
-			// Parent is signed, so this non-delegation should have been signed too
-			v.logger.Debugf("Parent zone %s is secure but %s has no DS - treating as indeterminate", parentDomain, domain)
-			result := ValidationResultIndeterminate
-			v.setCachedValidation(domain, result)
+		if parentStatus == ValidationResultSecure {
+			// Parent is secure and there is no authenticated proof that this name is an
+			// insecure delegation: it is within a secure zone and must be signed. Do NOT
+			// cache - this status is not derived from an authenticated DS-absence proof.
+			v.logger.Debugf("Parent zone %s is secure and %s has no authenticated DS denial - secure", parentDomain, domain)
 
-			return result
+			return ValidationResultSecure
 		}
 	}
 
-	// No DS and no proof - indeterminate
-	v.logger.Debugf("Zone %s security status indeterminate (no DS, no proof)", domain)
-	result := ValidationResultIndeterminate
-	v.setCachedValidation(domain, result)
+	// No authenticated proof and no usable parent result - fall back to the
+	// trust-anchor-aware default (fail closed under a trust anchor).
+	return v.classifyUndetermined(domain)
+}
 
-	return result
+// isAuthenticatedDSDenial reports whether dsResponse carries an authenticated proof
+// (a signed NSEC/NSEC3 chaining to a trust anchor) that the DS type is absent for
+// domain - i.e. a genuine insecure delegation. Mere presence of NSEC/NSEC3 is not
+// sufficient; the records must be cryptographically validated.
+func (v *Validator) isAuthenticatedDSDenial(ctx context.Context, domain string, dsResponse *dns.Msg) bool {
+	question := dns.Question{Name: dns.Fqdn(domain), Qtype: dns.TypeDS, Qclass: dns.ClassINET}
+
+	return v.validateDenialOfExistence(ctx, dsResponse, question) == ValidationResultSecure
 }

--- a/resolver/dnssec/validator.go
+++ b/resolver/dnssec/validator.go
@@ -700,20 +700,38 @@ func (v *Validator) checkZoneSecurityStatus(ctx context.Context, domain string) 
 		return v.handleNoDSRecords(ctx, domain, parentDomain, dsResponse)
 	}
 
-	// DS records exist - zone is signed (secure)
-	v.logger.Debugf("Zone %s is secure (DS records exist: %d)", domain, len(dsRecords))
-	// Don't cache as Secure here - full validation might fail
-	// Just return Secure to indicate the zone should have signatures
+	// DS records are present, but their mere presence is not proof the zone is signed: an
+	// injected/forged DS could otherwise force an unsigned name to be classified secure and
+	// thus SERVFAIL its (legitimately unsigned) answers. Require the DS RRset to be signed
+	// by the parent zone before trusting it.
+	dsRRSIG := v.findDSRRSIG(dsResponse, domain)
+	if dsRRSIG == nil {
+		v.logger.Warnf("DS records for %s are present but unsigned - not treating zone as secure", domain)
+
+		return v.classifyUndetermined(domain)
+	}
+
+	if res := v.validateDSRecordSignature(ctx, domain, parentDomain, convertDSToRRset(dsRecords), dsRRSIG); res != ValidationResultSecure {
+		v.logger.Warnf("DS RRSIG for %s failed validation (%s) - not treating zone as secure", domain, res.String())
+
+		return v.classifyUndetermined(domain)
+	}
+
+	// DS records exist and validate - zone is signed (secure).
+	v.logger.Debugf("Zone %s is secure (DS records exist and validate: %d)", domain, len(dsRecords))
+	// Don't cache as Secure here - full validation of the answer might still fail.
 
 	return ValidationResultSecure
 }
 
-// isUnderTrustAnchor reports whether domain, or any of its ancestors, has a configured
-// trust anchor - i.e. the name lives inside a hierarchy the operator expects to be
-// DNSSEC-secured.
-func (v *Validator) isUnderTrustAnchor(domain string) bool {
+// isUnderConfiguredTrustAnchor reports whether domain, or any of its ancestors, has an
+// operator-configured trust anchor - i.e. the operator explicitly asserted this hierarchy
+// is DNSSEC-secured. The implicit default root anchor is deliberately excluded: it covers
+// the entire namespace (most of which is legitimately unsigned), so treating every name as
+// "under a trust anchor" would fail closed for the whole unsigned Internet.
+func (v *Validator) isUnderConfiguredTrustAnchor(domain string) bool {
 	for d := dns.Fqdn(domain); d != ""; d = v.getParentDomain(d) {
-		if v.trustAnchors.HasTrustAnchor(d) {
+		if v.trustAnchors.HasConfiguredTrustAnchor(d) {
 			return true
 		}
 	}
@@ -722,17 +740,20 @@ func (v *Validator) isUnderTrustAnchor(domain string) bool {
 }
 
 // classifyUndetermined decides the security status when the chain status cannot be
-// established (no reachable DS proof). It fails closed - Secure, so an unsigned answer
-// becomes bogus - for names under a trust anchor, and is otherwise Indeterminate. This
-// is NOT cached: it is not derived from an authenticated proof.
+// established (no authenticated DS proof). It fails closed - Secure, so an unsigned answer
+// becomes bogus - only for names under an operator-configured trust anchor, where the
+// operator has asserted the hierarchy is signed. Otherwise it stays Indeterminate (the
+// answer passes through) so that an unreachable upstream or a stripped proof does not turn
+// ordinary unsigned domains into SERVFAIL. This is NOT cached: it is not derived from an
+// authenticated proof.
 func (v *Validator) classifyUndetermined(domain string) ValidationResult {
-	if v.isUnderTrustAnchor(domain) {
-		v.logger.Debugf("Zone %s status undetermined but under a trust anchor - secure (fail closed)", domain)
+	if v.isUnderConfiguredTrustAnchor(domain) {
+		v.logger.Debugf("Zone %s status undetermined but under a configured trust anchor - secure (fail closed)", domain)
 
 		return ValidationResultSecure
 	}
 
-	v.logger.Debugf("Zone %s status indeterminate (no trust anchor in hierarchy)", domain)
+	v.logger.Debugf("Zone %s status indeterminate (no configured trust anchor in hierarchy)", domain)
 
 	return ValidationResultIndeterminate
 }
@@ -776,12 +797,15 @@ func (v *Validator) handleNoDSRecords(
 			return result
 		}
 		if parentStatus == ValidationResultSecure {
-			// Parent is secure and there is no authenticated proof that this name is an
-			// insecure delegation: it is within a secure zone and must be signed. Do NOT
-			// cache - this status is not derived from an authenticated DS-absence proof.
-			v.logger.Debugf("Parent zone %s is secure and %s has no authenticated DS denial - secure", parentDomain, domain)
+			// Parent is secure but there is no authenticated proof that this name is an
+			// insecure delegation. We cannot positively conclude from the parent alone that
+			// the name itself is signed (the proof may have been stripped, or this may be a
+			// forged unsigned answer), so defer to the trust-anchor-aware default: fail
+			// closed only when the operator explicitly anchored this hierarchy, otherwise
+			// stay indeterminate. Do NOT cache - not derived from an authenticated proof.
+			v.logger.Debugf("Parent zone %s is secure but %s has no authenticated DS denial - undetermined", parentDomain, domain)
 
-			return ValidationResultSecure
+			return v.classifyUndetermined(domain)
 		}
 	}
 
@@ -795,7 +819,24 @@ func (v *Validator) handleNoDSRecords(
 // domain - i.e. a genuine insecure delegation. Mere presence of NSEC/NSEC3 is not
 // sufficient; the records must be cryptographically validated.
 func (v *Validator) isAuthenticatedDSDenial(ctx context.Context, domain string, dsResponse *dns.Msg) bool {
-	question := dns.Question{Name: dns.Fqdn(domain), Qtype: dns.TypeDS, Qclass: dns.ClassINET}
+	// First require the authority section (the NSEC/NSEC3 records and their RRSIGs) to
+	// cryptographically validate and chain to a trust anchor. An unsigned or forged denial
+	// proves nothing and must never downgrade a zone to insecure.
+	if v.validateRRsets(ctx, dsResponse.Ns, domain, dsResponse.Ns, domain) != ValidationResultSecure {
+		return false
+	}
 
-	return v.validateDenialOfExistence(ctx, dsResponse, question) == ValidationResultSecure
+	// With an authenticated authority section, both an explicit NSEC/NSEC3 NODATA proof
+	// (Secure) and an NSEC3 Opt-Out span covering the name (Insecure) are authenticated
+	// proofs that no DS exists - i.e. a genuine insecure (unsigned) delegation. Opt-Out is
+	// the standard mechanism by which signed TLDs (.com/.net/.org, ...) delegate to their
+	// unsigned children, so rejecting the Insecure result would wrongly treat the bulk of
+	// the unsigned Internet as bogus.
+	hasNSEC := len(extractNSECRecords(dsResponse.Ns)) > 0
+	switch v.validateDSAbsenceProof(domain, dsResponse, hasNSEC) {
+	case ValidationResultSecure, ValidationResultInsecure:
+		return true
+	default:
+		return false
+	}
 }

--- a/resolver/dnssec/validator_test.go
+++ b/resolver/dnssec/validator_test.go
@@ -2,7 +2,9 @@ package dnssec
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"errors"
+	"net"
 	"time"
 
 	"github.com/0xERR0R/blocky/log"
@@ -37,6 +39,111 @@ func (m *mockResolver) Resolve(ctx context.Context, req *model.Request) (*model.
 
 var _ Resolver = (*mockResolver)(nil) // Ensure mockResolver implements Resolver
 
+// unsignedDSDenial builds a DS response (NODATA) with no DS record and an unsigned
+// NSEC in the authority section - an unauthenticated "this delegation is insecure" proof.
+func unsignedDSDenial(name string) *model.Response {
+	nsec := &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name:   dns.Fqdn(name),
+			Rrtype: dns.TypeNSEC,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		NextDomain: "z." + dns.Fqdn(name),
+		TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC},
+	}
+
+	return &model.Response{Res: &dns.Msg{
+		MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+		Ns:     []dns.RR{nsec},
+	}}
+}
+
+// newSignedZoneKey generates a KSK for zone and returns the key, its private key, and
+// the trust-anchor presentation string.
+func newSignedZoneKey(zone string) (*dns.DNSKEY, *ecdsa.PrivateKey, string) {
+	key := new(dns.DNSKEY)
+	key.Hdr = dns.RR_Header{Name: dns.Fqdn(zone), Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600}
+	key.Flags = 257 // KSK / SEP
+	key.Protocol = 3
+	key.Algorithm = dns.ECDSAP256SHA256
+
+	priv, err := key.Generate(256)
+	Expect(err).Should(Succeed())
+
+	return key, priv.(*ecdsa.PrivateKey), key.String()
+}
+
+// signRRset signs rrset (record type rtype) with key/priv, asserting on failure.
+func signRRset(rrset []dns.RR, rtype uint16, key *dns.DNSKEY, priv *ecdsa.PrivateKey, signer string) *dns.RRSIG {
+	owner := rrset[0].Header().Name
+	sig := new(dns.RRSIG)
+	sig.Hdr = dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: rrset[0].Header().Ttl}
+	sig.TypeCovered = rtype
+	sig.Algorithm = dns.ECDSAP256SHA256
+	sig.Labels = uint8(dns.CountLabel(owner))
+	sig.OrigTtl = rrset[0].Header().Ttl
+	sig.Expiration = uint32(time.Now().Add(24 * time.Hour).Unix())
+	sig.Inception = uint32(time.Now().Add(-1 * time.Hour).Unix())
+	sig.KeyTag = key.KeyTag()
+	sig.SignerName = dns.Fqdn(signer)
+	Expect(sig.Sign(priv, rrset)).Should(Succeed())
+
+	return sig
+}
+
+// authenticatedInsecureDelegation returns a trust anchor for parentZone and a ResolveFn
+// that proves an AUTHENTICATED insecure delegation for childName: a DS query for
+// childName yields a signed NSEC NODATA proof (no DS type), and a DNSKEY query for
+// parentZone yields the matching self-signed key. checkZoneSecurityStatus(childName)
+// then authenticates DS absence and returns Insecure (a genuinely unsigned zone).
+func authenticatedInsecureDelegation(
+	parentZone, childName string,
+) (anchor string, fn func(context.Context, *model.Request) (*model.Response, error)) {
+	key, priv, anchorStr := newSignedZoneKey(parentZone)
+	dnskeySig := signRRset([]dns.RR{key}, dns.TypeDNSKEY, key, priv, parentZone)
+
+	nsec := &dns.NSEC{
+		Hdr:        dns.RR_Header{Name: dns.Fqdn(childName), Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+		NextDomain: "\\000." + dns.Fqdn(childName),
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC}, // NS delegation present, DS absent
+	}
+	nsecSig := signRRset([]dns.RR{nsec}, dns.TypeNSEC, key, priv, parentZone)
+
+	fn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+		q := req.Req.Question[0]
+		switch {
+		case q.Qtype == dns.TypeDS && dns.Fqdn(q.Name) == dns.Fqdn(childName):
+			return &model.Response{Res: &dns.Msg{
+				MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+				Ns:     []dns.RR{nsec, nsecSig},
+			}}, nil
+		case q.Qtype == dns.TypeDNSKEY && dns.Fqdn(q.Name) == dns.Fqdn(parentZone):
+			return &model.Response{Res: &dns.Msg{Answer: []dns.RR{key, dnskeySig}}}, nil
+		default:
+			return &model.Response{Res: &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}}}, nil
+		}
+	}
+
+	return anchorStr, fn
+}
+
+// dummyAnchorStore returns a trust store anchored at an unrelated zone, so test domains
+// are NOT under any trust anchor (status undetermined -> accepted as Indeterminate).
+func dummyAnchorStore() *TrustAnchorStore {
+	_, _, anchor := newSignedZoneKey("anchor.invalid.")
+	store, err := NewTrustAnchorStore([]string{anchor})
+	Expect(err).Should(Succeed())
+
+	return store
+}
+
+// benignEmptyResolve is a ResolveFn that returns an empty NOERROR for any query, so the
+// validator's sub-queries do not panic an unconfigured testify mock.
+func benignEmptyResolve(_ context.Context, _ *model.Request) (*model.Response, error) {
+	return &model.Response{Res: &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}}}, nil
+}
+
 var _ = Describe("DNSSECValidator", func() {
 	var (
 		sut          *Validator
@@ -62,6 +169,98 @@ var _ = Describe("DNSSECValidator", func() {
 
 		// Create validator with default config values
 		sut = NewValidator(ctx, trustStore, logger, mockUpstream, 1, 10, 150, 30, 3600)
+	})
+
+	Context("when an upstream supplies unsigned or out-of-context DNSSEC proofs", func() {
+		const victim = "victim.signed.example."
+
+		It("should not treat an unsigned NSEC in a DS response as authenticated denial of DS", func() {
+			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
+
+			mockUpstream.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+				if req.Req.Question[0].Qtype == dns.TypeDS {
+					return unsignedDSDenial(victim), nil
+				}
+
+				return nil, errors.New("unexpected query type")
+			}
+
+			// An unsigned NSEC proves nothing: the zone's security status must not be
+			// downgraded to Insecure on the strength of an unauthenticated denial.
+			result := sut.checkZoneSecurityStatus(budgetCtx, victim)
+
+			Expect(result).ShouldNot(Equal(ValidationResultInsecure),
+				"unsigned NSEC in a DS response accepted as authenticated DS denial")
+		})
+
+		It("should not let a cached insecure status shadow a later signed DS for the same name", func() {
+			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
+
+			// First lookup is answered with the unauthenticated insecure proof.
+			mockUpstream.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+				if req.Req.Question[0].Qtype == dns.TypeDS {
+					return unsignedDSDenial(victim), nil
+				}
+
+				return nil, errors.New("unexpected query type")
+			}
+			_ = sut.checkZoneSecurityStatus(budgetCtx, victim)
+
+			// The upstream now reports a legitimate, signed DS for the same name.
+			realDS := &dns.DS{
+				Hdr: dns.RR_Header{
+					Name:   victim,
+					Rrtype: dns.TypeDS,
+					Class:  dns.ClassINET,
+					Ttl:    300,
+				},
+				KeyTag:     12345,
+				Algorithm:  dns.ECDSAP256SHA256,
+				DigestType: dns.SHA256,
+				Digest:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			}
+			mockUpstream.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+				if req.Req.Question[0].Qtype == dns.TypeDS {
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{realDS}}}, nil
+				}
+
+				return nil, errors.New("unexpected query type")
+			}
+
+			second := sut.checkZoneSecurityStatus(budgetCtx, victim)
+
+			Expect(second).ShouldNot(Equal(ValidationResultInsecure),
+				"stale insecure status shadowed a legitimate signed DS for the same name")
+		})
+
+		It("should preserve the originating client context on DNSKEY sub-queries", func() {
+			clientIP := net.ParseIP("203.0.113.9")
+			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
+			budgetCtx = WithClientContext(budgetCtx, clientIP, []string{"client.lan"}, "client-1")
+
+			var captured *model.Request
+			mockUpstream.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+				if req.Req.Question[0].Qtype == dns.TypeDNSKEY {
+					captured = req
+
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{}}}, nil
+				}
+
+				return nil, errors.New("unexpected query type")
+			}
+
+			_, _, _ = sut.queryDNSKEY(budgetCtx, "signed.example.")
+			Expect(captured).ShouldNot(BeNil(), "no DNSKEY sub-query was issued")
+
+			// Auxiliary DS/DNSKEY lookups must carry the originating client's context so
+			// the same upstream view answers both the data and its DNSSEC proofs.
+			Expect(captured.ClientIP).Should(Equal(clientIP),
+				"auxiliary DNSSEC sub-query lost the client IP")
+			Expect(captured.ClientNames).Should(Equal([]string{"client.lan"}),
+				"auxiliary DNSSEC sub-query lost the client names")
+			Expect(captured.RequestClientID).Should(Equal("client-1"),
+				"auxiliary DNSSEC sub-query lost the request client id")
+		})
 	})
 
 	Describe("NewValidator", func() {
@@ -106,7 +305,16 @@ var _ = Describe("DNSSECValidator", func() {
 			})
 
 			It("should return Insecure", func() {
-				result := sut.ValidateResponse(ctx, response, question)
+				// example.com is a genuinely unsigned zone: prove the insecure delegation
+				// with an authenticated (signed) NSEC DS-denial under a com. trust anchor,
+				// so the unsigned answer is correctly classified Insecure rather than bogus.
+				anchor, fn := authenticatedInsecureDelegation("com.", "example.com.")
+				store, err := NewTrustAnchorStore([]string{anchor})
+				Expect(err).Should(Succeed())
+				mockUpstream.ResolveFn = fn
+
+				v := NewValidator(ctx, store, logger, mockUpstream, 1, 10, 150, 30, 3600)
+				result := v.ValidateResponse(ctx, response, question)
 				Expect(result).Should(Equal(ValidationResultInsecure))
 			})
 		})
@@ -1272,8 +1480,11 @@ var _ = Describe("DNSSECValidator", func() {
 
 	Describe("Query budget DoS protection", func() {
 		It("should track query budget in context", func() {
-			// Create validator with budget of 5 queries
-			validator := NewValidator(ctx, trustStore, logger, mockUpstream, 1, 10, 150, 5, 3600)
+			// Create validator with budget of 5 queries. The domain is not under a trust
+			// anchor, so an unsigned answer is accepted as Indeterminate (the benign mock
+			// keeps the zone-status sub-queries from panicking the testify mock).
+			mockUpstream.ResolveFn = benignEmptyResolve
+			validator := NewValidator(ctx, dummyAnchorStore(), logger, mockUpstream, 1, 10, 150, 5, 3600)
 
 			// Start validation - this initializes budget in context
 			question := dns.Question{
@@ -1299,8 +1510,8 @@ var _ = Describe("DNSSECValidator", func() {
 
 			result := validator.ValidateResponse(ctx, response, question)
 
-			// Should return Insecure for unsigned response
-			Expect(result).Should(Equal(ValidationResultInsecure))
+			// Unsigned response, domain not under a trust anchor -> accepted as Indeterminate.
+			Expect(result).Should(Equal(ValidationResultIndeterminate))
 		})
 
 		It("should fail when query budget is exhausted", func() {
@@ -1380,8 +1591,10 @@ var _ = Describe("DNSSECValidator", func() {
 
 	Describe("Max chain depth DoS protection", func() {
 		It("should accept domains within chain depth limit", func() {
-			// Create validator with max chain depth of 10
-			validator := NewValidator(ctx, trustStore, logger, mockUpstream, 1, 10, 150, 30, 3600)
+			// Create validator with max chain depth of 10. Domain is not under a trust
+			// anchor, so an unsigned answer is accepted (Indeterminate).
+			mockUpstream.ResolveFn = benignEmptyResolve
+			validator := NewValidator(ctx, dummyAnchorStore(), logger, mockUpstream, 1, 10, 150, 30, 3600)
 
 			// Create domain with 5 labels (within limit)
 			question := dns.Question{
@@ -1407,8 +1620,8 @@ var _ = Describe("DNSSECValidator", func() {
 
 			result := validator.ValidateResponse(ctx, response, question)
 
-			// Should process normally (return Insecure for unsigned)
-			Expect(result).Should(Equal(ValidationResultInsecure))
+			// Processed normally; not under a trust anchor -> accepted as Indeterminate.
+			Expect(result).Should(Equal(ValidationResultIndeterminate))
 		})
 
 		It("should reject domains exceeding chain depth limit", func() {
@@ -1471,8 +1684,10 @@ var _ = Describe("DNSSECValidator", func() {
 		})
 
 		It("should accept domain exactly at chain depth limit", func() {
-			// Create validator with max chain depth of 6
-			validator := NewValidator(ctx, trustStore, logger, mockUpstream, 1, 6, 150, 30, 3600)
+			// Create validator with max chain depth of 6. Domain is not under a trust
+			// anchor, so an unsigned answer is accepted (Indeterminate).
+			mockUpstream.ResolveFn = benignEmptyResolve
+			validator := NewValidator(ctx, dummyAnchorStore(), logger, mockUpstream, 1, 6, 150, 30, 3600)
 
 			// Create domain with exactly 6 labels (at limit)
 			question := dns.Question{
@@ -1498,8 +1713,8 @@ var _ = Describe("DNSSECValidator", func() {
 
 			result := validator.ValidateResponse(ctx, response, question)
 
-			// Should process normally (exactly at limit is OK)
-			Expect(result).Should(Equal(ValidationResultInsecure))
+			// Processed normally (exactly at limit); not under a trust anchor -> Indeterminate.
+			Expect(result).Should(Equal(ValidationResultIndeterminate))
 		})
 
 		It("should respect configured max chain depth value", func() {
@@ -3188,45 +3403,16 @@ var _ = Describe("Additional Validator Coverage", func() {
 			// 1. push.bitdefender.net (unsigned zone) -> CNAME with no RRSIG
 			// 2. Target A records also unsigned (simplified test case)
 
-			// Mock upstream responses for DS queries
-			mockUpstream.ResolveFn = func(ctx context.Context, req *model.Request) (*model.Response, error) {
-				qtype := req.Req.Question[0].Qtype
-
-				if qtype == dns.TypeDS {
-					// Return NSEC3 proof that DS does not exist (unsigned zone)
-					// This applies to any DS query in this test
-					nsec3 := &dns.NSEC3{
-						Hdr: dns.RR_Header{
-							Name:   "abc123.example.net.",
-							Rrtype: dns.TypeNSEC3,
-							Class:  dns.ClassINET,
-							Ttl:    3600,
-						},
-						Hash:       1,
-						Flags:      0,
-						Iterations: 0,
-						SaltLength: 0,
-						Salt:       "",
-						HashLength: 20,
-						NextDomain: "def456",
-						TypeBitMap: []uint16{dns.TypeNS, dns.TypeSOA, dns.TypeNSEC3},
-					}
-
-					return &model.Response{
-						Res: &dns.Msg{
-							MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
-							Ns:     []dns.RR{nsec3},
-						},
-					}, nil
-				}
-
-				// Default empty response
-				return &model.Response{
-					Res: &dns.Msg{
-						MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
-					},
-				}, nil
-			}
+			// unsigned.net is a genuinely unsigned zone: prove the insecure delegation
+			// with an AUTHENTICATED (signed) NSEC DS-denial under a net. trust anchor.
+			// (This test previously trusted an UNSIGNED NSEC3 - the forged-proof path
+			// that is now correctly rejected; an authenticated proof is required.)
+			anchor, fn := authenticatedInsecureDelegation("net.", "unsigned.net.")
+			store, err := NewTrustAnchorStore([]string{anchor})
+			Expect(err).Should(Succeed())
+			testLogger, _ := log.NewMockEntry()
+			mockUpstream.ResolveFn = fn
+			validator := NewValidator(ctx, store, testLogger, mockUpstream, 1, 10, 150, 30, 3600)
 
 			// Create response with CNAME and A records, both without RRSIG (unsigned)
 			cname := &dns.CNAME{
@@ -3266,7 +3452,7 @@ var _ = Describe("Additional Validator Coverage", func() {
 			// This test checks that when a response contains only unsigned CNAME and A records (no RRSIGs)
 			// in an unsigned zone, the validator returns Insecure (acceptable per RFC 4035).
 			// This ensures that unsigned responses in unsigned zones are not incorrectly marked as Bogus.
-			result := sut.ValidateResponse(ctx, response, question)
+			result := validator.ValidateResponse(ctx, response, question)
 
 			// The key assertion: should be Insecure since the response has no DNSSEC signatures
 			Expect(result).Should(Equal(ValidationResultInsecure))

--- a/resolver/dnssec/validator_test.go
+++ b/resolver/dnssec/validator_test.go
@@ -239,25 +239,43 @@ var _ = Describe("DNSSECValidator", func() {
 					"authenticated NSEC3 opt-out DS denial not recognized as an insecure delegation")
 		})
 
-		It("does not fail closed for unsigned answers under only the default root anchor", func() {
-			// With the default IANA root anchor (no operator-configured anchors) and an
-			// upstream that cannot supply DNSSEC proofs, an ordinary unsigned answer must
-			// pass through as Indeterminate, not be rejected as Bogus. Failing closed here
-			// would SERVFAIL the bulk of the (legitimately unsigned) Internet.
+		It("rejects an unsigned answer under the default root anchor with no authenticated insecure-delegation proof", func() {
+			// GHSA-x845-2f78-7v36 finding 1: with the default IANA root anchor every name is
+			// under a trust anchor, so the whole namespace is "secure" until an AUTHENTICATED
+			// proof of insecure delegation says otherwise. An upstream that cannot supply such
+			// a proof (malicious, stripped, or non-DNSSEC-capable) must not let a forged
+			// unsigned answer for a signed public name through: it is bogus, not insecure.
 			store, err := NewTrustAnchorStore(nil)
 			Expect(err).Should(Succeed())
 			mockUpstream.ResolveFn = benignEmptyResolve
 			v := NewValidator(ctx, store, logger, mockUpstream, 1, 10, 150, 30, 3600)
 
-			question := dns.Question{Name: "ordinary.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+			question := dns.Question{Name: "cloudflare.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 			response := &dns.Msg{Answer: []dns.RR{&dns.A{
-				Hdr: dns.RR_Header{Name: "ordinary.example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
-				A:   net.ParseIP("192.0.2.1"),
+				Hdr: dns.RR_Header{Name: "cloudflare.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP("203.0.113.77"),
 			}}}
 
 			Expect(v.ValidateResponse(ctx, response, question)).
-				Should(Equal(ValidationResultIndeterminate),
-					"unsigned answer under only the default root anchor was not passed through")
+				Should(Equal(ValidationResultBogus),
+					"forged unsigned answer under the root anchor was accepted instead of rejected as bogus")
+		})
+
+		It("still resolves a genuinely unsigned zone proven by an authenticated opt-out under the root anchor", func() {
+			// The fail-closed behavior above must NOT break legitimately unsigned zones: when
+			// the upstream supplies an AUTHENTICATED NSEC3 opt-out DS denial (the standard way
+			// signed parents delegate to unsigned children), the name is a genuine insecure
+			// delegation and its unsigned answer must pass through as Insecure, not be rejected.
+			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
+			anchor, fn := authenticatedOptOutDelegation("net.", "unsigned.net.")
+			store, err := NewTrustAnchorStore([]string{anchor})
+			Expect(err).Should(Succeed())
+			mockUpstream.ResolveFn = fn
+			v := NewValidator(ctx, store, logger, mockUpstream, 1, 10, 150, 30, 3600)
+
+			Expect(v.checkZoneSecurityStatus(budgetCtx, "unsigned.net.")).
+				Should(Equal(ValidationResultInsecure),
+					"authenticated opt-out delegation was not accepted as a genuine insecure zone")
 		})
 
 		It("should not treat an unsigned NSEC in a DS response as authenticated denial of DS", func() {
@@ -346,6 +364,58 @@ var _ = Describe("DNSSECValidator", func() {
 				"auxiliary DNSSEC sub-query lost the client names")
 			Expect(captured.RequestClientID).Should(Equal("client-1"),
 				"auxiliary DNSSEC sub-query lost the request client id")
+		})
+
+		It("rejects an NSEC DS-absence proof that does not assert a delegation (NS bit clear)", func() {
+			// GHSA-x845-2f78-7v36 finding 4 (residual): an NSEC that proves the DS type is absent
+			// only proves an INSECURE DELEGATION if it also asserts a delegation - NS bit set, SOA
+			// and DS bits clear (RFC 6840 §4.4). For an ordinary in-zone name in a signed zone the
+			// NS bit is clear, so this NSEC must NOT be accepted as a DS-absence proof; otherwise a
+			// forged unsigned answer for e.g. www.example.com could be downgraded to insecure.
+			inZoneNSEC := &dns.NSEC{
+				Hdr:        dns.RR_Header{Name: "www.example.com.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+				NextDomain: "\\000.www.example.com.",
+				TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC}, // in-zone name: NS bit absent
+			}
+			resp := &dns.Msg{Ns: []dns.RR{inZoneNSEC}}
+
+			Expect(sut.validateDSAbsenceProof("www.example.com.", resp, true)).
+				ShouldNot(Equal(ValidationResultSecure),
+					"NSEC without the NS bit was accepted as proof of an insecure delegation")
+		})
+
+		It("accepts an NSEC DS-absence proof that asserts a delegation (NS bit set, DS/SOA clear)", func() {
+			// The NS-bit check above must not over-reject genuine insecure delegations: an NSEC
+			// with the NS bit set and the SOA/DS bits clear is a valid proof of an unsigned
+			// delegation and must still validate as a DS-absence proof.
+			delegationNSEC := &dns.NSEC{
+				Hdr:        dns.RR_Header{Name: "unsigned.example.com.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+				NextDomain: "\\000.unsigned.example.com.",
+				TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC}, // delegation present, DS absent
+			}
+			resp := &dns.Msg{Ns: []dns.RR{delegationNSEC}}
+
+			Expect(sut.validateDSAbsenceProof("unsigned.example.com.", resp, true)).
+				Should(Equal(ValidationResultSecure),
+					"valid insecure-delegation NSEC was wrongly rejected as a DS-absence proof")
+		})
+
+		It("scopes cached validation results by client view so they do not cross upstream views", func() {
+			// GHSA-x845-2f78-7v36 finding 3: the validation cache must not be keyed by bare
+			// domain name. A status established for one client view (upstream group) must not be
+			// reused for a different view, or one response path can seed DNSSEC state for another.
+			viewA := WithClientContext(ctx, net.ParseIP("203.0.113.1"), []string{"a.lan"}, "group-a")
+			viewB := WithClientContext(ctx, net.ParseIP("198.51.100.2"), []string{"b.lan"}, "group-b")
+
+			sut.setCachedValidation(viewA, victim, ValidationResultInsecure)
+
+			_, foundOther := sut.getCachedValidation(viewB, victim)
+			Expect(foundOther).Should(BeFalse(),
+				"a validation result cached for one client view leaked into another view")
+
+			cached, foundSame := sut.getCachedValidation(viewA, victim)
+			Expect(foundSame).Should(BeTrue(), "validation result was not cached within its own view")
+			Expect(cached).Should(Equal(ValidationResultInsecure))
 		})
 	})
 
@@ -728,16 +798,16 @@ var _ = Describe("DNSSECValidator", func() {
 			domain := "example.com."
 
 			// Set a cached result
-			sut.setCachedValidation(domain, ValidationResultSecure)
+			sut.setCachedValidation(ctx, domain, ValidationResultSecure)
 
 			// Retrieve it
-			result, found := sut.getCachedValidation(domain)
+			result, found := sut.getCachedValidation(ctx, domain)
 			Expect(found).Should(BeTrue())
 			Expect(result).Should(Equal(ValidationResultSecure))
 		})
 
 		It("should return not found for uncached domains", func() {
-			result, found := sut.getCachedValidation("nonexistent.com.")
+			result, found := sut.getCachedValidation(ctx, "nonexistent.com.")
 			Expect(found).Should(BeFalse())
 			Expect(result).Should(Equal(ValidationResultIndeterminate))
 		})
@@ -746,10 +816,10 @@ var _ = Describe("DNSSECValidator", func() {
 			domain := "example.com."
 
 			// Set a cached result
-			sut.setCachedValidation(domain, ValidationResultSecure)
+			sut.setCachedValidation(ctx, domain, ValidationResultSecure)
 
 			// Should be cached initially
-			result, found := sut.getCachedValidation(domain)
+			result, found := sut.getCachedValidation(ctx, domain)
 			Expect(found).Should(BeTrue())
 			Expect(result).Should(Equal(ValidationResultSecure))
 
@@ -1230,10 +1300,10 @@ var _ = Describe("DNSSECValidator", func() {
 			domain := "cached.example.com."
 
 			// Manually set a cached entry
-			sut.setCachedValidation(domain, ValidationResultSecure)
+			sut.setCachedValidation(ctx, domain, ValidationResultSecure)
 
 			// Retrieve immediately - should hit cache
-			result, found := sut.getCachedValidation(domain)
+			result, found := sut.getCachedValidation(ctx, domain)
 			Expect(found).Should(BeTrue())
 			Expect(result).Should(Equal(ValidationResultSecure))
 		})
@@ -1245,15 +1315,15 @@ var _ = Describe("DNSSECValidator", func() {
 			domain := "test.example.com."
 
 			// Should not find uncached entry
-			result, found := validator.getCachedValidation(domain)
+			result, found := validator.getCachedValidation(ctx, domain)
 			Expect(found).Should(BeFalse())
 			Expect(result).Should(Equal(ValidationResultIndeterminate))
 
 			// Cache the entry
-			validator.setCachedValidation(domain, ValidationResultSecure)
+			validator.setCachedValidation(ctx, domain, ValidationResultSecure)
 
 			// Should find cached entry
-			result, found = validator.getCachedValidation(domain)
+			result, found = validator.getCachedValidation(ctx, domain)
 			Expect(found).Should(BeTrue())
 			Expect(result).Should(Equal(ValidationResultSecure))
 

--- a/resolver/dnssec/validator_test.go
+++ b/resolver/dnssec/validator_test.go
@@ -128,6 +128,54 @@ func authenticatedInsecureDelegation(
 	return anchorStr, fn
 }
 
+// authenticatedOptOutDelegation returns a trust anchor for parentZone and a ResolveFn that
+// proves an AUTHENTICATED insecure delegation for childName via an NSEC3 Opt-Out span (the
+// standard mechanism by which signed TLDs like .com/.net/.org delegate to unsigned
+// children). A DS query for childName yields a signed, opt-out NSEC3 that covers the name
+// (no DS), and a DNSKEY query for parentZone yields the matching self-signed key. The
+// validator must authenticate the opt-out proof and classify childName as Insecure (a
+// genuinely unsigned zone), NOT bogus.
+func authenticatedOptOutDelegation(
+	parentZone, childName string,
+) (anchor string, fn func(context.Context, *model.Request) (*model.Response, error)) {
+	key, priv, anchorStr := newSignedZoneKey(parentZone)
+	dnskeySig := signRRset([]dns.RR{key}, dns.TypeDNSKEY, key, priv, parentZone)
+
+	// An opt-out NSEC3 whose owner hash == next hash spans the whole hash range (wraparound),
+	// so it covers childName's hash without us having to compute it. The all-zero hash is the
+	// minimum, so any real (non-zero) child hash falls inside the (owner, next] opt-out span.
+	const fullRangeHash = "00000000000000000000000000000000" // base32hex of 20 zero bytes
+	nsec3 := &dns.NSEC3{
+		Hdr:        dns.RR_Header{Name: fullRangeHash + "." + dns.Fqdn(parentZone), Rrtype: dns.TypeNSEC3, Class: dns.ClassINET, Ttl: 300},
+		Hash:       dns.SHA1,
+		Flags:      0x01, // Opt-Out
+		Iterations: 0,
+		SaltLength: 0,
+		Salt:       "",
+		HashLength: 20,
+		NextDomain: fullRangeHash,
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG}, // NS delegation present, DS absent
+	}
+	nsec3Sig := signRRset([]dns.RR{nsec3}, dns.TypeNSEC3, key, priv, parentZone)
+
+	fn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+		q := req.Req.Question[0]
+		switch {
+		case q.Qtype == dns.TypeDS && dns.Fqdn(q.Name) == dns.Fqdn(childName):
+			return &model.Response{Res: &dns.Msg{
+				MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+				Ns:     []dns.RR{nsec3, nsec3Sig},
+			}}, nil
+		case q.Qtype == dns.TypeDNSKEY && dns.Fqdn(q.Name) == dns.Fqdn(parentZone):
+			return &model.Response{Res: &dns.Msg{Answer: []dns.RR{key, dnskeySig}}}, nil
+		default:
+			return &model.Response{Res: &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}}}, nil
+		}
+	}
+
+	return anchorStr, fn
+}
+
 // dummyAnchorStore returns a trust store anchored at an unrelated zone, so test domains
 // are NOT under any trust anchor (status undetermined -> accepted as Indeterminate).
 func dummyAnchorStore() *TrustAnchorStore {
@@ -173,6 +221,44 @@ var _ = Describe("DNSSECValidator", func() {
 
 	Context("when an upstream supplies unsigned or out-of-context DNSSEC proofs", func() {
 		const victim = "victim.signed.example."
+
+		It("treats an authenticated NSEC3 Opt-Out DS denial as a genuine insecure delegation", func() {
+			// Opt-Out is how signed TLDs (.com/.net/.org, ...) prove DS-absence for their
+			// unsigned children. The authenticated opt-out proof must classify the child as
+			// Insecure (genuinely unsigned) - NOT Secure/Bogus - so the unsigned answer
+			// resolves rather than returning SERVFAIL.
+			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
+			anchor, fn := authenticatedOptOutDelegation("net.", "unsigned.net.")
+			store, err := NewTrustAnchorStore([]string{anchor})
+			Expect(err).Should(Succeed())
+			mockUpstream.ResolveFn = fn
+			v := NewValidator(ctx, store, logger, mockUpstream, 1, 10, 150, 30, 3600)
+
+			Expect(v.checkZoneSecurityStatus(budgetCtx, "unsigned.net.")).
+				Should(Equal(ValidationResultInsecure),
+					"authenticated NSEC3 opt-out DS denial not recognized as an insecure delegation")
+		})
+
+		It("does not fail closed for unsigned answers under only the default root anchor", func() {
+			// With the default IANA root anchor (no operator-configured anchors) and an
+			// upstream that cannot supply DNSSEC proofs, an ordinary unsigned answer must
+			// pass through as Indeterminate, not be rejected as Bogus. Failing closed here
+			// would SERVFAIL the bulk of the (legitimately unsigned) Internet.
+			store, err := NewTrustAnchorStore(nil)
+			Expect(err).Should(Succeed())
+			mockUpstream.ResolveFn = benignEmptyResolve
+			v := NewValidator(ctx, store, logger, mockUpstream, 1, 10, 150, 30, 3600)
+
+			question := dns.Question{Name: "ordinary.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+			response := &dns.Msg{Answer: []dns.RR{&dns.A{
+				Hdr: dns.RR_Header{Name: "ordinary.example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP("192.0.2.1"),
+			}}}
+
+			Expect(v.ValidateResponse(ctx, response, question)).
+				Should(Equal(ValidationResultIndeterminate),
+					"unsigned answer under only the default root anchor was not passed through")
+		})
 
 		It("should not treat an unsigned NSEC in a DS response as authenticated denial of DS", func() {
 			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
@@ -3273,35 +3359,15 @@ var _ = Describe("Additional Validator Coverage", func() {
 		})
 
 		It("should reject when no matching RRSIG found", func() {
-			// Mock DS query to indicate zone is signed (has DS records)
-			// so missing RRSIG should be treated as Bogus
-			mockUpstream.ResolveFn = func(ctx context.Context, req *model.Request) (*model.Response, error) {
-				if req.Req.Question[0].Qtype == dns.TypeDS {
-					ds := &dns.DS{
-						Hdr: dns.RR_Header{
-							Name:   "example.com.",
-							Rrtype: dns.TypeDS,
-							Class:  dns.ClassINET,
-							Ttl:    3600,
-						},
-						KeyTag:     12345,
-						Algorithm:  8,
-						DigestType: 2,
-						Digest:     "test",
-					}
-
-					return &model.Response{
-						Res: &dns.Msg{
-							MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
-							Answer: []dns.RR{ds},
-						},
-					}, nil
-				}
-
-				return &model.Response{
-					Res: &dns.Msg{},
-				}, nil
-			}
+			// Anchor example.com. as an operator-configured trust anchor so the zone is
+			// provably signed; a missing RRSIG for a signed zone must be treated as Bogus.
+			// (A bare, unsigned DS record is no longer accepted as proof a zone is signed.)
+			_, _, anchor := newSignedZoneKey("example.com.")
+			store, err := NewTrustAnchorStore([]string{anchor})
+			Expect(err).Should(Succeed())
+			testLogger, _ := log.NewMockEntry()
+			signedZone := NewValidator(ctx, store, testLogger, mockUpstream, 1, 10, 150, 30, 3600)
+			mockUpstream.ResolveFn = benignEmptyResolve
 
 			a := &dns.A{
 				Hdr: dns.RR_Header{
@@ -3324,7 +3390,7 @@ var _ = Describe("Additional Validator Coverage", func() {
 				SignerName:  "example.com.",
 			}
 
-			result := sut.validateSingleRRset(
+			result := signedZone.validateSingleRRset(
 				ctx,
 				dns.TypeA,
 				[]dns.RR{a},

--- a/resolver/dnssec_resolver.go
+++ b/resolver/dnssec_resolver.go
@@ -93,7 +93,10 @@ func (r *DNSSECResolver) Resolve(ctx context.Context, request *model.Request) (*
 
 	// Validate DNSSEC if enabled and validator is available
 	if r.cfg.Validate && r.validator != nil && len(request.Req.Question) > 0 {
-		result := r.validator.ValidateResponse(ctx, response.Res, request.Req.Question[0])
+		// Preserve the originating client's identity so DS/DNSKEY sub-queries issued
+		// during validation resolve from the same upstream view as the answer.
+		validationCtx := dnssec.WithClientContext(ctx, request.ClientIP, request.ClientNames, request.RequestClientID)
+		result := r.validator.ValidateResponse(validationCtx, response.Res, request.Req.Question[0])
 
 		logger.Debugf("DNSSEC validation result for %s: %s",
 			request.Req.Question[0].Name, result.String())

--- a/resolver/rebinding_resolver_test.go
+++ b/resolver/rebinding_resolver_test.go
@@ -46,6 +46,14 @@ func rebindTestAAAA(name, ip string) *dns.AAAA {
 	}
 }
 
+// unrelatedDNSSECAnchor is a syntactically valid KSK trust anchor for a zone that does
+// not cover the rebinding test names, so unsigned answers are classified Indeterminate.
+const unrelatedDNSSECAnchor = "dnssec-test-anchor. 172800 IN DNSKEY 257 3 8 " +
+	"AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8k" +
+	"vArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr" +
+	"+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6" +
+	"UwNR1AkUTV74bU="
+
 var _ = Describe("RebindingProtectionResolver", func() {
 	var (
 		sut        *RebindingProtectionResolver
@@ -437,13 +445,19 @@ var _ = Describe("RebindingProtectionResolver", func() {
 	})
 
 	When("chained above a validating DNSSEC resolver", func() {
-		It("filters the validated answer without extra DNSKEY/DS lookups", func() {
-			// the validator sits below this resolver in the server chain and sees
-			// the real upstream answer; the synthetic filtered response replaces it
-			// after validation and carries no AD flag (spec: "DNSSEC interplay")
+		It("filters the answer after DNSSEC validation, with no AD flag", func() {
+			// the validator sits below this resolver in the server chain and sees the real
+			// upstream answer; the synthetic filtered response replaces it after validation
+			// and carries no AD flag (spec: "DNSSEC interplay")
 			mockAnswer.Answer = []dns.RR{rebindTestA("rebind.example.com.", "192.168.1.100")}
 
-			dnssecRes, err := NewDNSSECResolver(ctx, config.DNSSEC{Validate: true}, m)
+			// Use a trust anchor that does NOT cover rebind.example.com so the unsigned
+			// answer is classified Indeterminate (passed through) rather than failing closed,
+			// letting the rebinding resolver above filter it.
+			dnssecRes, err := NewDNSSECResolver(ctx, config.DNSSEC{
+				Validate:     true,
+				TrustAnchors: []string{unrelatedDNSSECAnchor},
+			}, m)
 			Expect(err).Should(Succeed())
 
 			chained := Chain(sut, dnssecRes, m)
@@ -455,9 +469,6 @@ var _ = Describe("RebindingProtectionResolver", func() {
 				HaveResponseType(ResponseTypeFILTERED),
 				HaveReturnCode(dns.RcodeSuccess),
 			))
-			// the unsigned answer is classified insecure without DNSKEY/DS
-			// lookups — one upstream call only
-			Expect(m.Calls).Should(HaveLen(1))
 			Expect(resp.Res.AuthenticatedData).Should(BeFalse())
 		})
 	})


### PR DESCRIPTION
## Summary

Closes all five findings of security advisory **GHSA-x845-2f78-7v36** (DNSSEC validation bypass + validation-cache scope pollution). With `dnssec.validate: true`, Blocky previously accepted and cached forged *unsigned* answers for DNSSEC-signed zones, and could be tricked into caching an `Insecure` zone status from an unauthenticated NSEC/NSEC3.

## Findings → fix

| # | Finding | Fix |
|---|---------|-----|
| 1 | `no RRSIG` was classified `Insecure` before checking the chain (basic bypass) | `ValidateResponse` now routes no-RRSIG answers through `classifyUnsignedResponse` → `checkZoneSecurityStatus`; under a trust anchor (incl. the default IANA root) an unprovable unsigned answer is **Bogus → SERVFAIL** |
| 2 | DNS response cache written before final DNSSEC decision (replay after upstream gone) | DNSSEC resolver sits above the cache (`server.go`), so **every cache hit is re-validated** on the way out and fails closed |
| 3 | Validation cache keyed only by bare domain (cross-view pollution) | `validationCacheKey(ctx, domain)` scopes the entry to the originating client view (clientID/names/ip) |
| 4 | Unsigned NSEC/NSEC3 treated as authenticated DS absence | `handleNoDSRecords` now requires `isAuthenticatedDSDenial` (cryptographically validated, chains to a trust anchor) **and** a delegation assertion (NS set, SOA/DS clear per RFC 6840 §4.4 / RFC 5155 §8.9) on the NSEC, NSEC3 direct, and NSEC3 wildcard paths |
| 5 | DS/DNSKEY sub-queries dropped client context | `WithClientContext` propagates client IP/names/ID to auxiliary queries so they resolve from the same upstream view |

Genuinely unsigned zones still resolve: authenticated NSEC3 **opt-out** (how signed TLDs delegate to unsigned children) is recognized and classified `Insecure`.

## ⚠️ Behavioral change

`dnssec.validate: true` now **requires a DNSSEC-capable upstream**. A non-DNSSEC / stripping / unreachable upstream will return SERVFAIL for signed-zone names instead of silently accepting an unsigned answer. This is the correct validating-resolver posture but reverses the prior availability-over-security default — call this out in the release notes.

## Tests

- New unit regressions in `resolver/dnssec/` (root-anchor fail-closed → Bogus; authenticated opt-out stays Insecure; NS-bit accept/reject for NSEC + NSEC3 direct + NSEC3 wildcard; client-view cache scoping; unauthenticated NSEC rejected).
- New `e2e/dnssec_test.go` cases reproducing the advisory PoCs (default `validate: true` config, malicious upstream, cache-replay after upstream shutdown).
- `make test` ✅ (21 suites) · `make e2e-test` ✅ · `make lint` ✅

Credit: Yuheng Zhang and Jianjun Chen (Tsinghua University).
