### PR TITLE
fix(dnssec): don't cache transient Indeterminate validation results (#2120)

### DIFF
--- a/resolver/dnssec/chain.go
+++ b/resolver/dnssec/chain.go
@@ -50,7 +50,19 @@ func (v *Validator) getCachedValidation(ctx context.Context, domain string) (Val
 
 // setCachedValidation stores a validation result in the cache, scoped to the originating
 // client's view (see validationCacheKey).
+//
+// Indeterminate is never cached. It means "could not determine" - in practice a transient
+// sub-query failure (timeout/unreachable upstream) while walking the chain of trust.
+// Persisting it would shadow every later RRSIG signed by that zone (the cached Indeterminate
+// makes the chain check fail, the signature is skipped, and the answer is declared Bogus ->
+// SERVFAIL) for the full cache TTL, even after the upstream recovers - turning one transient
+// blip into an hour of failures (issue #2120). Leaving it uncached lets the next query
+// re-evaluate the zone and establish its real (durable) status.
 func (v *Validator) setCachedValidation(ctx context.Context, domain string, result ValidationResult) {
+	if result == ValidationResultIndeterminate {
+		return
+	}
+
 	v.validationCache.Put(validationCacheKey(ctx, domain), &result, v.cacheExpiration)
 }
 

--- a/resolver/dnssec/validator_test.go
+++ b/resolver/dnssec/validator_test.go
@@ -337,6 +337,27 @@ var _ = Describe("DNSSECValidator", func() {
 				"stale insecure status shadowed a legitimate signed DS for the same name")
 		})
 
+		It("does not cache a transient chain-validation failure, so recovery is not shadowed (issue #2120)", func() {
+			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
+
+			// The upstream is momentarily unreachable: every DS/DNSKEY sub-query fails.
+			mockUpstream.ResolveFn = func(_ context.Context, _ *model.Request) (*model.Response, error) {
+				return nil, errors.New("i/o timeout")
+			}
+
+			const zone = "office.com."
+			first := sut.walkChainOfTrust(budgetCtx, zone)
+			Expect(first).Should(Equal(ValidationResultIndeterminate),
+				"a transient upstream failure should yield Indeterminate, not a durable verdict")
+
+			// The transient failure must NOT be cached. A cached Indeterminate makes every
+			// subsequent RRSIG signed by this zone be skipped -> Bogus -> SERVFAIL for the full
+			// cache TTL (default 1h), even after the upstream recovers (issue #2120).
+			_, found := sut.getCachedValidation(budgetCtx, zone)
+			Expect(found).Should(BeFalse(),
+				"a transient (Indeterminate) chain failure was cached, poisoning future validations")
+		})
+
 		It("should preserve the originating client context on DNSKEY sub-queries", func() {
 			clientIP := net.ParseIP("203.0.113.9")
 			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)


### PR DESCRIPTION
## Problem

Fixes #2120. With `dnssec.validate: true`, `outlook.office.com` (and similar) returned **SERVFAIL** persistently while `office.com` resolved, even though the configured upstreams (DNS0.eu / Cloudflare / Quad9) return fully-signed responses with AD set.

## Root cause: validation-cache poisoning

A single **transient** DS/DNSKEY sub-query failure during chain-of-trust validation (a timeout, a momentarily unreachable upstream, or slow upstream-hostname bootstrap) makes `validateDomainLevel`/`walkChainOfTrust` return `Indeterminate`. That `Indeterminate` was then written to the validation cache for the full cache TTL (default **1 hour**, `cacheExpirationHours`).

For that whole hour, every RRSIG signed by the affected zone was skipped (`chain of trust validation failed: Indeterminate`) → the answer was declared **Bogus → SERVFAIL** — *even after the upstream fully recovered*. That's why `office.com` worked but `outlook.office.com` didn't: only `cloud.microsoft` (the signer of the 2nd CNAME in the chain) got poisoned.

This is a pre-existing latent bug, not introduced by the GHSA-x845-2f78-7v36 hardening — that change only re-scoped the cache *key*; the `Indeterminate`-caching predates it.

## Fix

Never cache `Indeterminate` in `setCachedValidation`. It means "could not determine" — in practice a transient failure — and is not a durable verdict. Leaving it uncached lets the next query re-evaluate the zone and establish its real status. `Secure`, authenticated `Insecure`, and `Bogus` are still cached as before.

```go
func (v *Validator) setCachedValidation(ctx context.Context, domain string, result ValidationResult) {
	if result == ValidationResultIndeterminate {
		return
	}
	v.validationCache.Put(validationCacheKey(ctx, domain), &result, v.cacheExpiration)
}
```

## Security: GHSA-x845-2f78-7v36 findings remain closed

This change **does not relax any verdict**. Within a request, an `Indeterminate` chain still fails closed (RRSIG skipped → Bogus). It only stops a transient failure from *persisting*, forcing a fresh full re-evaluation next time — which is never weaker than the original. It also removes a self-inflicted cache-poisoning DoS.

- **Finding 1 (no-RRSIG bypass / fail-closed):** unchanged. `classifyUndetermined` still returns Secure (→ unsigned = Bogus) under a trust anchor; the immediate Bogus verdict on an Indeterminate chain is unchanged.
- **Finding 2 (cache-then-replay):** unchanged. Answer cache + re-validation-on-cache-hit untouched.
- **Finding 3 (cache key scoping):** preserved. The cache key is still `validationCacheKey(ctx, domain)` (client-view scoped); only an early-return for `Indeterminate` was added.
- **Finding 4 (authenticated DS-denial + NS-bit):** untouched.
- **Finding 5 (client context on sub-queries):** untouched.

## Tests / validation

- New regression test `does not cache a transient chain-validation failure ... (issue #2120)` (TDD: red → green).
- `go test ./resolver/dnssec/... ./resolver/` green; 20 GHSA-x845 regression specs pass.
- Verified against a running blocky:
  - Deterministic proxy that fails DS sub-queries on demand: **unfixed** stays SERVFAIL after the upstream recovers; **fixed** recovers to NOERROR immediately.
  - Reporter's exact config: a transient blip fails only that one request (next succeeds) instead of poisoning for an hour; with reliable upstreams it resolves 50/50.
