### PR TITLE
perf(log): cut per-request logger allocations on the resolver hot path

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -25,6 +25,19 @@ func FromCtx(ctx context.Context) *logrus.Entry {
 	return entryWithCtx(ctx, logger)
 }
 
+// baseFromCtx returns the entry stored in the context (or a fresh entry on the
+// global logger) WITHOUT copying it. The returned entry's `Context` may point at
+// an ancestor of `ctx`; callers that need `Context == ctx` must wrap it (FromCtx
+// copies via entryWithCtx; WrapCtx re-stamps Context via NewCtx).
+func baseFromCtx(ctx context.Context) *logrus.Entry {
+	if logger, ok := ctx.Value(ctxKey{}).(*logrus.Entry); ok {
+		return logger
+	}
+
+	// Fallback to the global logger
+	return logrus.NewEntry(Log())
+}
+
 func entryWithCtx(ctx context.Context, logger *logrus.Entry) *logrus.Entry {
 	loggerCopy := *logger
 	loggerCopy.Context = ctx
@@ -32,9 +45,14 @@ func entryWithCtx(ctx context.Context, logger *logrus.Entry) *logrus.Entry {
 	return &loggerCopy
 }
 
+// WrapCtx derives a new context logger by applying `wrap` to the context-stored entry.
+//
+// `wrap` MUST return a new entry (e.g. via WithField/WithFields) and MUST NOT mutate
+// the entry it is given in place: the base entry is passed without copying (the wrapped
+// result is a fresh entry and NewCtx re-stamps its Context), so an in-place mutation
+// would corrupt the shared context-stored logger.
 func WrapCtx(ctx context.Context, wrap func(*logrus.Entry) *logrus.Entry) (context.Context, *logrus.Entry) {
-	logger := FromCtx(ctx)
-	logger = wrap(logger)
+	logger := wrap(baseFromCtx(ctx))
 
 	return NewCtx(ctx, logger)
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -3,7 +3,6 @@ package log
 //go:generate go tool go-enum -f=$GOFILE --marshal --names --template ../tools/schemagen/templates/enum_description.tmpl
 
 import (
-	"fmt"
 	"io"
 	"maps"
 	"os"
@@ -75,8 +74,11 @@ func PrefixedLog(prefix string) *logrus.Entry {
 
 // WithPrefix adds the given prefix to the logger.
 func WithPrefix(logger *logrus.Entry, prefix string) *logrus.Entry {
-	if existingPrefix, ok := logger.Data[prefixField]; ok {
-		prefix = fmt.Sprintf("%s.%s", existingPrefix, prefix)
+	// avoid fmt.Sprintf here: this runs once per resolver per request on the hot path,
+	// and the values are plain strings, so a direct concat skips the interface boxing
+	// and format-string parsing.
+	if existingPrefix, ok := logger.Data[prefixField].(string); ok {
+		prefix = existingPrefix + "." + prefix
 	}
 
 	return logger.WithField(prefixField, prefix)

--- a/log/logger.go
+++ b/log/logger.go
@@ -72,6 +72,14 @@ func PrefixedLog(prefix string) *logrus.Entry {
 	return logger.WithField(prefixField, prefix)
 }
 
+// SetPrefix sets prefix as the logger's prefix, replacing any prefix it already
+// carries. Use this to give each resolver its own prefix without accumulating the
+// prefixes of resolvers earlier in the chain. Contrast with WithPrefix, which
+// appends to build a dotted chain (a.b.c).
+func SetPrefix(logger *logrus.Entry, prefix string) *logrus.Entry {
+	return logger.WithField(prefixField, prefix)
+}
+
 // WithPrefix adds the given prefix to the logger.
 func WithPrefix(logger *logrus.Entry, prefix string) *logrus.Entry {
 	// avoid fmt.Sprintf here: this runs once per resolver per request on the hot path,

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -461,7 +461,10 @@ func (r *BlockingResolver) hasAllowlistOnlyAllowed(groupsToCheck []string) bool 
 func (r *BlockingResolver) handleDenylist(ctx context.Context, groupsToCheck []string,
 	request *model.Request, logger *logrus.Entry,
 ) (bool, *model.Response, error) {
-	logger.WithField("groupsToCheck", strings.Join(groupsToCheck, "; ")).Debug("checking groups for request")
+	if logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		logger.WithField("groupsToCheck", strings.Join(groupsToCheck, "; ")).Debug("checking groups for request")
+	}
+
 	allowlistOnlyAllowed := r.hasAllowlistOnlyAllowed(groupsToCheck)
 
 	for _, question := range request.Req.Question {

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -461,7 +461,7 @@ func (r *BlockingResolver) hasAllowlistOnlyAllowed(groupsToCheck []string) bool 
 func (r *BlockingResolver) handleDenylist(ctx context.Context, groupsToCheck []string,
 	request *model.Request, logger *logrus.Entry,
 ) (bool, *model.Response, error) {
-	if logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+	if isDebugEnabled(logger) {
 		logger.WithField("groupsToCheck", strings.Join(groupsToCheck, "; ")).Debug("checking groups for request")
 	}
 

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -138,16 +138,18 @@ func (r *ConditionalUpstreamResolver) internalResolve(ctx context.Context, reso 
 		return nil, fmt.Errorf("conditional upstream resolution failed for domain '%s': %w", do, err)
 	}
 
-	var answer string
-	if response != nil {
-		answer = util.Obfuscate(util.AnswerToString(response.Res.Answer))
-	}
+	if logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		var answer string
+		if response != nil {
+			answer = util.Obfuscate(util.AnswerToString(response.Res.Answer))
+		}
 
-	logger.WithFields(logrus.Fields{
-		logFieldAnswer:   answer,
-		logFieldDomain:   util.Obfuscate(do),
-		logFieldUpstream: reso,
-	}).Debugf("received response from conditional upstream")
+		logger.WithFields(logrus.Fields{
+			logFieldAnswer:   answer,
+			logFieldDomain:   util.Obfuscate(do),
+			logFieldUpstream: reso,
+		}).Debugf("received response from conditional upstream")
+	}
 
 	return response, nil
 }

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -138,7 +138,7 @@ func (r *ConditionalUpstreamResolver) internalResolve(ctx context.Context, reso 
 		return nil, fmt.Errorf("conditional upstream resolution failed for domain '%s': %w", do, err)
 	}
 
-	if logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+	if isDebugEnabled(logger) {
 		var answer string
 		if response != nil {
 			answer = util.Obfuscate(util.AnswerToString(response.Res.Answer))

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -192,7 +192,7 @@ func evaluateResponses(
 			continue
 		}
 
-		if logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		if isDebugEnabled(logger) {
 			logger.WithField(logFieldAnswer, util.Obfuscate(util.AnswerToString(result.response.Res.Answer))).
 				Debug("using response from resolver")
 		}

--- a/resolver/parallel_best_resolver.go
+++ b/resolver/parallel_best_resolver.go
@@ -192,8 +192,10 @@ func evaluateResponses(
 			continue
 		}
 
-		logger.WithField(logFieldAnswer, util.Obfuscate(util.AnswerToString(result.response.Res.Answer))).
-			Debug("using response from resolver")
+		if logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+			logger.WithField(logFieldAnswer, util.Obfuscate(util.AnswerToString(result.response.Res.Answer))).
+				Debug("using response from resolver")
+		}
 
 		return result.response, nil
 	}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -213,7 +213,11 @@ func (t *typed) logWithFields(ctx context.Context, fields logrus.Fields) (contex
 
 func (t *typed) logWith(ctx context.Context, wrap func(*logrus.Entry) *logrus.Entry) (context.Context, *logrus.Entry) {
 	return log.WrapCtx(ctx, func(logger *logrus.Entry) *logrus.Entry {
-		logger = log.WithPrefix(logger, t.Type())
+		// per-resolver prefix: each resolver replaces the prefix with its own type rather
+		// than accumulating earlier resolvers' prefixes (avoids the dotted chain and the
+		// string concat that built it). The request-scoped fields (req_id/question/
+		// client_ip) the logger already carries are preserved.
+		logger = log.SetPrefix(logger, t.Type())
 
 		return wrap(logger)
 	})

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -219,6 +219,13 @@ func (t *typed) logWith(ctx context.Context, wrap func(*logrus.Entry) *logrus.En
 	})
 }
 
+// isDebugEnabled reports whether logger would emit at Debug level. Use it to guard
+// construction of expensive Debug-only log fields on the hot path, since Go evaluates
+// log-call arguments before logrus checks the level.
+func isDebugEnabled(logger *logrus.Entry) bool {
+	return logger.Logger.IsLevelEnabled(logrus.DebugLevel)
+}
+
 // Should be embedded in a Resolver to auto-implement `config.Configurable`.
 type configurable[T config.Configurable] struct {
 	cfg T

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -594,7 +594,7 @@ func (r *UpstreamResolver) logResponse(
 ) {
 	// runs on every successful upstream response (every cache miss); skip building the
 	// (expensive) answer string / field map entirely when Debug isn't enabled.
-	if !logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+	if !isDebugEnabled(logger) {
 		return
 	}
 

--- a/resolver/upstream_resolver.go
+++ b/resolver/upstream_resolver.go
@@ -592,6 +592,12 @@ func (r *UpstreamResolver) Resolve(ctx context.Context, request *model.Request) 
 func (r *UpstreamResolver) logResponse(
 	logger *logrus.Entry, request *model.Request, resp *dns.Msg, ip net.IP, rtt time.Duration,
 ) {
+	// runs on every successful upstream response (every cache miss); skip building the
+	// (expensive) answer string / field map entirely when Debug isn't enabled.
+	if !logger.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		return
+	}
+
 	logger.WithFields(logrus.Fields{
 		logFieldAnswer:     util.Obfuscate(util.AnswerToString(resp.Answer)),
 		"return_code":      dns.RcodeToString[resp.Rcode],


### PR DESCRIPTION
## What

Reduces per-request allocations on the DNS hot path by cutting avoidable work in
the per-resolver logger plumbing. Every request derives a prefixed context logger
in each resolver (`r.log(ctx)`), unconditionally and regardless of log level — this
was one of the largest fixed per-request allocators.

This is the first slice of a broader hot-path performance pass; it focuses on the
logging plumbing only.

## Changes

1. **`log`: no-copy `WrapCtx` + concat in `WithPrefix`** — `WrapCtx` copied the
   context-stored entry via `FromCtx` before applying `wrap`, but `wrap`
   (`WithField`/`WithFields`) always returns a fresh entry and `NewCtx` re-stamps
   `Context`, so the copy was redundant; use a non-copying `baseFromCtx`.
   `WithPrefix` used `fmt.Sprintf` to join the prefix — the values are plain
   strings, so a direct concat skips the interface boxing + format parsing.
   *(no behavior change)*

2. **`resolver`: gate eager Debug log-field building behind a level check** — several
   resolvers build expensive Debug fields (`util.Obfuscate(util.AnswerToString(...))`
   — a sprintf-per-record + join, plus `cfg.String()`/`ip.String()` and a
   `logrus.Fields` map) as eager call arguments, so the work ran on every cache-miss
   request even though it's discarded at the default Info level. Wrapped each site in
   `isDebugEnabled(logger)`. Sites: upstream `logResponse`, parallel-best, conditional
   upstream, blocking's groups-to-check line. *(no behavior change)*

3. **`resolver`: `isDebugEnabled` helper** for the guards above (readability).
   *(no behavior change)*

4. **`log`: per-resolver log prefix instead of accumulating the chain** — each resolver
   appended its type to the prefix inherited from earlier resolvers
   (`stats.rate_limiting.filtering...`), with a string concat per resolver per request.
   Switched the resolver hot path to `log.SetPrefix`, which replaces the prefix with
   just this resolver's type.
   **⚠️ Behavior change:** the `prefix` field on resolver log lines is now the single
   resolver name (e.g. `blocking`) rather than the accumulated chain
   (`caching.blocking`). Request-scoped fields (`req_id`/`question`/`client_ip`) are
   unchanged, and intra-resolver sub-prefixes (e.g. blocking's `client_id_cache`) still
   accumulate onto their parent.

## Benchmark

Synthetic 15-resolver chain at Info level (the production default, where Debug/Trace
lines never print but the prefixed context logger is still rebuilt in every resolver).
`benchstat`, n=6:

| metric | before | after | delta |
|---|---|---|---|
| allocs/op | 152 | 109 | **−28.3%** (p=0.002) |
| B/op | 13357 | 10168 | **−23.9%** (p=0.002) |
| sec/op | 48.8µs | 40.7µs | **−16.6%** (p=0.004) |

The Debug-field guards additionally remove ~7 allocs / ~1.5µs per guarded site on the
cache-**miss** path at Info level (not captured by the above silent-path benchmark).

## Testing

- `go test ./resolver/... ./server/...` pass.
- Both behavior-preserving and the prefix change verified against the existing suites.
- The benchmark used for the numbers above is intentionally **not** included in this PR.

## Notes / follow-ups

- Removing the remaining per-request map clone entirely would require carrying the
  prefix as a context value and building the logrus `Data` map only at actual emission
  via a hook — preserves request fields but touches the prefixed formatter + adds
  concurrency considerations. Deferred.
