### PR TITLE
feat(cli): add 'blocky stats' command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ Complete documentation is available at https://github.com/0xERR0R/blocky`,
 		NewListsCommand(),
 		NewHealthcheckCommand(),
 		newCacheCommand(),
+		NewStatsCommand(),
 		NewValidateCommand())
 
 	return c

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/0xERR0R/blocky/api"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+const (
+	statsTimeFormat = "2006-01-02 15:04"
+	emptyNote       = "(none)"
+)
+
+// renderStats writes a human-readable dashboard of the stats snapshot to w.
+func renderStats(w io.Writer, s *api.ApiStats) {
+	fmt.Fprintf(w, "Window: %s .. %s (UTC)\n\n",
+		s.Start.UTC().Format(statsTimeFormat),
+		s.End.UTC().Format(statsTimeFormat))
+
+	renderSummary(w, s)
+	renderTopTable(w, "Top Domains", s.TopDomains)
+	renderTopTable(w, "Top Blocked", s.TopBlockedDomains)
+	renderTopTable(w, "Top Clients", s.TopClients)
+	renderBreakdown(w, "By Query Type", s.ByQueryType)
+	renderBreakdown(w, "By Response Code", s.ByResponseCode)
+	renderBreakdown(w, "By Response Type", s.ByResponseType)
+	renderFooter(w, s)
+}
+
+func newStatsTable(w io.Writer, rightAlignCols ...int) table.Writer {
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+
+	cfgs := make([]table.ColumnConfig, 0, len(rightAlignCols))
+	for _, c := range rightAlignCols {
+		cfgs = append(cfgs, table.ColumnConfig{Number: c, Align: text.AlignRight})
+	}
+
+	t.SetColumnConfigs(cfgs)
+
+	return t
+}
+
+func renderSummary(w io.Writer, s *api.ApiStats) {
+	sum := s.Summary
+
+	fmt.Fprintf(w, "Summary\n")
+
+	t := newStatsTable(w, 2)
+	t.AppendHeader(table.Row{"Metric", "Value"})
+	t.AppendRow(table.Row{"Queries", formatInt(sum.Queries)})
+	t.AppendRow(table.Row{"Cached", withPercent(sum.Cached, sum.Queries)})
+	t.AppendRow(table.Row{"Forwarded", formatInt(sum.Forwarded)})
+	t.AppendRow(table.Row{"Blocked", withPercent(sum.Blocked, sum.Queries)})
+	t.AppendRow(table.Row{"Local", formatInt(sum.Local)})
+	t.AppendRow(table.Row{"Dropped", formatInt(sum.Dropped)})
+	t.AppendRow(table.Row{"Errors", formatInt(sum.Errors)})
+	t.AppendRow(table.Row{"Avg response", fmt.Sprintf("%d ms", sum.AvgResponseMs)})
+	t.AppendRow(table.Row{"Cache hit rate", fmt.Sprintf("%.1f%%", sum.CacheHitRate*100)})
+	t.Render()
+	fmt.Fprintln(w)
+}
+
+func renderTopTable(w io.Writer, title string, rows []api.ApiNameCount) {
+	if len(rows) == 0 {
+		fmt.Fprintf(w, "%s: %s\n\n", title, emptyNote)
+
+		return
+	}
+
+	fmt.Fprintf(w, "%s\n", title)
+
+	t := newStatsTable(w, 2)
+	t.AppendHeader(table.Row{"Name", "Count"})
+
+	for _, r := range rows {
+		t.AppendRow(table.Row{r.Name, formatInt(r.Count)})
+	}
+
+	t.Render()
+	fmt.Fprintln(w)
+}
+
+func renderBreakdown(w io.Writer, title string, counts map[string]int) {
+	if len(counts) == 0 {
+		fmt.Fprintf(w, "%s: %s\n\n", title, emptyNote)
+
+		return
+	}
+
+	type kv struct {
+		name  string
+		count int
+	}
+
+	items := make([]kv, 0, len(counts))
+	for k, v := range counts {
+		items = append(items, kv{k, v})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].count != items[j].count {
+			return items[i].count > items[j].count
+		}
+
+		return items[i].name < items[j].name
+	})
+
+	fmt.Fprintf(w, "%s\n", title)
+
+	t := newStatsTable(w, 2)
+	t.AppendHeader(table.Row{"Type", "Count"})
+
+	for _, it := range items {
+		t.AppendRow(table.Row{it.name, formatInt(it.count)})
+	}
+
+	t.Render()
+	fmt.Fprintln(w)
+}
+
+func renderFooter(w io.Writer, s *api.ApiStats) {
+	fmt.Fprintf(w, "Cache: %s entries\n\n", formatInt(s.Cache.Entries))
+
+	groups := map[string]struct{}{}
+	for g := range s.Lists.Denylist {
+		groups[g] = struct{}{}
+	}
+
+	for g := range s.Lists.Allowlist {
+		groups[g] = struct{}{}
+	}
+
+	if len(groups) == 0 {
+		fmt.Fprintf(w, "Lists: %s\n", emptyNote)
+
+		return
+	}
+
+	names := make([]string, 0, len(groups))
+	for g := range groups {
+		names = append(names, g)
+	}
+
+	sort.Strings(names)
+
+	fmt.Fprintf(w, "Lists\n")
+
+	t := newStatsTable(w, 2, 3)
+	t.AppendHeader(table.Row{"Group", "Denylist", "Allowlist"})
+
+	for _, g := range names {
+		t.AppendRow(table.Row{g, formatInt(s.Lists.Denylist[g]), formatInt(s.Lists.Allowlist[g])})
+	}
+
+	t.Render()
+}
+
+func withPercent(part, total int) string {
+	return fmt.Sprintf("%s (%s)", formatInt(part), formatPercent(part, total))
+}
+
+func formatPercent(part, total int) string {
+	if total == 0 {
+		return "0.0%"
+	}
+
+	return fmt.Sprintf("%.1f%%", float64(part)/float64(total)*100)
+}
+
+func formatInt(n int) string {
+	s := strconv.Itoa(n)
+
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		s = s[1:]
+	}
+
+	var b strings.Builder
+
+	for i := range len(s) {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+
+		b.WriteByte(s[i])
+	}
+
+	if neg {
+		return "-" + b.String()
+	}
+
+	return b.String()
+}

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -10,12 +12,51 @@ import (
 	"github.com/0xERR0R/blocky/api"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
 )
 
 const (
 	statsTimeFormat = "2006-01-02 15:04"
 	emptyNote       = "(none)"
 )
+
+// NewStatsCommand creates new command instance
+func NewStatsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "stats",
+		Args:              cobra.NoArgs,
+		Short:             "shows DNS statistics",
+		RunE:              stats,
+		PersistentPreRunE: initConfigPreRun,
+	}
+}
+
+func stats(cmd *cobra.Command, _ []string) error {
+	client, err := newAPIClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.GetStatsWithResponse(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("can't execute %w", err)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK:
+		if resp.JSON200 == nil {
+			return errors.New("unexpected empty stats response")
+		}
+
+		renderStats(cmd.OutOrStdout(), resp.JSON200)
+
+		return nil
+	case http.StatusServiceUnavailable:
+		return errors.New("statistics are disabled (enable 'statistics.enable' in config)")
+	default:
+		return fmt.Errorf("response NOK, %s %s", resp.Status(), string(resp.Body))
+	}
+}
 
 // renderStats writes a human-readable dashboard of the stats snapshot to w.
 func renderStats(w io.Writer, s *api.ApiStats) {

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -161,6 +161,7 @@ func renderFooter(w io.Writer, s *api.ApiStats) {
 	}
 
 	t.Render()
+	fmt.Fprintln(w)
 }
 
 func withPercent(part, total int) string {

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -16,8 +16,11 @@ import (
 )
 
 const (
-	statsTimeFormat = "2006-01-02 15:04"
-	emptyNote       = "(none)"
+	statsTimeFormat        = "2006-01-02 15:04"
+	emptyNote              = "(none)"
+	statsTypeColLabel      = "Type"
+	percentMultiplier      = 100
+	statsListsAllowlistCol = 3
 )
 
 // NewStatsCommand creates new command instance
@@ -104,7 +107,7 @@ func renderSummary(w io.Writer, s *api.ApiStats) {
 	t.AppendRow(table.Row{"Dropped", formatInt(sum.Dropped)})
 	t.AppendRow(table.Row{"Errors", formatInt(sum.Errors)})
 	t.AppendRow(table.Row{"Avg response", fmt.Sprintf("%d ms", sum.AvgResponseMs)})
-	t.AppendRow(table.Row{"Cache hit rate", fmt.Sprintf("%.1f%%", sum.CacheHitRate*100)})
+	t.AppendRow(table.Row{"Cache hit rate", fmt.Sprintf("%.1f%%", sum.CacheHitRate*percentMultiplier)})
 	t.Render()
 	fmt.Fprintln(w)
 }
@@ -157,7 +160,7 @@ func renderBreakdown(w io.Writer, title string, counts map[string]int) {
 	fmt.Fprintf(w, "%s\n", title)
 
 	t := newStatsTable(w, 2)
-	t.AppendHeader(table.Row{"Type", "Count"})
+	t.AppendHeader(table.Row{statsTypeColLabel, "Count"})
 
 	for _, it := range items {
 		t.AppendRow(table.Row{it.name, formatInt(it.count)})
@@ -194,7 +197,7 @@ func renderFooter(w io.Writer, s *api.ApiStats) {
 
 	fmt.Fprintf(w, "Lists\n")
 
-	t := newStatsTable(w, 2, 3)
+	t := newStatsTable(w, 2, statsListsAllowlistCol)
 	t.AppendHeader(table.Row{"Group", "Denylist", "Allowlist"})
 
 	for _, g := range names {
@@ -214,7 +217,7 @@ func formatPercent(part, total int) string {
 		return "0.0%"
 	}
 
-	return fmt.Sprintf("%.1f%%", float64(part)/float64(total)*100)
+	return fmt.Sprintf("%.1f%%", float64(part)/float64(total)*percentMultiplier)
 }
 
 func formatInt(n int) string {

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/0xERR0R/blocky/api"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func sampleStats() api.ApiStats {
+	start := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+
+	return api.ApiStats{
+		Start: start,
+		End:   start.Add(12 * time.Hour),
+		Summary: api.ApiStatsSummary{
+			Queries: 12431, Cached: 5102, Forwarded: 4445, Blocked: 2884,
+			Local: 12, Dropped: 3, Errors: 7, AvgResponseMs: 7, CacheHitRate: 0.41,
+		},
+		ByQueryType:       map[string]int{"A": 9000, "AAAA": 3431},
+		ByResponseCode:    map[string]int{"NOERROR": 11000, "NXDOMAIN": 1431},
+		ByResponseType:    map[string]int{"CACHED": 5102, "BLOCKED": 2884},
+		TopDomains:        []api.ApiNameCount{{Name: "github.com", Count: 1203}},
+		TopBlockedDomains: []api.ApiNameCount{{Name: "ads.example.com", Count: 402}},
+		TopClients:        []api.ApiNameCount{{Name: "10.0.0.5", Count: 4310}},
+		Lists: api.ApiListCounts{
+			Denylist:  map[string]int{"ads": 142000},
+			Allowlist: map[string]int{"ads": 30},
+		},
+		Cache: api.ApiCacheStats{Entries: 8123},
+	}
+}
+
+var _ = Describe("renderStats", func() {
+	It("renders a populated snapshot with formatted numbers and all sections", func() {
+		s := sampleStats()
+		var buf bytes.Buffer
+
+		renderStats(&buf, &s)
+		out := buf.String()
+
+		Expect(out).Should(ContainSubstring("Window:"))
+		Expect(out).Should(ContainSubstring("(UTC)"))
+		Expect(out).Should(ContainSubstring("Summary"))
+		Expect(out).Should(ContainSubstring("Queries"))
+		Expect(out).Should(ContainSubstring("12,431")) // thousands separator
+		Expect(out).Should(ContainSubstring("41.0%"))  // cache hit rate 0.41 -> 41.0%
+		Expect(out).Should(ContainSubstring("Top Domains"))
+		Expect(out).Should(ContainSubstring("github.com"))
+		Expect(out).Should(ContainSubstring("Top Blocked"))
+		Expect(out).Should(ContainSubstring("ads.example.com"))
+		Expect(out).Should(ContainSubstring("Top Clients"))
+		Expect(out).Should(ContainSubstring("By Query Type"))
+		Expect(out).Should(ContainSubstring("Cache: 8,123 entries"))
+		Expect(out).Should(ContainSubstring("Lists"))
+	})
+
+	It("renders (none) for empty lists and avoids divide-by-zero when there are no queries", func() {
+		s := api.ApiStats{
+			Start:          time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+			End:            time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+			Summary:        api.ApiStatsSummary{}, // all zero
+			ByQueryType:    map[string]int{},
+			ByResponseCode: map[string]int{},
+			ByResponseType: map[string]int{},
+			TopDomains:     []api.ApiNameCount{},
+			Lists:          api.ApiListCounts{Denylist: map[string]int{}, Allowlist: map[string]int{}},
+			Cache:          api.ApiCacheStats{Entries: 0},
+		}
+		var buf bytes.Buffer
+
+		renderStats(&buf, &s)
+		out := buf.String()
+
+		Expect(out).Should(ContainSubstring("Top Domains: (none)"))
+		Expect(out).Should(ContainSubstring("By Query Type: (none)"))
+		Expect(out).Should(ContainSubstring("Lists: (none)"))
+		Expect(out).Should(ContainSubstring("0.0%")) // no panic, graceful percentage
+	})
+
+	It("formats integers with thousands separators", func() {
+		Expect(formatInt(0)).Should(Equal("0"))
+		Expect(formatInt(999)).Should(Equal("999"))
+		Expect(formatInt(12431)).Should(Equal("12,431"))
+		Expect(formatInt(1000000)).Should(Equal("1,000,000"))
+		Expect(formatInt(-12431)).Should(Equal("-12,431"))
+	})
+
+	It("formats percentages and guards against zero totals", func() {
+		Expect(formatPercent(41, 100)).Should(Equal("41.0%"))
+		Expect(formatPercent(0, 0)).Should(Equal("0.0%"))
+	})
+})

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/0xERR0R/blocky/api"
-	"github.com/0xERR0R/blocky/log"
-	"github.com/sirupsen/logrus/hooks/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,7 +31,9 @@ func sampleStats() api.ApiStats {
 		TopBlockedDomains: []api.ApiNameCount{{Name: "ads.example.com", Count: 402}},
 		TopClients:        []api.ApiNameCount{{Name: "10.0.0.5", Count: 4310}},
 		Lists: api.ApiListCounts{
-			Denylist:  map[string]int{"ads": 142000},
+			// "tracking" is denylist-only: it must still appear in the Lists table
+			// (with a 0 allowlist cell), exercising the group-key union in renderFooter.
+			Denylist:  map[string]int{"ads": 142000, "tracking": 5000},
 			Allowlist: map[string]int{"ads": 30},
 		},
 		Cache: api.ApiCacheStats{Entries: 8123},
@@ -66,6 +66,8 @@ var _ = Describe("renderStats", func() {
 		Expect(out).Should(ContainSubstring("By Response Code"))
 		Expect(out).Should(ContainSubstring("By Response Type"))
 		Expect(out).Should(ContainSubstring("142,000"))
+		Expect(out).Should(ContainSubstring("tracking")) // denylist-only group surfaces via union
+		Expect(out).Should(ContainSubstring("5,000"))    // its denylist count
 		Expect(strings.Index(out, "9,000")).Should(BeNumerically("<", strings.Index(out, "3,431")))
 	})
 
@@ -108,9 +110,8 @@ var _ = Describe("renderStats", func() {
 
 var _ = Describe("stats command", func() {
 	var (
-		ts         *httptest.Server
-		mockFn     func(w http.ResponseWriter, _ *http.Request)
-		loggerHook *test.Hook
+		ts     *httptest.Server
+		mockFn func(w http.ResponseWriter, _ *http.Request)
 	)
 
 	JustBeforeEach(func() {
@@ -121,11 +122,6 @@ var _ = Describe("stats command", func() {
 	})
 	BeforeEach(func() {
 		mockFn = func(w http.ResponseWriter, _ *http.Request) {}
-		loggerHook = test.NewGlobal()
-		log.Log().AddHook(loggerHook)
-	})
-	AfterEach(func() {
-		loggerHook.Reset()
 	})
 
 	When("stats are available", func() {

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"strings"
 	"time"
 
 	"github.com/0xERR0R/blocky/api"
@@ -56,6 +57,11 @@ var _ = Describe("renderStats", func() {
 		Expect(out).Should(ContainSubstring("By Query Type"))
 		Expect(out).Should(ContainSubstring("Cache: 8,123 entries"))
 		Expect(out).Should(ContainSubstring("Lists"))
+		Expect(out).Should(ContainSubstring("7 ms"))
+		Expect(out).Should(ContainSubstring("By Response Code"))
+		Expect(out).Should(ContainSubstring("By Response Type"))
+		Expect(out).Should(ContainSubstring("142,000"))
+		Expect(strings.Index(out, "9,000")).Should(BeNumerically("<", strings.Index(out, "3,431")))
 	})
 
 	It("renders (none) for empty lists and avoids divide-by-zero when there are no queries", func() {

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -2,10 +2,15 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"time"
 
 	"github.com/0xERR0R/blocky/api"
+	"github.com/0xERR0R/blocky/log"
+	"github.com/sirupsen/logrus/hooks/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -98,5 +103,87 @@ var _ = Describe("renderStats", func() {
 	It("formats percentages and guards against zero totals", func() {
 		Expect(formatPercent(41, 100)).Should(Equal("41.0%"))
 		Expect(formatPercent(0, 0)).Should(Equal("0.0%"))
+	})
+})
+
+var _ = Describe("stats command", func() {
+	var (
+		ts         *httptest.Server
+		mockFn     func(w http.ResponseWriter, _ *http.Request)
+		loggerHook *test.Hook
+	)
+
+	JustBeforeEach(func() {
+		ts = testHTTPAPIServer(mockFn)
+	})
+	JustAfterEach(func() {
+		ts.Close()
+	})
+	BeforeEach(func() {
+		mockFn = func(w http.ResponseWriter, _ *http.Request) {}
+		loggerHook = test.NewGlobal()
+		log.Log().AddHook(loggerHook)
+	})
+	AfterEach(func() {
+		loggerHook.Reset()
+	})
+
+	When("stats are available", func() {
+		BeforeEach(func() {
+			mockFn = func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Add("Content-Type", "application/json")
+				s := sampleStats()
+				response, err := json.Marshal(s)
+				Expect(err).Should(Succeed())
+				_, err = w.Write(response)
+				Expect(err).Should(Succeed())
+			}
+		})
+		It("renders the dashboard to the command output", func() {
+			cmd := withContext(NewStatsCommand())
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+
+			Expect(stats(cmd, []string{})).Should(Succeed())
+			Expect(buf.String()).Should(ContainSubstring("Queries"))
+			Expect(buf.String()).Should(ContainSubstring("github.com"))
+			Expect(buf.String()).Should(ContainSubstring("Cache:"))
+		})
+	})
+
+	When("statistics are disabled (503)", func() {
+		BeforeEach(func() {
+			mockFn = func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte("statistics are disabled"))
+			}
+		})
+		It("returns a friendly error", func() {
+			err := stats(withContext(NewStatsCommand()), []string{})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("disabled"))
+		})
+	})
+
+	When("server returns 500", func() {
+		BeforeEach(func() {
+			mockFn = func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		})
+		It("returns an error", func() {
+			err := stats(withContext(NewStatsCommand()), []string{})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("500 Internal Server Error"))
+		})
+	})
+
+	When("the API URL is unreachable", func() {
+		It("returns a transport error", func() {
+			apiPort = 0
+			err := stats(withContext(NewStatsCommand()), []string{})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("connection refused"))
+		})
 	})
 })

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -59,6 +59,7 @@ To run the CLI, please ensure, that blocky DNS server is running, then execute `
 - `./blocky query <domain>` execute DNS query (A) (simple replacement for dig, useful for debug purposes)
 - `./blocky query <domain> --type <queryType>` execute DNS query with passed query type (A, AAAA, MX, ...)
 - `./blocky lists refresh` reloads all allow/denylists
+- `./blocky stats` shows DNS statistics (requires `statistics.enable: true`)
 - `./blocky validate [--config /path/to/config.yaml]` validates configuration file
 
 !!! tip 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/invopop/jsonschema v0.14.0
+	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/jedisct1/go-dnsstamps v0.0.0-20260518121737-6579dc73e4a2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/miekg/dns v1.1.72
@@ -104,7 +105,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/jedib0t/go-pretty/v6 v6.6.7 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect


### PR DESCRIPTION
## Summary

Adds a new `blocky stats` CLI command that queries the `GET /api/stats` REST endpoint and renders the in-memory DNS statistics as a readable terminal dashboard.

The dashboard shows:
- **Summary** — queries, cached, forwarded, blocked, local, dropped, errors, avg response time, and cache hit rate (with `% of queries` where meaningful)
- **Top Domains / Top Blocked / Top Clients** tables
- **Breakdowns** by query type, response code, and response type (sorted by count, then name)
- **Cache** entry count and a per-group **Lists** table (denylist / allowlist)

Rendering uses `github.com/jedib0t/go-pretty/v6`, promoted from an indirect to a direct dependency — it was already in the module graph, so this adds no new transitive dependencies. Tabular output is written to stdout rather than through the logger, so table alignment is preserved.

Pretty-only by design (YAGNI): no flags, no JSON mode, no per-hour series — the raw response stays available via `curl .../api/stats`.

## Behaviour

| Response | Outcome |
| --- | --- |
| `200` | renders the dashboard |
| `503` (statistics disabled) | friendly error: `statistics are disabled (enable 'statistics.enable' in config)` |
| transport error | `can't execute …` (matches sibling commands) |
| other non-200 | `response NOK, <status> <body>` |

## Tests

ginkgo/gomega specs in `cmd/stats_test.go`:
- **Pure renderer** — populated snapshot (all sections, thousands separators, cache-hit %, deterministic count-desc ordering, footer group-key union with a denylist-only group), empty/zero-query snapshot (`(none)` sections, divide-by-zero guard), and the `formatInt`/`formatPercent` helpers.
- **Command (HTTP-mocked via `testHTTPAPIServer`)** — 200 renders the dashboard, 503 → disabled error, 500 → error, unreachable → connection error.

`go test ./cmd/` passes; `golangci-lint run ./cmd/...` reports 0 issues.

## Docs

`docs/interfaces.md` CLI command list updated with `./blocky stats`.
