### PR TITLE
fix(ecs): apply useAsClient above cache and client-name lookup (#2140)

### DIFF
--- a/e2e/ecs_clientname_test.go
+++ b/e2e/ecs_clientname_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ECS client identity (issue #2140)", func() {
 		By("sending the same query twice, each carrying a /32 ECS option for 10.0.0.1", func() {
 			for range 2 {
 				msg := util.NewMsgWithQuestion("example.com.", A)
-				addECSOption(msg, net.ParseIP("10.0.0.1"), 32)
+				addECSOption(msg, net.ParseIP("10.0.0.1"))
 
 				Expect(doDNSRequest(ctx, blocky, msg)).
 					Should(BeDNSRecord("example.com.", A, "1.2.3.4"))
@@ -128,5 +128,8 @@ type ecsLogEntry struct {
 func queryECSEntries(db *gorm.DB) ([]ecsLogEntry, error) {
 	var entries []ecsLogEntry
 
-	return entries, db.Table("log_entries").Order("request_ts").Find(&entries).Error
+	// Order by rowid as a tiebreaker: the two back-to-back queries can share the same
+	// request_ts, and ORDER BY request_ts alone would then return them in an undefined
+	// order. rowid reflects insertion order (resolved entry queued before the cached one).
+	return entries, db.Table("log_entries").Order("request_ts, rowid").Find(&entries).Error
 }

--- a/e2e/ecs_clientname_test.go
+++ b/e2e/ecs_clientname_test.go
@@ -1,0 +1,132 @@
+package e2e
+
+import (
+	"context"
+	"net"
+	"os"
+
+	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/util"
+
+	sqliteDriver "github.com/glebarez/sqlite"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+	"gorm.io/gorm"
+)
+
+// Regression test for https://github.com/0xERR0R/blocky/issues/2140
+//
+// With ecs.useAsClient, blocky must attribute a query to the EDNS Client Subnet client (for
+// client-name lookup and query logging) rather than to the connecting forwarder - and that
+// attribution must survive cache hits. The connecting test client is some docker network
+// address (never 10.0.0.1), so resolving the client name to "ecsclient" and logging the
+// client IP as 10.0.0.1 can only happen if the ECS subnet was adopted as the client.
+var _ = Describe("ECS client identity (issue #2140)", func() {
+	var (
+		e2eNet  *testcontainers.DockerNetwork
+		blocky  testcontainers.Container
+		hostDir string
+		db      *gorm.DB
+		err     error
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		e2eNet = getRandomNetwork(ctx)
+
+		_, err = createDNSMokkaContainer(ctx, "moka", e2eNet,
+			`A example.com/NOERROR("A 1.2.3.4 300")`)
+		Expect(err).Should(Succeed())
+
+		// Create a host dir, world-writable so the container's non-root user can write the DB.
+		hostDir, err = os.MkdirTemp("", "blocky_e2e_ecs_clientname-")
+		Expect(err).Should(Succeed())
+		Expect(os.Chmod(hostDir, 0o777)).Should(Succeed())
+		DeferCleanup(func() error { return os.RemoveAll(hostDir) })
+
+		blocky, err = createBlockyContainerWithBinds(ctx, e2eNet,
+			[]string{hostDir + ":/data"},
+			"log:",
+			"  level: warn",
+			"upstreams:",
+			"  groups:",
+			"    default:",
+			"      - moka",
+			// map the ECS client IP (not the forwarder) to a name, resolved in-memory
+			"clientLookup:",
+			"  clients:",
+			"    ecsclient:",
+			"      - 10.0.0.1",
+			"ecs:",
+			"  useAsClient: true",
+			"queryLog:",
+			"  type: sqlite",
+			"  target: /data/querylog.db",
+			"  flushInterval: 1s",
+		)
+		Expect(err).Should(Succeed())
+	})
+
+	It("attributes both the resolved and the cached response to the ECS client", func(ctx context.Context) {
+		By("sending the same query twice, each carrying a /32 ECS option for 10.0.0.1", func() {
+			for range 2 {
+				msg := util.NewMsgWithQuestion("example.com.", A)
+				addECSOption(msg, net.ParseIP("10.0.0.1"), 32)
+
+				Expect(doDNSRequest(ctx, blocky, msg)).
+					Should(BeDNSRecord("example.com.", A, "1.2.3.4"))
+			}
+		})
+
+		By("opening the SQLite query log written by blocky (after it created the schema)", func() {
+			Eventually(func() error {
+				db, err = gorm.Open(sqliteDriver.Open(
+					"file:"+hostDir+"/querylog.db?_pragma=busy_timeout(5000)"), &gorm.Config{})
+
+				return err
+			}, "10s", "1s").Should(Succeed())
+		})
+
+		By("waiting for both entries to be flushed", func() {
+			Eventually(countEntries, "60s", "1s").WithArguments(db).Should(BeNumerically("==", 2))
+		})
+
+		By("checking the resolved entry is attributed to the ECS client", func() {
+			entries, err := queryECSEntries(db)
+			Expect(err).Should(Succeed())
+			Expect(entries).Should(HaveLen(2))
+
+			Expect(entries[0]).Should(
+				SatisfyAll(
+					HaveField("ResponseType", "RESOLVED"),
+					HaveField("ClientIP", "10.0.0.1"),
+					HaveField("ClientName", "ecsclient"),
+				))
+		})
+
+		By("checking the cached entry is still attributed to the ECS client", func() {
+			entries, err := queryECSEntries(db)
+			Expect(err).Should(Succeed())
+
+			Expect(entries[1]).Should(
+				SatisfyAll(
+					HaveField("ResponseType", "CACHED"),
+					HaveField("ClientIP", "10.0.0.1"),
+					HaveField("ClientName", "ecsclient"),
+				))
+		})
+	})
+})
+
+type ecsLogEntry struct {
+	ClientIP     string `gorm:"column:client_ip"`
+	ClientName   string `gorm:"column:client_name"`
+	ResponseType string `gorm:"column:response_type"`
+	QuestionName string `gorm:"column:question_name"`
+}
+
+func queryECSEntries(db *gorm.DB) ([]ecsLogEntry, error) {
+	var entries []ecsLogEntry
+
+	return entries, db.Table("log_entries").Order("request_ts").Find(&entries).Error
+}

--- a/e2e/ecs_test.go
+++ b/e2e/ecs_test.go
@@ -12,20 +12,22 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 )
 
-// addECSOption adds an EDNS0 CLIENT-SUBNET option to the given DNS message.
-func addECSOption(msg *dns.Msg, ip net.IP, mask uint8) {
+// addECSOption adds a full-prefix EDNS0 CLIENT-SUBNET option (the only form the ECS e2e
+// tests need) to the given DNS message.
+func addECSOption(msg *dns.Msg, ip net.IP) {
 	o := new(dns.OPT)
 	o.Hdr.Name = "."
 	o.Hdr.Rrtype = dns.TypeOPT
 
 	e := new(dns.EDNS0_SUBNET)
 	if ip.To4() != nil {
-		e.Family = 1 // IPv4
+		e.Family = 1                      // IPv4
+		e.SourceNetmask = net.IPv4len * 8 // /32
 	} else {
-		e.Family = 2 // IPv6
+		e.Family = 2                      // IPv6
+		e.SourceNetmask = net.IPv6len * 8 // /128
 	}
 
-	e.SourceNetmask = mask
 	e.SourceScope = 0
 	e.Address = ip
 
@@ -66,7 +68,7 @@ var _ = Describe("EDNS Client Subnet (ECS)", func() {
 
 			It("should resolve queries when ECS option is present", func(ctx context.Context) {
 				msg := util.NewMsgWithQuestion("example.com.", A)
-				addECSOption(msg, net.ParseIP("10.0.0.1"), 32)
+				addECSOption(msg, net.ParseIP("10.0.0.1"))
 
 				Expect(doDNSRequest(ctx, blocky, msg)).
 					Should(
@@ -100,7 +102,7 @@ var _ = Describe("EDNS Client Subnet (ECS)", func() {
 
 			It("should resolve queries with ECS forwarding enabled", func(ctx context.Context) {
 				msg := util.NewMsgWithQuestion("example.com.", A)
-				addECSOption(msg, net.ParseIP("10.1.2.3"), 32)
+				addECSOption(msg, net.ParseIP("10.1.2.3"))
 
 				Expect(doDNSRequest(ctx, blocky, msg)).
 					Should(
@@ -135,7 +137,7 @@ var _ = Describe("EDNS Client Subnet (ECS)", func() {
 
 			It("should resolve queries with custom ECS masks configured", func(ctx context.Context) {
 				msg := util.NewMsgWithQuestion("example.com.", A)
-				addECSOption(msg, net.ParseIP("10.1.2.3"), 32)
+				addECSOption(msg, net.ParseIP("10.1.2.3"))
 
 				Expect(doDNSRequest(ctx, blocky, msg)).
 					Should(

--- a/resolver/ecs_client_resolver_test.go
+++ b/resolver/ecs_client_resolver_test.go
@@ -1,0 +1,188 @@
+package resolver
+
+import (
+	"context"
+	"net"
+
+	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/util"
+	"github.com/creasty/defaults"
+
+	. "github.com/0xERR0R/blocky/helpertest"
+	. "github.com/0xERR0R/blocky/model"
+
+	"github.com/miekg/dns"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ = Describe("ECSClientResolver", func() {
+	var (
+		sut       *ECSClientResolver
+		sutConfig config.ECS
+		m         *mockResolver
+		origIP    net.IP
+		ecsIP     net.IP
+	)
+
+	BeforeEach(func() {
+		Expect(defaults.Set(&sutConfig)).Should(Succeed())
+		sutConfig.UseAsClient = true
+
+		origIP = net.ParseIP("1.2.3.4").To4()
+		ecsIP = net.ParseIP("4.3.2.1").To4()
+	})
+
+	JustBeforeEach(func() {
+		m = &mockResolver{}
+		m.On("Resolve", mock.Anything).Return(respondWith(new(dns.Msg)), nil)
+
+		sut = NewECSClientResolver(sutConfig).(*ECSClientResolver)
+		sut.Next(m)
+	})
+
+	Describe("Type", func() {
+		It("follows conventions", func() {
+			expectValidResolverType(sut)
+		})
+	})
+
+	When("useAsClient is enabled and a full-prefix (/32) ECS option is present", func() {
+		It("adopts the ECS address as the internal client IP", func(ctx context.Context) {
+			request := newRequest("example.com.", A)
+			request.ClientIP = origIP
+			addEcsOption(request.Req, ecsIP, ecsMaskIPv4)
+
+			m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
+				Expect(req.ClientIP).Should(Equal(ecsIP))
+
+				return respondWith(new(dns.Msg)), nil
+			}
+
+			_, err := sut.Resolve(ctx, request)
+			Expect(err).Should(Succeed())
+		})
+	})
+
+	When("the ECS option only covers a partial prefix (/24)", func() {
+		It("keeps the original client IP", func(ctx context.Context) {
+			request := newRequest("example.com.", A)
+			request.ClientIP = origIP
+			addEcsOption(request.Req, ecsIP, 24)
+
+			m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
+				Expect(req.ClientIP).Should(Equal(origIP))
+
+				return respondWith(new(dns.Msg)), nil
+			}
+
+			_, err := sut.Resolve(ctx, request)
+			Expect(err).Should(Succeed())
+		})
+	})
+
+	When("useAsClient is disabled", func() {
+		BeforeEach(func() {
+			sutConfig.UseAsClient = false
+		})
+
+		It("keeps the original client IP even with a full-prefix ECS option", func(ctx context.Context) {
+			request := newRequest("example.com.", A)
+			request.ClientIP = origIP
+			addEcsOption(request.Req, ecsIP, ecsMaskIPv4)
+
+			m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
+				Expect(req.ClientIP).Should(Equal(origIP))
+
+				return respondWith(new(dns.Msg)), nil
+			}
+
+			_, err := sut.Resolve(ctx, request)
+			Expect(err).Should(Succeed())
+		})
+	})
+})
+
+// Regression test for https://github.com/0xERR0R/blocky/issues/2140
+//
+// With ecs.useAsClient, the EDNS Client Subnet address must be adopted as the internal
+// client IP *before* the client-name lookup and the cache, so that:
+//   - the client name is resolved from the ECS client (not the connecting forwarder), and
+//   - cached responses are still attributed to the ECS client (the cache short-circuits the
+//     chain on a hit, so anything below it never runs for cached answers).
+var _ = Describe("ECS as client across the resolver chain (issue #2140)", func() {
+	var (
+		ecsClient   *ECSClientResolver
+		upstream    *mockResolver
+		ecsIP       net.IP
+		forwarderIP net.IP
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		ecsIP = net.ParseIP("4.3.2.1").To4()
+		forwarderIP = net.ParseIP("1.2.3.4").To4()
+
+		// upstream returns a cacheable answer
+		answer, err := util.NewMsgWithAnswer("example.com.", 300, A, "9.9.9.9")
+		Expect(err).Should(Succeed())
+
+		upstream = &mockResolver{}
+		upstream.On("Resolve", mock.Anything).
+			Return(&Response{Res: answer, RType: ResponseTypeRESOLVED, Reason: "Test"}, nil)
+
+		// caching resolver (enabled with defaults)
+		var cachingCfg config.Caching
+		Expect(defaults.Set(&cachingCfg)).Should(Succeed())
+
+		caching, err := NewCachingResolver(ctx, cachingCfg, nil)
+		Expect(err).Should(Succeed())
+		caching.Next(upstream)
+
+		// client names resolver resolves the ECS client IP -> name from an in-memory
+		// mapping, so no rDNS upstream is required for the test
+		clientNames, err := NewClientNamesResolver(ctx, config.ClientLookup{
+			ClientnameIPMapping: map[string][]net.IP{"ecs-client": {ecsIP}},
+		}, defaultUpstreamsConfig, nil)
+		Expect(err).Should(Succeed())
+		clientNames.Next(caching)
+
+		// ECS-as-client runs ABOVE the client-name lookup and the cache
+		var ecsCfg config.ECS
+		Expect(defaults.Set(&ecsCfg)).Should(Succeed())
+		ecsCfg.UseAsClient = true
+
+		ecsClient = NewECSClientResolver(ecsCfg).(*ECSClientResolver)
+		ecsClient.Next(clientNames)
+	})
+
+	newECSRequest := func() *Request {
+		req := newRequest("example.com.", A)
+		req.ClientIP = forwarderIP // the connecting forwarder, e.g. the opnsense router
+		addEcsOption(req.Req, ecsIP, ecsMaskIPv4)
+
+		return req
+	}
+
+	It("attributes both the resolved and the cached response to the ECS client", func(ctx context.Context) {
+		By("resolving the first query upstream", func() {
+			req := newECSRequest()
+
+			resp, err := ecsClient.Resolve(ctx, req)
+			Expect(err).Should(Succeed())
+			Expect(resp.RType).Should(Equal(ResponseTypeRESOLVED))
+			Expect(req.ClientIP).Should(Equal(ecsIP))
+			Expect(req.ClientNames).Should(Equal([]string{"ecs-client"}))
+		})
+
+		By("serving the second identical query from cache, still attributed to the ECS client", func() {
+			req := newECSRequest()
+
+			resp, err := ecsClient.Resolve(ctx, req)
+			Expect(err).Should(Succeed())
+			Expect(resp.RType).Should(Equal(ResponseTypeCACHED))
+			Expect(req.ClientIP).Should(Equal(ecsIP))
+			Expect(req.ClientNames).Should(Equal([]string{"ecs-client"}))
+		})
+	})
+})

--- a/resolver/ecs_resolver.go
+++ b/resolver/ecs_resolver.go
@@ -60,7 +60,7 @@ func (r *ECSClientResolver) Resolve(ctx context.Context, request *model.Request)
 		// A full prefix (/32 for IPv4, /128 for IPv6) identifies a single client, so the
 		// subnet address can stand in for the connecting client's IP.
 		so := util.GetEdns0Option[*dns.EDNS0_SUBNET](request.Req)
-		if so != nil && ((so.Family == ecsFamilyIPv4 && so.SourceNetmask == ecsMaskIPv4) ||
+		if so != nil && so.Address != nil && ((so.Family == ecsFamilyIPv4 && so.SourceNetmask == ecsMaskIPv4) ||
 			(so.Family == ecsFamilyIPv6 && so.SourceNetmask == ecsMaskIPv6)) {
 			logger.Debugf("using request's edns0 address as internal client IP: %s", so.Address)
 			request.ClientIP = so.Address

--- a/resolver/ecs_resolver.go
+++ b/resolver/ecs_resolver.go
@@ -31,6 +31,55 @@ type ECSMask interface {
 	config.ECSv4Mask | config.ECSv6Mask
 }
 
+// ECSClientResolver adopts the EDNS Client Subnet address of a request as the internal
+// client IP (the ecs.useAsClient option).
+type ECSClientResolver struct {
+	configurable[*config.ECS]
+	NextResolver
+	typed
+}
+
+// NewECSClientResolver creates a new resolver instance which uses the ECS subnet as client IP
+func NewECSClientResolver(cfg config.ECS) ChainedResolver {
+	return &ECSClientResolver{
+		configurable: withConfig(&cfg),
+		typed:        withType("ecs_as_client"),
+	}
+}
+
+// Resolve adopts the request's full-prefix EDNS Client Subnet address as the internal
+// client IP (when ecs.useAsClient is enabled) and delegates to the next resolver.
+//
+// It must run above the client-name lookup and the cache so the ECS-derived client identity
+// is used for those features and survives cache hits (the cache short-circuits the chain on a
+// hit, so anything below it never runs for cached answers).
+func (r *ECSClientResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
+	if r.cfg.UseAsClient {
+		_, logger := r.log(ctx)
+
+		// A full prefix (/32 for IPv4, /128 for IPv6) identifies a single client, so the
+		// subnet address can stand in for the connecting client's IP.
+		so := util.GetEdns0Option[*dns.EDNS0_SUBNET](request.Req)
+		if so != nil && ((so.Family == ecsFamilyIPv4 && so.SourceNetmask == ecsMaskIPv4) ||
+			(so.Family == ecsFamilyIPv6 && so.SourceNetmask == ecsMaskIPv6)) {
+			logger.Debugf("using request's edns0 address as internal client IP: %s", so.Address)
+			request.ClientIP = so.Address
+		}
+	}
+
+	return r.next.Resolve(ctx, request)
+}
+
+// IsEnabled implements `config.Configurable`.
+func (r *ECSClientResolver) IsEnabled() bool {
+	return r.cfg.UseAsClient
+}
+
+// LogConfig implements `config.Configurable`.
+func (r *ECSClientResolver) LogConfig(logger *logrus.Entry) {
+	logger.Infof("use ECS subnet as client = %t", r.cfg.UseAsClient)
+}
+
 // ECSResolver is responsible for adding the EDNS Client Subnet information as EDNS0 option.
 type ECSResolver struct {
 	configurable[*config.ECS]
@@ -46,20 +95,17 @@ func NewECSResolver(cfg config.ECS) ChainedResolver {
 	}
 }
 
-// Resolve adds the subnet information as EDNS0 option to the request of the next resolver
-// and sets the client IP from the EDNS0 option to the request if this option is enabled
+// Resolve adds, forwards or removes the EDNS Client Subnet option on the request before it is
+// sent upstream. Adopting the ECS subnet as the internal client IP (ecs.useAsClient) is handled
+// separately by the ECSClientResolver, which runs above the client-name lookup and the cache.
 func (r *ECSResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	if r.cfg.IsEnabled() {
-		ctx, logger := r.log(ctx)
-		_ = ctx
+		_, logger := r.log(ctx)
 
 		so := util.GetEdns0Option[*dns.EDNS0_SUBNET](request.Req)
-		// Set the client IP from the Edns0 subnet option if the option is enabled and the correct subnet mask is set
-		if r.cfg.UseAsClient && so != nil && ((so.Family == ecsFamilyIPv4 && so.SourceNetmask == ecsMaskIPv4) ||
-			(so.Family == ecsFamilyIPv6 && so.SourceNetmask == ecsMaskIPv6)) {
-			logger.Debugf("using request's edns0 address as internal client IP: %s", so.Address)
-			request.ClientIP = so.Address
-		}
+
+		// Adopting the ECS subnet as the internal client IP (ecs.useAsClient) happens in the
+		// ECSClientResolver, which runs above the client-name lookup and the cache.
 
 		// Set the Edns0 subnet option if the client IP is IPv4 or IPv6 and the masks are set in the configuration
 		if r.cfg.IPv4Mask > 0 || r.cfg.IPv6Mask > 0 {

--- a/resolver/ecs_resolver_test.go
+++ b/resolver/ecs_resolver_test.go
@@ -76,54 +76,6 @@ var _ = Describe("EcsResolver", func() {
 			})
 		})
 
-		When("use ECS client ip is enabled", func() {
-			BeforeEach(func() {
-				sutConfig.UseAsClient = true
-			})
-
-			It("should change ClientIP with subnet 32", func(ctx context.Context) {
-				request := newRequest("example.com.", A)
-				request.ClientIP = origIP
-
-				addEcsOption(request.Req, ecsIP, ecsMaskIPv4)
-
-				m.ResolveFn = func(ctx context.Context, req *Request) (*Response, error) {
-					Expect(req.ClientIP).Should(Equal(ecsIP))
-
-					return respondWith(mockAnswer), nil
-				}
-
-				Expect(sut.Resolve(ctx, request)).
-					Should(
-						SatisfyAll(
-							HaveNoAnswer(),
-							HaveResponseType(ResponseTypeRESOLVED),
-							HaveReturnCode(dns.RcodeSuccess),
-							HaveReason("Test")))
-			})
-
-			It("shouldn't change ClientIP with subnet 24", func(ctx context.Context) {
-				request := newRequest("example.com.", A)
-				request.ClientIP = origIP
-
-				addEcsOption(request.Req, ecsIP, 24)
-
-				m.ResolveFn = func(ctx context.Context, req *Request) (*Response, error) {
-					Expect(req.ClientIP).Should(Equal(origIP))
-
-					return respondWith(mockAnswer), nil
-				}
-
-				Expect(sut.Resolve(ctx, request)).
-					Should(
-						SatisfyAll(
-							HaveNoAnswer(),
-							HaveResponseType(ResponseTypeRESOLVED),
-							HaveReturnCode(dns.RcodeSuccess),
-							HaveReason("Test")))
-			})
-		})
-
 		When("add ECS information", func() {
 			BeforeEach(func() {
 				sutConfig.IPv4Mask = 32
@@ -184,7 +136,7 @@ var _ = Describe("EcsResolver", func() {
 				addEcsOption(request.Req, ecsIP, ecsMaskIPv4)
 
 				m.ResolveFn = func(ctx context.Context, req *Request) (*Response, error) {
-					Expect(req.ClientIP).Should(Equal(ecsIP))
+					Expect(req.ClientIP).Should(Equal(origIP))
 					Expect(req.Req).Should(HaveEdnsOption(dns.EDNS0SUBNET))
 
 					so := util.GetEdns0Option[*dns.EDNS0_SUBNET](req.Req)
@@ -214,7 +166,7 @@ var _ = Describe("EcsResolver", func() {
 					addEcsOption(request.Req, ecsIP, ecsMaskIPv4)
 
 					m.ResolveFn = func(ctx context.Context, req *Request) (*Response, error) {
-						Expect(req.ClientIP).Should(Equal(ecsIP))
+						Expect(req.ClientIP).Should(Equal(origIP))
 						Expect(req.Req).Should(HaveEdnsOption(dns.EDNS0SUBNET))
 
 						so := util.GetEdns0Option[*dns.EDNS0_SUBNET](req.Req)

--- a/server/server.go
+++ b/server/server.go
@@ -528,6 +528,10 @@ func createQueryResolver(
 		resolver.NewRateLimitingResolver(ctx, cfg.RateLimit),
 		resolver.NewFilteringResolver(cfg.Filtering),
 		resolver.NewFQDNOnlyResolver(cfg.FQDNOnly),
+		// adopts the ECS subnet as the internal client IP (ecs.useAsClient) before the
+		// client-name lookup, blocking and the cache consume the client identity, so the
+		// ECS client is used for those features and is preserved across cache hits
+		resolver.NewECSClientResolver(cfg.ECS),
 		clientNames,
 		resolver.NewEDEResolver(cfg.EDE),
 		queryLogging,


### PR DESCRIPTION
## Summary

Fixes #2140 — with `ecs.useAsClient`, the EDNS Client Subnet client was ignored for cached responses (the query log showed the forwarder IP), and the client name was always resolved from the forwarder (e.g. always `opnsense`) even on cache misses.

## Root cause

`ecs.useAsClient` rewrote `request.ClientIP` inside `ECSResolver`, which is placed at the **bottom** of the resolver chain (below the cache):

* On a **cache hit**, `CachingResolver.Resolve` returns early without calling the next resolver, so the ECS rewrite never runs → the cached query-log entry is attributed to the forwarder.
* `ClientNamesResolver` runs **above** `ECSResolver`, so the client name is always resolved from the forwarder IP, on both cache hits and misses.

## Regression

This worked when ECS was introduced (#1007, ECS sat near the top of the chain, above client-names/blocking/cache). It broke in **#1933 (DNS64 support)**, which relocated the ECS resolver to the bottom of the chain next to DNS64. Last good release **v0.28.2**; broken in **v0.29.0 → v0.32.1**.

## Fix

Split the two responsibilities instead of moving the whole resolver back up (a wholesale move would change `isRequestCacheable`/cache-key behaviour for `forward`/`ipv4Mask`/`ipv6Mask` configs):

* **New `ECSClientResolver`** (`ecs_as_client`) — does **only** the `useAsClient` → `request.ClientIP` adoption, placed **above** `clientNames` and the cache, so the ECS client is used for client-name lookup, blocking, stats and query logging, and is preserved across cache hits.
* **`ECSResolver`** keeps the outgoing EDNS0-subnet handling (set / forward / strip) **below** the cache, unchanged.

The two resolvers have disjoint, individually-gated responsibilities; the EDNS-option-toward-upstream behaviour and cache semantics are unchanged.

## Tests

* `resolver/ecs_client_resolver_test.go` — unit tests for the new resolver plus a cross-chain regression test (`ECSClientResolver → clientNames → cache → upstream`) asserting the correct client IP **and** name on both the resolved and the cached response.
* `e2e/ecs_clientname_test.go` — end-to-end: a `/32` ECS query sent twice; asserts the SQLite query log attributes both the `RESOLVED` and `CACHED` entries to the ECS client (`10.0.0.1` / `ecsclient`). Verified to fail without the fix (logs the forwarder `172.18.0.1`).
* `resolver/ecs_resolver_test.go` — the client-IP tests moved to the new resolver; `forward` tests adjusted (`ECSResolver` no longer adopts the client IP).
