### PR TITLE
fix(dnssec): only validate public-upstream answers (#2126)

### DIFF
--- a/resolver/dnssec_resolver.go
+++ b/resolver/dnssec_resolver.go
@@ -93,18 +93,23 @@ func (r *DNSSECResolver) Resolve(ctx context.Context, request *model.Request) (*
 
 	// Validate DNSSEC if enabled and validator is available
 	if r.cfg.Validate && r.validator != nil && len(request.Req.Question) > 0 {
-		// Conditional-upstream answers are served by an operator-trusted resolver for
-		// private/split-horizon zones. They are inherently unsigned and have no chain of
-		// trust in the public DNS hierarchy, so the post-GHSA-x845 unsigned-answer handling
-		// would classify them bogus - the whole namespace sits under the default root trust
-		// anchor - and turn every private lookup into SERVFAIL (#2126). Like the rebinding
-		// resolver, which exempts trusted-local answers by response type, skip validation
-		// for them; the public-upstream answers that carry the GHSA attack surface
-		// (RESOLVED/CACHED) remain fully validated. Clear AD: we have not authenticated it.
-		if response != nil && response.Res != nil && response.RType == model.ResponseTypeCONDITIONAL {
+		// Only public-upstream answers carry a chain of trust in the public DNS hierarchy and
+		// form the GHSA-x845 attack surface, so validate exactly those: RESOLVED, plus cached
+		// upstream answers re-served as CACHED (re-validated on every hit). Every other response
+		// type that can reach this resolver from below is trusted-local or synthesized -
+		// conditional-upstream private/split-horizon zones (CONDITIONAL), special-use names like
+		// localhost (SPECIAL), DNS64-synthesized AAAA (SYNTHESIZED). Those are inherently unsigned
+		// with no public chain of trust, so the post-GHSA-x845 handling would classify them bogus
+		// - the whole namespace sits under the default root trust anchor - and turn every such
+		// lookup into SERVFAIL (#2126). Mirror the rebinding resolver's response-type whitelist
+		// and skip validation for them, clearing AD since we have not authenticated them. The
+		// RType is assigned by blocky's own resolvers, never by the (attacker-controlled) upstream
+		// answer, so a poisoned public answer cannot mislabel itself out of validation.
+		if response != nil && response.Res != nil &&
+			response.RType != model.ResponseTypeRESOLVED && response.RType != model.ResponseTypeCACHED {
 			response.Res.AuthenticatedData = false
-			logger.Debugf("skipping DNSSEC validation for conditional (trusted-local) response: %s",
-				request.Req.Question[0].Name)
+			logger.Debugf("skipping DNSSEC validation for trusted-local/synthesized response (%s): %s",
+				response.RType, request.Req.Question[0].Name)
 
 			return response, nil
 		}

--- a/resolver/dnssec_resolver.go
+++ b/resolver/dnssec_resolver.go
@@ -93,6 +93,22 @@ func (r *DNSSECResolver) Resolve(ctx context.Context, request *model.Request) (*
 
 	// Validate DNSSEC if enabled and validator is available
 	if r.cfg.Validate && r.validator != nil && len(request.Req.Question) > 0 {
+		// Conditional-upstream answers are served by an operator-trusted resolver for
+		// private/split-horizon zones. They are inherently unsigned and have no chain of
+		// trust in the public DNS hierarchy, so the post-GHSA-x845 unsigned-answer handling
+		// would classify them bogus - the whole namespace sits under the default root trust
+		// anchor - and turn every private lookup into SERVFAIL (#2126). Like the rebinding
+		// resolver, which exempts trusted-local answers by response type, skip validation
+		// for them; the public-upstream answers that carry the GHSA attack surface
+		// (RESOLVED/CACHED) remain fully validated. Clear AD: we have not authenticated it.
+		if response != nil && response.Res != nil && response.RType == model.ResponseTypeCONDITIONAL {
+			response.Res.AuthenticatedData = false
+			logger.Debugf("skipping DNSSEC validation for conditional (trusted-local) response: %s",
+				request.Req.Question[0].Name)
+
+			return response, nil
+		}
+
 		// Preserve the originating client's identity so DS/DNSKEY sub-queries issued
 		// during validation resolve from the same upstream view as the answer.
 		validationCtx := dnssec.WithClientContext(ctx, request.ClientIP, request.ClientNames, request.RequestClientID)

--- a/resolver/dnssec_resolver_test.go
+++ b/resolver/dnssec_resolver_test.go
@@ -231,40 +231,55 @@ var _ = Describe("DNSSECResolver", func() {
 				Expect(resp.Res.AuthenticatedData).Should(BeFalse())
 			})
 
-			// Regression test for #2126: after the GHSA-x845 hardening an unsigned answer
-			// under the (default) root trust anchor is classified bogus -> SERVFAIL.
-			// Conditional-upstream answers serve private/split-horizon zones from an
-			// operator-trusted resolver and are inherently unsigned, so they must be exempted
-			// from validation (like the rebinding resolver's response-type carve-out) instead
-			// of being turned into SERVFAIL.
-			It("should not validate (SERVFAIL) a conditional (trusted-local) response", func() {
-				// unsigned answer, as a private zone served by the conditional upstream returns;
-				// the local resolver may even assert AD, which we must not propagate
-				response.AuthenticatedData = true
-				mockUpstream.On("Resolve", mock.Anything).Return(
-					&model.Response{Res: response, RType: model.ResponseTypeCONDITIONAL}, nil)
+			// Regression for #2126 and the follow-up review: after the GHSA-x845 hardening an
+			// unsigned answer under the (default) root trust anchor is classified bogus -> SERVFAIL.
+			// Only public-upstream answers (RESOLVED, and cached upstream answers re-served as
+			// CACHED) carry a chain of trust in the public DNS hierarchy and form the GHSA-x845
+			// attack surface, so we validate exactly those. Trusted-local / synthesized answers
+			// - conditional-upstream private zones, special-use names like localhost, DNS64-
+			// synthesized AAAA - are inherently unsigned and must be exempted (like the rebinding
+			// resolver's response-type whitelist) instead of being turned into SERVFAIL.
+			DescribeTable("skips validation for trusted-local / synthesized responses (whitelist carve-out)",
+				func(rType model.ResponseType) {
+					// unsigned answer; the local resolver may even assert AD, which we must not propagate
+					response.AuthenticatedData = true
+					mockUpstream.On("Resolve", mock.Anything).Return(
+						&model.Response{Res: response, RType: rType}, nil)
 
-				resp, err := sut.Resolve(ctx, request)
-				Expect(err).Should(Succeed())
-				// passes through untouched - not turned into SERVFAIL
-				Expect(resp.Res.Rcode).Should(Equal(dns.RcodeSuccess))
-				Expect(resp.Res.Answer).Should(HaveLen(1))
-				Expect(resp.RType).Should(Equal(model.ResponseTypeCONDITIONAL))
-				// AD cleared: we did not authenticate it
-				Expect(resp.Res.AuthenticatedData).Should(BeFalse())
-			})
+					resp, err := sut.Resolve(ctx, request)
+					Expect(err).Should(Succeed())
+					// passes through untouched - not turned into SERVFAIL
+					Expect(resp.Res.Rcode).Should(Equal(dns.RcodeSuccess))
+					Expect(resp.Res.Answer).Should(HaveLen(1))
+					Expect(resp.RType).Should(Equal(rType))
+					// AD cleared: we did not authenticate it
+					Expect(resp.Res.AuthenticatedData).Should(BeFalse())
+					// the carve-out short-circuits before the validator runs, so no DS/DNSKEY
+					// sub-queries are issued - only the initial next.Resolve hit the upstream
+					Expect(mockUpstream.Calls).Should(HaveLen(1))
+				},
+				Entry("conditional upstream - private/split-horizon zone (#2126)", model.ResponseTypeCONDITIONAL),
+				Entry("special-use domain name - e.g. localhost", model.ResponseTypeSPECIAL),
+				Entry("DNS64-synthesized AAAA", model.ResponseTypeSYNTHESIZED),
+			)
 
-			It("should still validate (SERVFAIL) an equivalent unsigned upstream response", func() {
-				// same unsigned answer but RESOLVED (public upstream) is the GHSA-x845 attack
-				// vector and must remain bogus under the default root anchor - the carve-out
-				// above is strictly response-type scoped
-				mockUpstream.On("Resolve", mock.Anything).Return(
-					&model.Response{Res: response, RType: model.ResponseTypeRESOLVED}, nil)
+			// The GHSA-x845 attack surface - public-upstream answers - must remain fully
+			// validated, including cached upstream answers re-served as CACHED (re-validated on
+			// every cache hit). The whitelist carve-out above is strictly response-type scoped
+			// and must not weaken this.
+			DescribeTable("still validates (SERVFAIL) unsigned public-upstream responses (GHSA-x845 preserved)",
+				func(rType model.ResponseType) {
+					mockUpstream.On("Resolve", mock.Anything).Return(
+						&model.Response{Res: response, RType: rType}, nil)
 
-				resp, err := sut.Resolve(ctx, request)
-				Expect(err).Should(Succeed())
-				Expect(resp.Res.Rcode).Should(Equal(dns.RcodeServerFailure))
-			})
+					resp, err := sut.Resolve(ctx, request)
+					Expect(err).Should(Succeed())
+					// unsigned answer under the default root anchor -> bogus -> SERVFAIL
+					Expect(resp.Res.Rcode).Should(Equal(dns.RcodeServerFailure))
+				},
+				Entry("resolved - public upstream", model.ResponseTypeRESOLVED),
+				Entry("cached upstream answer - re-validated on hit", model.ResponseTypeCACHED),
+			)
 		})
 
 		When("upstream resolver returns error", func() {

--- a/resolver/dnssec_resolver_test.go
+++ b/resolver/dnssec_resolver_test.go
@@ -230,6 +230,41 @@ var _ = Describe("DNSSECResolver", func() {
 				Expect(resp.Res.Rcode).Should(Equal(dns.RcodeServerFailure))
 				Expect(resp.Res.AuthenticatedData).Should(BeFalse())
 			})
+
+			// Regression test for #2126: after the GHSA-x845 hardening an unsigned answer
+			// under the (default) root trust anchor is classified bogus -> SERVFAIL.
+			// Conditional-upstream answers serve private/split-horizon zones from an
+			// operator-trusted resolver and are inherently unsigned, so they must be exempted
+			// from validation (like the rebinding resolver's response-type carve-out) instead
+			// of being turned into SERVFAIL.
+			It("should not validate (SERVFAIL) a conditional (trusted-local) response", func() {
+				// unsigned answer, as a private zone served by the conditional upstream returns;
+				// the local resolver may even assert AD, which we must not propagate
+				response.AuthenticatedData = true
+				mockUpstream.On("Resolve", mock.Anything).Return(
+					&model.Response{Res: response, RType: model.ResponseTypeCONDITIONAL}, nil)
+
+				resp, err := sut.Resolve(ctx, request)
+				Expect(err).Should(Succeed())
+				// passes through untouched - not turned into SERVFAIL
+				Expect(resp.Res.Rcode).Should(Equal(dns.RcodeSuccess))
+				Expect(resp.Res.Answer).Should(HaveLen(1))
+				Expect(resp.RType).Should(Equal(model.ResponseTypeCONDITIONAL))
+				// AD cleared: we did not authenticate it
+				Expect(resp.Res.AuthenticatedData).Should(BeFalse())
+			})
+
+			It("should still validate (SERVFAIL) an equivalent unsigned upstream response", func() {
+				// same unsigned answer but RESOLVED (public upstream) is the GHSA-x845 attack
+				// vector and must remain bogus under the default root anchor - the carve-out
+				// above is strictly response-type scoped
+				mockUpstream.On("Resolve", mock.Anything).Return(
+					&model.Response{Res: response, RType: model.ResponseTypeRESOLVED}, nil)
+
+				resp, err := sut.Resolve(ctx, request)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.Rcode).Should(Equal(dns.RcodeServerFailure))
+			})
 		})
 
 		When("upstream resolver returns error", func() {


### PR DESCRIPTION
## What

Exempt conditional-upstream answers (`ResponseTypeCONDITIONAL`) from DNSSEC validation, clearing the AD flag instead of validating them.

Fixes #2126.

## Why

Since v0.32.0 (the GHSA-x845-2f78-7v36 hardening, #2119), a response carrying no RRSIGs is no longer automatically treated as Insecure — `classifyUnsignedResponse` now checks the zone's security status, and because the whole namespace sits under the default IANA root trust anchor, the fail-closed logic classifies any unsigned answer without an authenticated insecure-delegation proof as **Bogus → SERVFAIL**.

Conditional-upstream answers serve private/split-horizon zones from an operator-trusted resolver. They are inherently unsigned and have no chain of trust in the public DNS hierarchy, so with `dnssec.validate: true` every private lookup routed through a `conditional` mapping now returns SERVFAIL:

```
No RRSIG for myhost. but zone is secure - treating unsigned answer as bogus
DNSSEC validation failed for myhost. - returning SERVFAIL
```

This worked before 0.32.0, where an unsigned answer resolved to Insecure (AD cleared) and passed through.

## How

In `DNSSECResolver.Resolve`, skip validation for `ResponseTypeCONDITIONAL` and clear the AD flag — mirroring `RebindingProtectionResolver`, which already exempts trusted-local answers by response type. The DNSSEC resolver sits above the conditional resolver in the chain, so it observes these answers on the way back up.

## Security

The GHSA-x845 findings concern answers from the **public DNS hierarchy** — `RESOLVED` and `CACHED` — which remain **fully validated**. `ResponseTypeCONDITIONAL` is assigned only by blocky's own conditional resolver for operator-configured mappings and can never be attacker-assigned, so the carve-out does not reopen the unsigned-answer bypass. The change is deliberately scoped to this single response type to stay as close as possible to the hardened 0.32 behaviour; `SPECIAL` (SUDN) and `SYNTHESIZED` (DNS64) remain validated.

## Tests

- Regression test: an unsigned `CONDITIONAL` answer passes through (no SERVFAIL, AD cleared) under the default root anchor.
- Companion test: an equivalent unsigned `RESOLVED` answer **still** SERVFAILs — proving validation remains active and the carve-out is strictly response-type scoped.
- `go test ./resolver/...` green; `gofmt`/`go vet` clean.

---

## Update — generalized to a response-type whitelist (89185b0d)

Follow-up review found the `CONDITIONAL`-only carve-out above left two siblings of the **same** SERVFAIL class open, since both also reach the DNSSEC resolver from below in the chain and are inherently unsigned under the default root anchor:

- **`SPECIAL` (SUDN)** — e.g. `localhost A → 127.0.0.1` SERVFAILs under the **default** config (SUDN is on by default + `dnssec.validate: true`) — the same precondition as #2126 itself.
- **`SYNTHESIZED` (DNS64)** — synthesized AAAA for signed zones SERVFAILs when DNS64 is enabled.

The carve-out is now the rebinding resolver's **exact** response-type whitelist: **validate only `RESOLVED` and `CACHED`** (the public chain of trust / GHSA-x845 attack surface) and skip + clear AD for every other trusted-local or synthesized type. This **supersedes** the "deliberately scoped to this single response type" note above — `SPECIAL` and `SYNTHESIZED` are now exempted too. The security argument is unchanged: `RType` is assigned by blocky's own resolvers and is never attacker-controlled, and `CACHED` stays validated so re-validation on every cache hit (a GHSA finding) is preserved.

Tests are now table-driven: the skip table `{CONDITIONAL, SPECIAL, SYNTHESIZED}` asserts pass-through + AD cleared + **no DS/DNSKEY sub-queries issued**; the validate table `{RESOLVED, CACHED}` asserts unsigned answers still SERVFAIL.

**Known residual:** a DNS64-synthesized answer is cacheable and re-served as `CACHED`, so it is re-validated and SERVFAILs on cache **hits** — inherent to DNS64 + server-side DNSSEC validation (RFC 6147 §5.5), left for a separate change.
