### PR TITLE
docs: adopt mkdocs-material features (code copy, tooltips, nav, tabs, mermaid)

### DIFF
--- a/docs/additional_information.md
+++ b/docs/additional_information.md
@@ -118,5 +118,3 @@ This will trigger a workflow on every push of a branch starting with `fb-` and c
 
 To enable automatic fork synchronisation create a secret with the name `FORK_SYNC_TOKEN` with an access token that has write permission to the fork repository.
 The enabled workflow will sync the main branch every 30 minutes with its upstream.
-
---8<-- "docs/includes/abbreviations.md"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ editor autocomplete and validation (see [Editor support and validation](#editor-
 ??? example "reference configuration file"
 
     ```yaml
-    --8<-- "docs/config.yml"
+    --8<-- "config.yml"
     ```
 
 ## Editor support and validation
@@ -1894,5 +1894,3 @@ Default value is 4.
     As with other settings under `loading`, the limit applies to the blocking and hosts file resolvers separately.
     The total number of concurrent sources concurrently processed can reach the sum of both values.
     For example if blocking has a limit set to 8 and hosts file's is 4, there could be up to 12 concurrent jobs.
-
---8<-- "docs/includes/abbreviations.md"

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,15 @@
 
 Blocky is a DNS proxy and ad-blocker for the local network written in Go with following features:
 
+```mermaid
+flowchart LR
+    C[Client devices] -->|DNS query| B(Blocky)
+    B -->|allowed query| U[Upstream resolvers]
+    U -->|answer| B
+    B -->|blocked domain| X[Blocked response]
+    B -->|answer| C
+```
+
 ## Features
 
 - **Blocking** - :no_entry: Blocking of DNS queries with external lists (Ad-block, malware) and allowlisting

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,5 +88,3 @@ small, is hugely appreciated. Thank you! :heart:
 [![Donate on Liberapay](https://img.shields.io/badge/Liberapay-donate-F6C915?logo=liberapay&logoColor=black)](https://liberapay.com/spx01)
 [![Buy me a coffee on Ko-fi](https://img.shields.io/badge/Ko--fi-donate-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/0xerr0r)
 [![Donate via PayPal](https://img.shields.io/badge/PayPal-donate-00457C?logo=paypal&logoColor=white)](https://paypal.me/spx01)
-
---8<-- "docs/includes/abbreviations.md"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,22 +15,26 @@ Simple configuration file, which enables only basic features:
 ```yaml
 upstreams:
   groups:
-    default:
+    default: # (1)!
       - 46.182.19.48
       - 80.241.218.68
       - tcp-tls:fdns1.dismail.de:853
       - https://dns.digitale-gesellschaft.ch/dns-query
 blocking:
   denylists:
-    ads:
+    ads: # (2)!
       - https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
   clientGroupsBlock:
     default:
       - ads
 ports:
-  dns: 53
+  dns: 53 # (3)!
   http: 4000
 ```
+
+1.  Upstream DNS resolvers blocky forwards allowed queries to. Plain IPs as well as `tcp-tls:` (DoT) and `https://` (DoH) endpoints are supported.
+2.  A named denylist group. Each entry is a URL or local file with hosts/domains to block; reference it from `clientGroupsBlock`.
+3.  Listening ports — `dns` serves DNS (UDP/TCP), `http` serves the REST API and Prometheus metrics.
 
 ## Run as standalone binary
 
@@ -83,45 +87,47 @@ Default value is `/app/config.yml`.
     fallback when `BLOCKY_CONFIG_FILE` is unset. New deployments
     should use `BLOCKY_CONFIG_FILE`.
 
-### Docker from command line
+### Start the container
 
-Execute following command from the command line:
+=== "docker run"
 
-```sh
-docker run --name blocky -v /path/to/config.yml:/app/config.yml -p 4000:4000 -p 53:53/udp spx01/blocky
-```
+    Execute the following command from the command line:
 
-### Run with docker-compose
+    ```sh
+    docker run --name blocky -v /path/to/config.yml:/app/config.yml -p 4000:4000 -p 53:53/udp spx01/blocky
+    ```
 
-Create following `docker-compose.yml` file
+=== "docker-compose"
 
-```yaml
-version: "2.1"
-services:
-  blocky:
-    image: spx01/blocky
-    container_name: blocky
-    restart: unless-stopped
-    # Optional the instance hostname for logging purpose
-    hostname: blocky-hostname
-    ports:
-      - "53:53/tcp"
-      - "53:53/udp"
-      - "4000:4000/tcp"
-    environment:
-      - TZ=Europe/Berlin # Optional to synchronize the log timestamp with host
-    volumes:
-      # Optional to synchronize the log timestamp with host
-      - /etc/localtime:/etc/localtime:ro
-      # config file
-      - ./config.yml:/app/config.yml:ro
-```
+    Create the following `docker-compose.yml` file:
 
-and start docker container with
+    ```yaml
+    version: "2.1"
+    services:
+      blocky:
+        image: spx01/blocky
+        container_name: blocky
+        restart: unless-stopped
+        # Optional the instance hostname for logging purpose
+        hostname: blocky-hostname
+        ports:
+          - "53:53/tcp"
+          - "53:53/udp"
+          - "4000:4000/tcp"
+        environment:
+          - TZ=Europe/Berlin # Optional to synchronize the log timestamp with host
+        volumes:
+          # Optional to synchronize the log timestamp with host
+          - /etc/localtime:/etc/localtime:ro
+          # config file
+          - ./config.yml:/app/config.yml:ro
+    ```
 
-```sh
-docker-compose up -d
-```
+    Then start the container with:
+
+    ```sh
+    docker-compose up -d
+    ```
 
 ### Advanced setup
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,46 +36,86 @@ ports:
 2.  A named denylist group. Each entry is a URL or local file with hosts/domains to block; reference it from `clientGroupsBlock`.
 3.  Listening ports — `dns` serves DNS (UDP/TCP), `http` serves the REST API and Prometheus metrics.
 
-## Run as standalone binary
+## Run Blocky
 
-Download the binary file from [GitHub](https://github.com/0xERR0R/blocky/releases) for your architecture and
-run `./blocky --config config.yml`.
+=== "Standalone binary"
 
-!!! warning
+    Download the binary file from [GitHub](https://github.com/0xERR0R/blocky/releases) for your architecture and
+    run `./blocky --config config.yml`.
 
-    To bind a **privileged port (< 1024, e.g. 53 or 853)** as a non-root user on
-    Linux, the binary needs the `NET_BIND_SERVICE` capability. Add it with
-    `setcap 'cap_net_bind_service=+ep' ./blocky`, run as root (not recommended),
-    or configure a port >= 1024.
+    !!! warning
 
-    If Blocky runs under a **restricted capability bounding set** (for example a
-    hardened `systemd` unit, or a container that drops capabilities), use
-    `setcap 'cap_net_bind_service=+p' ./blocky` instead. Blocky raises the
-    capability to effective itself at startup, which avoids the
-    `operation not permitted` exec error that `+ep` triggers when the capability
-    is not in the bounding set.
+        To bind a **privileged port (< 1024, e.g. 53 or 853)** as a non-root user on
+        Linux, the binary needs the `NET_BIND_SERVICE` capability. Add it with
+        `setcap 'cap_net_bind_service=+ep' ./blocky`, run as root (not recommended),
+        or configure a port >= 1024.
 
-## Run with docker
+        If Blocky runs under a **restricted capability bounding set** (for example a
+        hardened `systemd` unit, or a container that drops capabilities), use
+        `setcap 'cap_net_bind_service=+p' ./blocky` instead. Blocky raises the
+        capability to effective itself at startup, which avoids the
+        `operation not permitted` exec error that `+ep` triggers when the capability
+        is not in the bounding set.
 
-!!! note "Running under a restricted runtime"
+=== "Docker"
 
-    The container image is capability-aware. The binary ships with
-    `cap_net_bind_service=+p` (permitted only), so the container starts even under
-    a restricted runtime that drops all capabilities (for example the Kubernetes
-    *Restricted* Pod Security Standard, `capabilities: drop: [ALL]`).
+    !!! note "Running under a restricted runtime"
 
-    - On **ports >= 1024** no capability is required.
-    - On **privileged ports (< 1024, e.g. 53/853)** Blocky needs `NET_BIND_SERVICE`.
-      With the default runtime capability set it is already present and Blocky
-      enables it automatically. Under `drop: [ALL]`, grant it back (Kubernetes
-      `securityContext.capabilities.add: ["NET_BIND_SERVICE"]`, or
-      `docker run --cap-add NET_BIND_SERVICE`) or configure a port >= 1024.
+        The container image is capability-aware. The binary ships with
+        `cap_net_bind_service=+p` (permitted only), so the container starts even under
+        a restricted runtime that drops all capabilities (for example the Kubernetes
+        *Restricted* Pod Security Standard, `capabilities: drop: [ALL]`).
 
-### Alternative registry
+        - On **ports >= 1024** no capability is required.
+        - On **privileged ports (< 1024, e.g. 53/853)** Blocky needs `NET_BIND_SERVICE`.
+          With the default runtime capability set it is already present and Blocky
+          enables it automatically. Under `drop: [ALL]`, grant it back (Kubernetes
+          `securityContext.capabilities.add: ["NET_BIND_SERVICE"]`, or
+          `docker run --cap-add NET_BIND_SERVICE`) or configure a port >= 1024.
 
-Blocky docker images are deployed to DockerHub (`spx01/blocky`) and GitHub Container Registry (`ghcr.io/0xerr0r/blocky`).
+    Blocky docker images are deployed to DockerHub (`spx01/blocky`) and GitHub Container Registry (`ghcr.io/0xerr0r/blocky`).
 
-### Parameters
+    === "docker run"
+
+        Execute the following command from the command line:
+
+        ```sh
+        docker run --name blocky -v /path/to/config.yml:/app/config.yml -p 4000:4000 -p 53:53/udp spx01/blocky
+        ```
+
+    === "docker-compose"
+
+        Create the following `docker-compose.yml` file:
+
+        ```yaml
+        version: "2.1"
+        services:
+          blocky:
+            image: spx01/blocky
+            container_name: blocky
+            restart: unless-stopped
+            # Optional the instance hostname for logging purpose
+            hostname: blocky-hostname
+            ports:
+              - "53:53/tcp"
+              - "53:53/udp"
+              - "4000:4000/tcp"
+            environment:
+              - TZ=Europe/Berlin # Optional to synchronize the log timestamp with host
+            volumes:
+              # Optional to synchronize the log timestamp with host
+              - /etc/localtime:/etc/localtime:ro
+              # config file
+              - ./config.yml:/app/config.yml:ro
+        ```
+
+        Then start the container with:
+
+        ```sh
+        docker-compose up -d
+        ```
+
+## Container configuration file
 
 You can define the location of the config file in the container with environment variable `BLOCKY_CONFIG_FILE`.
 Default value is `/app/config.yml`.
@@ -87,19 +127,13 @@ Default value is `/app/config.yml`.
     fallback when `BLOCKY_CONFIG_FILE` is unset. New deployments
     should use `BLOCKY_CONFIG_FILE`.
 
-### Start the container
+## Advanced docker-compose setup
 
-=== "docker run"
+Following example shows, how to run blocky in a docker container and store query logs on a SAMBA share. Local black and
+allowlists directories are mounted as volume. You can create own black or allowlists in these directories and define the
+path like '/app/allowlists/allowlist.txt' in the config file.
 
-    Execute the following command from the command line:
-
-    ```sh
-    docker run --name blocky -v /path/to/config.yml:/app/config.yml -p 4000:4000 -p 53:53/udp spx01/blocky
-    ```
-
-=== "docker-compose"
-
-    Create the following `docker-compose.yml` file:
+!!! example
 
     ```yaml
     version: "2.1"
@@ -108,67 +142,31 @@ Default value is `/app/config.yml`.
         image: spx01/blocky
         container_name: blocky
         restart: unless-stopped
-        # Optional the instance hostname for logging purpose
-        hostname: blocky-hostname
         ports:
           - "53:53/tcp"
           - "53:53/udp"
-          - "4000:4000/tcp"
+          - "4000:4000/tcp" # Prometheus stats (if enabled)
         environment:
-          - TZ=Europe/Berlin # Optional to synchronize the log timestamp with host
+          - TZ=Europe/Berlin
         volumes:
-          # Optional to synchronize the log timestamp with host
-          - /etc/localtime:/etc/localtime:ro
           # config file
           - ./config.yml:/app/config.yml:ro
-    ```
+          # write query logs in this volume
+          - queryLogs:/logs
+          # put your custom allow/denylists in these directories
+          - ./denylists:/app/denylists/
+          - ./allowlists:/app/allowlists/
 
-    Then start the container with:
-
-    ```sh
-    docker-compose up -d
-    ```
-
-### Advanced setup
-
-Following example shows, how to run blocky in a docker container and store query logs on a SAMBA share. Local black and
-allowlists directories are mounted as volume. You can create own black or allowlists in these directories and define the
-path like '/app/allowlists/allowlist.txt' in the config file.
-
-!!! example
-
-```yaml
-version: "2.1"
-services:
-  blocky:
-    image: spx01/blocky
-    container_name: blocky
-    restart: unless-stopped
-    ports:
-      - "53:53/tcp"
-      - "53:53/udp"
-      - "4000:4000/tcp" # Prometheus stats (if enabled)
-    environment:
-      - TZ=Europe/Berlin
     volumes:
-      # config file
-      - ./config.yml:/app/config.yml:ro
-      # write query logs in this volume
-      - queryLogs:/logs
-      # put your custom allow/denylists in these directories
-      - ./denylists:/app/denylists/
-      - ./allowlists:/app/allowlists/
+      queryLogs:
+        driver: local
+        driver_opts:
+          type: cifs
+          o: username=USER,password=PASSWORD,rw
+          device: //NAS_HOSTNAME/blocky
+    ```
 
-volumes:
-  queryLogs:
-    driver: local
-    driver_opts:
-      type: cifs
-      o: username=USER,password=PASSWORD,rw
-      device: //NAS_HOSTNAME/blocky
-```
-
-#### Multiple configuration files
+## Multiple configuration files
 
 For complex setups, splitting the configuration between multiple YAML files might be desired. In this case, folder containing YAML files is passed on startup, Blocky will join all the files.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -241,5 +241,3 @@ See linked project for installation instructions.
 - [BlockyUI](https://github.com/GabeDuarteM/blocky-ui) provides a fully featured and modern Web UI for managing your Blocky DNS server.
 
 - [Blocky Visor](https://github.com/JCHHeilmann/blocky-visor) is a static SPA dashboard with live metrics and DNS query testing. Comes with an optional Go sidecar that adds historical analytics based on parsing Blocky's log files, log viewing, and config editing.
-
---8<-- "docs/includes/abbreviations.md"

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -6,7 +6,7 @@
 ??? abstract "OpenAPI specification"
 
     ```yaml
-    --8<-- "docs/api/openapi.yaml"
+    --8<-- "api/openapi.yaml"
     ```
 
 If http listener is enabled, blocky provides REST API. You can download the [OpenAPI YAML](api/openapi.yaml) interface specification. 
@@ -64,5 +64,3 @@ To run the CLI, please ensure, that blocky DNS server is running, then execute `
 !!! tip 
 
     To run this inside docker run `docker exec blocky ./blocky blocking status`
-
---8<-- "docs/includes/abbreviations.md"

--- a/docs/network_configuration.md
+++ b/docs/network_configuration.md
@@ -165,5 +165,3 @@ protocol on the Blocky listener and configure the proxy to send it.
         }
     }
     ```
-
---8<-- "docs/includes/abbreviations.md"

--- a/docs/prometheus_grafana.md
+++ b/docs/prometheus_grafana.md
@@ -82,5 +82,3 @@ Please define the MySQL source in Grafana, which points to the database with blo
 ## Postgres
 
 The JSON for a Grafana dashboard equivalent to the MySQL/MariaDB version is located [here](blocky-query-grafana-postgres.json)
-
---8<-- "docs/includes/abbreviations.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,19 @@ site_name: blocky
 site_description: blocky Documentation
 theme:
   name: material
+  features:
+    - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.top
+    - toc.follow
+    - content.code.copy
+    - content.tooltips
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+    - search.share
   palette:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
@@ -32,10 +45,14 @@ extra:
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/r/spx01/blocky
 repo_url: https://github.com/0xERR0R/blocky
+edit_uri: edit/main/docs/
 
 markdown_extensions:
   - abbr
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      base_path: [docs]
+      auto_append:
+        - includes/abbreviations.md
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ theme:
     - navigation.top
     - toc.follow
     - content.code.copy
+    - content.code.annotate
     - content.tooltips
     - content.action.edit
     - search.suggest
@@ -49,6 +50,8 @@ edit_uri: edit/main/docs/
 
 markdown_extensions:
   - abbr
+  - attr_list
+  - md_in_html
   - pymdownx.snippets:
       base_path: [docs]
       auto_append:
@@ -57,7 +60,16 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.keys
   - admonition
   - pymdownx.details
 


### PR DESCRIPTION
## What & why

Material for MkDocs is now in maintenance mode, and its **9.7.0** release folded every previously-paid Insiders feature into the free MIT edition. This PR adopts the now-free, high-value features to improve the docs UX — staying on MkDocs (no migration), with **no new build dependencies** and the `docs.yml` CI workflow unchanged.

## Changes

**Tier 1 — config-only UX wins (`16b02797`)**
- `features:` enabled: `content.code.copy`, `content.tooltips`, `content.action.edit`, `navigation.instant` (+ `prefetch`/`progress`), `navigation.tracking`, `navigation.top`, `toc.follow`, `search.suggest`/`highlight`/`share`
- `edit_uri: edit/main/docs/` for the "edit this page" action
- `pymdownx.snippets`: `base_path: [docs]` + `auto_append: includes/abbreviations.md` → removed the 6 repeated abbreviation includes and shortened the remaining snippet paths

**Tier 2 — richer content (`aa60203b`, `aff51785`)**
- Content tabs (`pymdownx.tabbed`): installation now offers **Standalone binary** vs **Docker** top-level tabs, with **docker run** / **docker-compose** nested under Docker
- Mermaid diagram (superfences custom fence) on the landing page
- Code annotations on the intro config example
- Enabled `attr_list`, `md_in_html`, `pymdownx.tasklist`, `pymdownx.keys` (deliberately skipped `mark`/`caret`/`tilde` to avoid re-parsing existing prose)
- Promoted the docker reference subsections to top-level headings so they stay in the page TOC
- Fixed a pre-existing bug: the *Advanced setup* code block wasn't indented into its `!!! example` admonition (rendered detached)

## Verification

Every step built cleanly with the project's own `squidfunk/mkdocs-material` image (exit 0, no warnings). Tabs/nesting, mermaid blocks, snippet inclusion, abbreviation auto-append, and the new heading structure are all confirmed in the generated HTML. Mermaid and code annotations render client-side (Material JS) — confirmed via an isolated canonical-example test that this is expected, not a misconfiguration.

## Not included (Tier 3, follow-up)

These need pip deps added to `docs.yml`, so left for a separate PR: `privacy` plugin (self-host hotlinked rapidoc/svg/fontawesome assets), `social` cards, `optimize` (shrink the 233 KB Grafana PNG), `git-revision-date-localized` ("last updated").