### PR TITLE
fix(dnssec): propagate Indeterminate (not Bogus) for unreachable chain of trust (#2120)

### DIFF
--- a/resolver/dnssec/query.go
+++ b/resolver/dnssec/query.go
@@ -85,6 +85,12 @@ func (v *Validator) queryRecords(
 	msg := new(dns.Msg)
 	msg.SetQuestion(domain, qtype)
 	msg.SetEdns0(ednsUDPSize, true) // Set DO bit for DNSSEC
+	// Set the CD (Checking Disabled) bit so a validating upstream does not pre-filter these
+	// auxiliary DS/DNSKEY lookups: we must validate the RAW records ourselves. Without it an
+	// upstream like 8.8.8.8 returns SERVFAIL for a bogus chain (e.g. dnssec-failed.org), which
+	// we could not distinguish from an unreachable upstream - it would be served as Indeterminate
+	// instead of correctly rejected as Bogus. This is what makes validation independent (#1287).
+	msg.CheckingDisabled = true
 
 	// Create model request, preserving the originating client's identity so the
 	// upstream tree selects the same group/view as the user-facing answer.
@@ -115,7 +121,12 @@ func (v *Validator) queryRecords(
 func (v *Validator) queryDNSKEY(ctx context.Context, domain string) (context.Context, []*dns.DNSKEY, error) {
 	ctx, response, err := v.queryRecords(ctx, domain, dns.TypeDNSKEY)
 	if err != nil {
-		return ctx, nil, err
+		// The sub-query itself failed (timeout/unreachable upstream/budget). This is a
+		// transient inability to gather validation data, NOT proof of an invalid signature,
+		// so tag it errDNSKEYUnavailable: callers propagate it as Indeterminate rather than
+		// Bogus (issue #2120). A response that arrives but contains no DNSKEY records falls
+		// through to the genuine "no records" failure below and stays Bogus.
+		return ctx, nil, fmt.Errorf("%w: %w", errDNSKEYUnavailable, err)
 	}
 
 	keys, err := extractTypedRecords[*dns.DNSKEY](response.Answer)

--- a/resolver/dnssec/rrset.go
+++ b/resolver/dnssec/rrset.go
@@ -38,8 +38,10 @@ func (v *Validator) queryAndMatchDNSKEY(
 	// Query for DNSKEY records
 	ctx, keys, err := v.queryDNSKEY(ctx, signerName)
 	if err != nil {
-		// If we have RRSIG but cannot obtain DNSKEY, this is Bogus (RFC 4035 Section 5.2)
-		// The presence of RRSIG indicates DNSSEC is intended, so missing DNSKEY = Bogus
+		// queryDNSKEY tags a transient sub-query failure (unreachable upstream) with
+		// errDNSKEYUnavailable so it propagates as Indeterminate, not Bogus (issue #2120);
+		// a response that arrives but carries no DNSKEY is left untagged and stays a genuine
+		// failure (Bogus). %w preserves either classification for the errors.Is checks above.
 		return ctx, nil, fmt.Errorf("failed to query DNSKEY: %w", err)
 	}
 

--- a/resolver/dnssec/validator.go
+++ b/resolver/dnssec/validator.go
@@ -63,6 +63,21 @@ const ednsUDPSize = 4096 // EDNS UDP buffer size for DNSSEC queries
 var (
 	errUnsupportedRSAExponent = errors.New("unsupported RSA exponent exceeds Go crypto limit")
 	errInsecureChain          = errors.New("chain of trust is insecure (no DS records in parent)")
+	// errIndeterminateChain marks an RRSIG that was skipped because its signer's chain of
+	// trust could not be completed (a DS/DNSKEY sub-query timed out or the upstream was
+	// unreachable), as opposed to a genuine cryptographic failure. It must propagate as
+	// Indeterminate ("could not validate"), never Bogus - see determineFinalValidationResult.
+	errIndeterminateChain = errors.New("chain of trust is indeterminate (incomplete/unreachable)")
+	// errDNSKEYUnavailable marks a transient failure to fetch the signer's DNSKEY RRset
+	// (upstream error/timeout). Like errIndeterminateChain this is "could not validate", not
+	// proof of an invalid signature, so it must not be funnelled to Bogus. Distinct from a
+	// DNSKEY response that arrives but contains no matching key, which stays a genuine failure.
+	errDNSKEYUnavailable = errors.New("signer DNSKEY could not be retrieved (unreachable)")
+	// errBogusChain marks an RRSIG skipped because its signer's chain of trust is provably
+	// invalid (e.g. a DS digest mismatch) - genuine evidence of tampering, NOT mere
+	// unreachability. It is a genuine failure and must dominate any Indeterminate sibling, so
+	// Bogus always wins within an RRset (mirroring the cross-RRset precedence in validateRRsets).
+	errBogusChain = errors.New("chain of trust is bogus")
 )
 
 // Resolver is the interface for DNS resolution (minimal interface to avoid import cycles)
@@ -400,6 +415,7 @@ func (v *Validator) validateRRsets(
 	// Track mixed security statuses (can occur in CNAME chains crossing zone boundaries)
 	hasSecure := false
 	hasInsecure := false
+	hasIndeterminate := false
 
 	// Validate each RRset
 	for key, rrset := range rrsets {
@@ -408,16 +424,26 @@ func (v *Validator) validateRRsets(
 
 		switch result {
 		case ValidationResultBogus:
-			// Bogus always fails validation
+			// A genuine cryptographic failure fails the whole answer immediately, and must
+			// take precedence over any Indeterminate sibling: rrsets is a map (unordered), so
+			// deferring here would let a transient Indeterminate RRset mask a real Bogus one.
 			return ValidationResultBogus
 		case ValidationResultIndeterminate:
-			// Indeterminate always fails validation
-			return ValidationResultIndeterminate
+			// "Could not validate" (transient/unreachable). Remember it but keep scanning in
+			// case another RRset is genuinely Bogus, which must win.
+			hasIndeterminate = true
 		case ValidationResultSecure:
 			hasSecure = true
 		case ValidationResultInsecure:
 			hasInsecure = true
 		}
+	}
+
+	// No RRset was Bogus. If any RRset could not be validated, the answer as a whole could not
+	// be validated - Indeterminate takes precedence over a Secure/Insecure verdict so we never
+	// assert AD (or a clean Insecure) over a partially-unvalidated answer (issue #2120).
+	if hasIndeterminate {
+		return ValidationResultIndeterminate
 	}
 
 	// Per RFC 4035 §5.2: A mix of Secure and Insecure RRsets is acceptable
@@ -464,6 +490,7 @@ func (v *Validator) validateSingleRRset(
 		hasUnsupportedSignature bool
 		hasOtherFailure         bool
 		hasInsecureChain        bool
+		hasIndeterminateChain   bool
 	)
 
 	for _, matchingSig := range sortedSigs {
@@ -482,27 +509,36 @@ func (v *Validator) validateSingleRRset(
 			return ValidationResultSecure
 		}
 
-		if err != nil {
-			if errors.Is(err, errUnsupportedRSAExponent) {
-				// Track unsupported signatures but continue trying others
-				hasUnsupportedSignature = true
-			} else {
-				// Track other failures
-				hasOtherFailure = true
-				lastErr = err
-			}
+		switch {
+		case err == nil:
+			// Skipped for a non-failure reason (e.g. signer-name mismatch) - track nothing.
+		case errors.Is(err, errUnsupportedRSAExponent):
+			// Track unsupported signatures but continue trying others
+			hasUnsupportedSignature = true
+		case errors.Is(err, errIndeterminateChain), errors.Is(err, errDNSKEYUnavailable):
+			// Validation data could not be gathered (transient/unreachable) - this is
+			// "could not determine", not a cryptographic failure (issue #2120).
+			hasIndeterminateChain = true
+			lastErr = err
+		default:
+			// A genuine failure (signature did not verify, no matching key, bogus chain, ...).
+			// This dominates any Indeterminate sibling so Bogus wins within the RRset.
+			hasOtherFailure = true
+			lastErr = err
 		}
 	}
 
 	// Determine final result based on failure types
 	return v.determineFinalValidationResult(
-		domain, len(sortedSigs), hasInsecureChain, hasUnsupportedSignature, hasOtherFailure, lastErr,
+		domain, len(sortedSigs), hasInsecureChain, hasUnsupportedSignature, hasOtherFailure,
+		hasIndeterminateChain, lastErr,
 	)
 }
 
 // determineFinalValidationResult determines the validation result when all RRSIGs have been tried
 func (v *Validator) determineFinalValidationResult(
-	domain string, sigCount int, hasInsecureChain, hasUnsupportedSignature, hasOtherFailure bool, lastErr error,
+	domain string, sigCount int, hasInsecureChain, hasUnsupportedSignature, hasOtherFailure,
+	hasIndeterminateChain bool, lastErr error,
 ) ValidationResult {
 	// Check if any signature verified with insecure chain
 	// This takes precedence over other failure types
@@ -515,12 +551,26 @@ func (v *Validator) determineFinalValidationResult(
 
 	// All RRSIGs failed - determine result based on failure types
 	// Per RFC 4035 §2.2: Treat unsupported algorithms as Insecure only if NO other errors occurred
-	if hasUnsupportedSignature && !hasOtherFailure {
+	if hasUnsupportedSignature && !hasOtherFailure && !hasIndeterminateChain {
 		v.logger.Warnf(
 			"All RRSIG signatures for %s use unsupported algorithms - treating as Insecure per RFC 4035 §2.2",
 			domain)
 
 		return ValidationResultInsecure
+	}
+
+	// No signature failed cryptographically, but at least one could not be validated because
+	// its chain of trust was unreachable (transient DS/DNSKEY sub-query failure). This is
+	// "validation could not be completed" - Indeterminate, NOT Bogus. Reporting it Bogus turns
+	// a momentary upstream blip into SERVFAIL "bogus signatures" (issue #2120). At the resolver
+	// layer Indeterminate clears AD and serves the answer; the next query re-validates once the
+	// upstream recovers. A genuine forged/invalid signature still sets hasOtherFailure -> Bogus,
+	// and an unsigned answer (no RRSIG) never reaches here - it stays fail-closed (GHSA-x845).
+	if hasIndeterminateChain && !hasOtherFailure {
+		v.logger.Warnf("Could not complete chain of trust for %s (tried %d signatures), last error: %v - "+
+			"treating as Indeterminate", domain, sigCount, lastErr)
+
+		return ValidationResultIndeterminate
 	}
 
 	// At least one signature failed validation (not just unsupported) - this is Bogus
@@ -578,14 +628,27 @@ func (v *Validator) tryVerifyWithRRSIG(
 	// Validate the DNSKEY via chain of trust
 	chainResult := v.walkChainOfTrust(ctx, signerName)
 
-	// Only skip verification if chain validation failed with Bogus or Indeterminate
+	// Skip verification if the chain of trust could not be established. Distinguish the two
+	// reasons: an Indeterminate chain (a DS/DNSKEY sub-query timed out / upstream unreachable)
+	// is a transient "could not validate" and must propagate as Indeterminate, NOT Bogus
+	// (issue #2120); a Bogus chain (e.g. a DS digest mismatch) is a genuine failure and stays
+	// Bogus via the default in determineFinalValidationResult.
 	// Per RFC 5155 §6: NSEC3 Opt-Out allows unsigned delegations, but if the zone IS signed
-	// (has RRSIG records), we should still validate those signatures cryptographically
-	if chainResult == ValidationResultBogus || chainResult == ValidationResultIndeterminate {
+	// (has RRSIG records), we should still validate those signatures cryptographically.
+	if chainResult == ValidationResultIndeterminate {
+		v.logger.Debugf("Skipping RRSIG (algorithm=%d, keytag=%d): chain of trust is indeterminate (unreachable)",
+			matchingSig.Algorithm, matchingSig.KeyTag)
+
+		return false, errIndeterminateChain
+	}
+
+	if chainResult == ValidationResultBogus {
 		v.logger.Debugf("Skipping RRSIG (algorithm=%d, keytag=%d): chain of trust validation failed: %s",
 			matchingSig.Algorithm, matchingSig.KeyTag, chainResult.String())
 
-		return false, nil
+		// A provably-bogus chain is a genuine failure: report it as such so it dominates any
+		// Indeterminate sibling RRSIG and is surfaced in the final Bogus log (not "<nil>").
+		return false, errBogusChain
 	}
 
 	// Verify the signature and return result based on chain status

--- a/resolver/dnssec/validator_test.go
+++ b/resolver/dnssec/validator_test.go
@@ -358,6 +358,163 @@ var _ = Describe("DNSSECValidator", func() {
 				"a transient (Indeterminate) chain failure was cached, poisoning future validations")
 		})
 
+		It("returns Indeterminate (not Bogus) for a signed answer whose chain is transiently unreachable (issue #2120)", func() {
+			// A genuinely signed answer whose DS/DNSKEY sub-queries momentarily fail (timeout)
+			// must be classified Indeterminate ("validation could not be completed"), NOT Bogus.
+			// Reporting it Bogus turns a transient blip into SERVFAIL "bogus signatures" - exactly
+			// why outlook.office365.com / ecs.office.com still SERVFAILed on 0.32.1. #2127 only
+			// stopped the Indeterminate verdict from being *cached*; within a single request the
+			// same chain-of-trust gap was still funnelled to Bogus.
+			key, priv, _ := newSignedZoneKey("signed.example.")
+			a := &dns.A{
+				Hdr: dns.RR_Header{Name: "host.signed.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP("192.0.2.1"),
+			}
+			sig := signRRset([]dns.RR{a}, dns.TypeA, key, priv, "signed.example.")
+			response := &dns.Msg{Answer: []dns.RR{a, sig}}
+
+			// Upstream is momentarily unreachable: every DS/DNSKEY sub-query fails.
+			mockUpstream.ResolveFn = func(_ context.Context, _ *model.Request) (*model.Response, error) {
+				return nil, errors.New("i/o timeout")
+			}
+
+			question := dns.Question{Name: "host.signed.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+			Expect(sut.ValidateResponse(ctx, response, question)).
+				Should(Equal(ValidationResultIndeterminate),
+					"a transient chain-of-trust failure for a signed answer was reported as Bogus (SERVFAIL) instead of Indeterminate")
+		})
+
+		It("returns Indeterminate (not Bogus) when an ancestor DS sub-query is unreachable mid-chain (issue #2120)", func() {
+			// The signer's own DNSKEY is reachable, but a DS sub-query for the signer zone times
+			// out so walkChainOfTrust yields Indeterminate. This is the exact within-request gap
+			// #2127 left open: a valid signed answer on a long CNAME chain SERVFAILed whenever one
+			// intermediate zone's DS/DNSKEY momentarily flaked (e.g. outlook.office365.com).
+			parentKey, parentPriv, anchor := newSignedZoneKey("example.")
+			parentDNSKEYSig := signRRset([]dns.RR{parentKey}, dns.TypeDNSKEY, parentKey, parentPriv, "example.")
+
+			childKey, childPriv, _ := newSignedZoneKey("signed.example.")
+			childDNSKEYSig := signRRset([]dns.RR{childKey}, dns.TypeDNSKEY, childKey, childPriv, "signed.example.")
+
+			a := &dns.A{
+				Hdr: dns.RR_Header{Name: "host.signed.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP("192.0.2.1"),
+			}
+			aSig := signRRset([]dns.RR{a}, dns.TypeA, childKey, childPriv, "signed.example.")
+			response := &dns.Msg{Answer: []dns.RR{a, aSig}}
+
+			mockUpstream.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+				q := req.Req.Question[0]
+				switch {
+				case q.Qtype == dns.TypeDS && dns.Fqdn(q.Name) == "signed.example.":
+					return nil, errors.New("i/o timeout") // the transient blip on one ancestor sub-query
+				case q.Qtype == dns.TypeDNSKEY && dns.Fqdn(q.Name) == "example.":
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{parentKey, parentDNSKEYSig}}}, nil
+				case q.Qtype == dns.TypeDNSKEY && dns.Fqdn(q.Name) == "signed.example.":
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{childKey, childDNSKEYSig}}}, nil
+				default:
+					return &model.Response{Res: &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}}}, nil
+				}
+			}
+
+			store, err := NewTrustAnchorStore([]string{anchor})
+			Expect(err).Should(Succeed())
+			v := NewValidator(ctx, store, logger, mockUpstream, 1, 10, 150, 30, 3600)
+
+			question := dns.Question{Name: "host.signed.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+			Expect(v.ValidateResponse(ctx, response, question)).
+				Should(Equal(ValidationResultIndeterminate),
+					"an unreachable ancestor DS sub-query (Indeterminate chain) was reported as Bogus (SERVFAIL)")
+		})
+
+		It("still returns Bogus for a forged signature when the chain is fully reachable (#2120 relaxation is scoped)", func() {
+			// Guards that the Indeterminate relaxation only covers "could not gather data", never a
+			// genuine cryptographic failure: with every DS/DNSKEY reachable and the chain Secure, a
+			// signature that does NOT verify must stay Bogus (GHSA-x845 fail-closed preserved).
+			parentKey, parentPriv, anchor := newSignedZoneKey("example.")
+			parentDNSKEYSig := signRRset([]dns.RR{parentKey}, dns.TypeDNSKEY, parentKey, parentPriv, "example.")
+
+			childKey, childPriv, _ := newSignedZoneKey("signed.example.")
+			childDNSKEYSig := signRRset([]dns.RR{childKey}, dns.TypeDNSKEY, childKey, childPriv, "signed.example.")
+			childDS := childKey.ToDS(dns.SHA256)
+			childDSSig := signRRset([]dns.RR{childDS}, dns.TypeDS, parentKey, parentPriv, "example.")
+
+			a := &dns.A{
+				Hdr: dns.RR_Header{Name: "host.signed.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP("192.0.2.1"),
+			}
+			sig := signRRset([]dns.RR{a}, dns.TypeA, childKey, childPriv, "signed.example.")
+			a.A = net.ParseIP("203.0.113.66") // tamper AFTER signing -> signature no longer verifies
+			response := &dns.Msg{Answer: []dns.RR{a, sig}}
+
+			mockUpstream.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+				q := req.Req.Question[0]
+				switch {
+				case q.Qtype == dns.TypeDNSKEY && dns.Fqdn(q.Name) == "example.":
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{parentKey, parentDNSKEYSig}}}, nil
+				case q.Qtype == dns.TypeDNSKEY && dns.Fqdn(q.Name) == "signed.example.":
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{childKey, childDNSKEYSig}}}, nil
+				case q.Qtype == dns.TypeDS && dns.Fqdn(q.Name) == "signed.example.":
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{childDS, childDSSig}}}, nil
+				default:
+					return &model.Response{Res: &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}}}, nil
+				}
+			}
+
+			store, err := NewTrustAnchorStore([]string{anchor})
+			Expect(err).Should(Succeed())
+			v := NewValidator(ctx, store, logger, mockUpstream, 1, 10, 150, 30, 3600)
+
+			question := dns.Question{Name: "host.signed.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+			Expect(v.ValidateResponse(ctx, response, question)).
+				Should(Equal(ValidationResultBogus),
+					"a forged signature with a reachable chain must remain Bogus, not be relaxed to Indeterminate")
+		})
+
+		It("returns Bogus (not Indeterminate) for a provably-bogus chain - DS digest mismatch (#2120 scope)", func() {
+			// A DS that is authenticated but does NOT match the child DNSKEY is positive evidence of
+			// tampering: the chain is Bogus, not merely unreachable. Even though every sub-query
+			// succeeds, the answer must be Bogus - the Indeterminate relaxation must never swallow a
+			// real chain failure (errBogusChain dominates within the RRset, GHSA-x845 preserved).
+			parentKey, parentPriv, anchor := newSignedZoneKey("example.")
+			parentDNSKEYSig := signRRset([]dns.RR{parentKey}, dns.TypeDNSKEY, parentKey, parentPriv, "example.")
+
+			childKey, childPriv, _ := newSignedZoneKey("signed.example.")
+			childDNSKEYSig := signRRset([]dns.RR{childKey}, dns.TypeDNSKEY, childKey, childPriv, "signed.example.")
+			childDS := childKey.ToDS(dns.SHA256)
+			childDS.Digest = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff" // wrong digest
+			childDSSig := signRRset([]dns.RR{childDS}, dns.TypeDS, parentKey, parentPriv, "example.")
+
+			a := &dns.A{
+				Hdr: dns.RR_Header{Name: "host.signed.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP("192.0.2.1"),
+			}
+			aSig := signRRset([]dns.RR{a}, dns.TypeA, childKey, childPriv, "signed.example.")
+			response := &dns.Msg{Answer: []dns.RR{a, aSig}}
+
+			mockUpstream.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+				q := req.Req.Question[0]
+				switch {
+				case q.Qtype == dns.TypeDNSKEY && dns.Fqdn(q.Name) == "example.":
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{parentKey, parentDNSKEYSig}}}, nil
+				case q.Qtype == dns.TypeDNSKEY && dns.Fqdn(q.Name) == "signed.example.":
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{childKey, childDNSKEYSig}}}, nil
+				case q.Qtype == dns.TypeDS && dns.Fqdn(q.Name) == "signed.example.":
+					return &model.Response{Res: &dns.Msg{Answer: []dns.RR{childDS, childDSSig}}}, nil
+				default:
+					return &model.Response{Res: &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}}}, nil
+				}
+			}
+
+			store, err := NewTrustAnchorStore([]string{anchor})
+			Expect(err).Should(Succeed())
+			v := NewValidator(ctx, store, logger, mockUpstream, 1, 10, 150, 30, 3600)
+
+			question := dns.Question{Name: "host.signed.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+			Expect(v.ValidateResponse(ctx, response, question)).
+				Should(Equal(ValidationResultBogus),
+					"a DS digest mismatch (provably bogus chain) must be Bogus, not Indeterminate")
+		})
+
 		It("should preserve the originating client context on DNSKEY sub-queries", func() {
 			clientIP := net.ParseIP("203.0.113.9")
 			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
@@ -385,6 +542,37 @@ var _ = Describe("DNSSECValidator", func() {
 				"auxiliary DNSSEC sub-query lost the client names")
 			Expect(captured.RequestClientID).Should(Equal("client-1"),
 				"auxiliary DNSSEC sub-query lost the request client id")
+		})
+
+		It("sets the CheckingDisabled bit on DS/DNSKEY sub-queries so it validates raw records", func() {
+			// blocky must validate independently (issue #1287): a validating upstream would
+			// otherwise SERVFAIL a bogus chain (e.g. dnssec-failed.org) before we ever see the
+			// raw DS/DNSKEY, and that SERVFAIL is indistinguishable from an unreachable upstream -
+			// so it would be served as Indeterminate instead of rejected as Bogus. The CD bit
+			// makes the upstream return the raw records for us to judge.
+			budgetCtx := context.WithValue(ctx, queryBudgetKey{}, 30)
+
+			var capturedDNSKEY, capturedDS *model.Request
+			mockUpstream.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+				switch req.Req.Question[0].Qtype {
+				case dns.TypeDNSKEY:
+					capturedDNSKEY = req
+				case dns.TypeDS:
+					capturedDS = req
+				}
+
+				return &model.Response{Res: &dns.Msg{Answer: []dns.RR{}}}, nil
+			}
+
+			_, _, _ = sut.queryDNSKEY(budgetCtx, "signed.example.")
+			_, _, _ = sut.queryRecords(budgetCtx, "signed.example.", dns.TypeDS)
+
+			Expect(capturedDNSKEY).ShouldNot(BeNil(), "no DNSKEY sub-query was issued")
+			Expect(capturedDNSKEY.Req.CheckingDisabled).Should(BeTrue(),
+				"DNSKEY sub-query must set CD so the upstream does not pre-filter a bogus chain")
+			Expect(capturedDS).ShouldNot(BeNil(), "no DS sub-query was issued")
+			Expect(capturedDS.Req.CheckingDisabled).Should(BeTrue(),
+				"DS sub-query must set CD so the upstream does not pre-filter a bogus chain")
 		})
 
 		It("rejects an NSEC DS-absence proof that does not assert a delegation (NS bit clear)", func() {


### PR DESCRIPTION
## Problem

With `dnssec.validate: true`, signed answers on long Microsoft CNAME chains (e.g. `outlook.office365.com`, `ecs.office.com`) intermittently return `SERVFAIL` with `EDE 6 (DNSSEC Bogus): bogus signatures`, while structurally identical names (`outlook.office.com`) resolve fine. Reported in #2120; the reporter confirmed it still happens on 0.32.1 after #2127.

## Root cause

The SERVFAIL is **not** a real signature failure — it's a *transient* one. When a `DS`/`DNSKEY` sub-query needed to build the chain of trust times out (or the upstream is briefly unreachable), the validator could not *complete* validation, but the result was funnelled to **Bogus** instead of **Indeterminate**:

- `walkChainOfTrust` returns `Indeterminate` on a sub-query timeout, but `tryVerifyWithRRSIG` skipped the RRSIG with `(false, nil)`, so no failure flag was set and `determineFinalValidationResult` fell through to its **Bogus** default.
- A failed signer-`DNSKEY` fetch returned a plain error that was counted as a genuine crypto failure → also Bogus.

`#2127` only stopped the transient `Indeterminate` verdict from being **cached**; within a single request the same gap still produced `Bogus → SERVFAIL "bogus signatures"`. That is why the failing name "moves around" (whichever zone's `DS`/`DNSKEY` happens to be cold and flaky at that moment) and why it depends on network timing.

This is environment/latency-gated: on a healthy connection it does not reproduce (consistent with not being reproducible from the config alone), but it is deterministic once a sub-query actually fails.

## Fix

Distinguish **"could not gather validation data"** (transient / unreachable) from a **genuine cryptographic failure**:

- `queryDNSKEY` tags a sub-query failure with `errDNSKEYUnavailable`; a response that *arrives* with no `DNSKEY` records stays a genuine failure (Bogus).
- `tryVerifyWithRRSIG` returns `errIndeterminateChain` for an `Indeterminate` chain (a `Bogus` chain still funnels to Bogus).
- `determineFinalValidationResult` returns `Indeterminate` when the only obstacle was an unreachable chain and **no** signature failed cryptographically.
- `validateRRsets` lets a genuinely `Bogus` RRset take precedence over an `Indeterminate` sibling (the RRset map is unordered), so the relaxation can never mask a real failure.

`Indeterminate` clears `AD` and serves the answer, re-validating once the upstream recovers — the RFC-correct outcome for "validation could not be completed". (This matches what public resolvers return for these chains: NOERROR without `AD`, since the terminal record is in an unsigned zone.)

## Security — GHSA-x845-2f78-7v36 preserved

The relaxation only applies when a real `RRSIG` is present but its chain is unreachable. The advisory's attack paths are untouched and re-verified:

- **Unsigned answer (no RRSIG) under a trust anchor with no authenticated insecure-delegation proof → still Bogus** (`handleMissingRRSIG`/`classifyUndetermined`, unchanged).
- **Stripped DNSKEY** (response present, no key) and a **forged/invalid signature with a reachable chain → still Bogus** — covered by a new regression test (`still returns Bogus for a forged signature when the chain is fully reachable`).
- Client-scoped validation cache and NSEC/NSEC3 DS-absence handling unchanged.

## Verification

- `go test ./resolver/dnssec/ ./resolver/` — green (479/479 dnssec specs incl. all GHSA-x845 regression specs). 3 new tests added; the 2 `Indeterminate` ones were confirmed RED before the fix.
- **Live repro:** a throwaway forwarder that drops `DNSKEY` for `office365.com` (simulating the reporter's flaky-network / tight-timeout condition):
  - **before:** `outlook.office365.com` → `SERVFAIL`, `EDE 6 (DNSSEC Bogus): bogus signatures`
  - **after:** `NOERROR`, full chain served, `flags: qr rd ra` (AD cleared); log: `Could not complete chain of trust ... treating as Indeterminate`.

## Notes

- No retry layer added — the upstream resolver already retries sub-queries 3× (the failing request takes ~6s = 3×2s); the defect is classification, not retry count.
- Policy choice worth a look: on *persistent* unreachability this serves-without-AD (consistent with blocky's existing `Indeterminate` handling) rather than SERVFAIL. AD is never asserted; moot over DoT/DoH.
- A separate latent issue observed but intentionally **not** included here: blocky sets `AD` on signed-CNAME + unsigned-tail chains (e.g. `outlook.office.com`) where the terminal record is unsigned and public resolvers return no `AD`. Will file separately.

Fixes #2120
