### PR TITLE
fix(querylog): add loong64 to unsupported list

### DIFF
--- a/querylog/database_writer_sqlite.go
+++ b/querylog/database_writer_sqlite.go
@@ -1,4 +1,4 @@
-//go:build !mips && !mipsle && !mips64 && !mips64le && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64)
+//go:build !mips && !mipsle && !mips64 && !mips64le && !loong64 && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64)
 
 // SQLite support is compiled in only on the GOOS/GOARCH targets supported by the
 // pure-Go driver chain (github.com/glebarez/sqlite -> modernc.org/sqlite ->

--- a/querylog/database_writer_sqlite_unsupported.go
+++ b/querylog/database_writer_sqlite_unsupported.go
@@ -1,4 +1,4 @@
-//go:build mips || mipsle || mips64 || mips64le || (netbsd && !amd64) || (openbsd && !amd64 && !arm64)
+//go:build mips || mipsle || mips64 || mips64le || loong64 || (netbsd && !amd64) || (openbsd && !amd64 && !arm64)
 
 // This is the exact complement of the constraint in database_writer_sqlite.go: the
 // GOOS/GOARCH targets where the pure-Go SQLite driver chain (github.com/glebarez/


### PR DESCRIPTION
Closes #2122

modernc.org/libc v1.22.5 does not support loong64

add loong64 to querylog/database_writer_sqlite.go and querylog/database_writer_sqlite_unsupported.go exclude list.