### PR TITLE
perf(blocking): Tier 2 — lock-free grouped cache, cheapest-first lookup, client-name indexing

### DIFF
--- a/cache/stringcache/chained_grouped_cache.go
+++ b/cache/stringcache/chained_grouped_cache.go
@@ -1,6 +1,9 @@
 package stringcache
 
-import "maps"
+import (
+	"maps"
+	"slices"
+)
 
 type ChainedGroupedCache struct {
 	caches []GroupedStringCache
@@ -42,16 +45,18 @@ func (c *ChainedGroupedCache) Contains(searchString string, groups []string) map
 
 	remaining := groups
 
-	for i := len(c.caches) - 1; i >= 0; i-- {
-		matches := c.caches[i].Contains(searchString, remaining)
+	for _, cache := range slices.Backward(c.caches) {
+		matches := cache.Contains(searchString, remaining)
 		if len(matches) == 0 {
 			continue
 		}
 
 		if result == nil {
-			// Adopt the sub-cache's freshly-allocated map instead of allocating a
-			// second one; the common single-sub-cache match then costs one map, not
-			// two. Sub-cache maps are never shared, so this is safe to retain/extend.
+			// Adopt the sub-cache's map instead of allocating a second one; the common
+			// single-sub-cache match then costs one map, not two. We then retain and
+			// mutate it (via maps.Copy below), which is only safe because the
+			// GroupedStringCache contract requires Contains to return a fresh, caller-
+			// ownable map per call (never a retained/shared/pooled one).
 			result = matches
 		} else {
 			maps.Copy(result, matches)

--- a/cache/stringcache/chained_grouped_cache.go
+++ b/cache/stringcache/chained_grouped_cache.go
@@ -1,5 +1,7 @@
 package stringcache
 
+import "maps"
+
 type ChainedGroupedCache struct {
 	caches []GroupedStringCache
 }
@@ -24,23 +26,61 @@ func (c *ChainedGroupedCache) Contains(searchString string, groups []string) map
 	// Ordering of matched groups is not defined here; callers that render the
 	// result sort it (see resolver.formatBlockReason).
 	//
-	// If a group matches in more than one chained cache (e.g. an exact entry and
-	// a wildcard), we keep a single rule per group: the last chained cache wins.
-	// One representative rule per group is enough for the block reason, and the
-	// chain order is fixed, so the choice is stable across requests.
+	// Sub-caches are queried cheapest-first, i.e. in reverse of construction order.
+	// The chain is built most-expensive-first (regex, wildcard, string) because
+	// chainedGroupFactory routes each insert to the first accepting cache and the
+	// string cache is the catch-all, so it must be last. Querying in reverse means
+	// an exact string-denylist hit never pays the linear regex scan first.
+	//
+	// Once a group matches, it is dropped from the set still being searched, so no
+	// group is looked up in more than one sub-cache. If a group matches in more
+	// than one chained cache (e.g. an exact entry and a wildcard), a single rule is
+	// reported: the one from the last (cheapest) cache in construction order. That
+	// is the same representative the previous "last chained cache wins" produced —
+	// reverse-first-match equals forward-last-match under short-circuiting.
 	var result map[string]string
 
-	for _, cache := range c.caches {
-		for group, rule := range cache.Contains(searchString, groups) {
-			if result == nil {
-				result = make(map[string]string, len(groups))
-			}
+	remaining := groups
 
-			result[group] = rule
+	for i := len(c.caches) - 1; i >= 0; i-- {
+		matches := c.caches[i].Contains(searchString, remaining)
+		if len(matches) == 0 {
+			continue
 		}
+
+		if result == nil {
+			// Adopt the sub-cache's freshly-allocated map instead of allocating a
+			// second one; the common single-sub-cache match then costs one map, not
+			// two. Sub-cache maps are never shared, so this is safe to retain/extend.
+			result = matches
+		} else {
+			maps.Copy(result, matches)
+		}
+
+		if len(result) == len(groups) {
+			break // every group matched; nothing left to search
+		}
+
+		remaining = remainingGroups(groups, result)
 	}
 
 	return result
+}
+
+// remainingGroups returns the groups that do not yet have a match in matched. It is
+// only reached when a lookup matches some but not all groups across different
+// sub-caches; the hot single-group path matches (and breaks) or misses without
+// allocating here.
+func remainingGroups(groups []string, matched map[string]string) []string {
+	out := make([]string, 0, len(groups)-len(matched))
+
+	for _, g := range groups {
+		if _, done := matched[g]; !done {
+			out = append(out, g)
+		}
+	}
+
+	return out
 }
 
 func (c *ChainedGroupedCache) Refresh(group string) GroupFactory {

--- a/cache/stringcache/chained_grouped_cache_test.go
+++ b/cache/stringcache/chained_grouped_cache_test.go
@@ -66,6 +66,42 @@ var _ = Describe("Chained grouped cache", func() {
 		})
 	})
 
+	Describe("Multiple sub-caches matching the same group", func() {
+		// Mirror the real lists.ListCache composition (regex, wildcard, string).
+		// When a domain matches in more than one sub-cache for the same group, a
+		// single representative rule is reported: the one from the last (cheapest)
+		// cache in construction order. This contract must hold regardless of the
+		// internal query order/short-circuiting.
+		BeforeEach(func() {
+			cache = stringcache.NewChainedGroupedCache(
+				stringcache.NewInMemoryGroupedRegexCache(),
+				stringcache.NewInMemoryGroupedWildcardCache(),
+				stringcache.NewInMemoryGroupedStringCache(),
+			)
+
+			factory = cache.Refresh("group1")
+			factory.AddEntry(`/^multi\.example$/`) // regex match for multi.example
+			factory.AddEntry("*.wild.example")     // wildcard match for x.wild.example
+			factory.AddEntry("multi.example")      // exact string match for multi.example
+			factory.Finish()
+		})
+
+		It("reports the string rule when string, wildcard and regex could all match", func() {
+			Expect(cache.Contains("multi.example", []string{"group1"})).
+				Should(Equal(map[string]string{"group1": "multi.example"}))
+		})
+
+		It("reports the wildcard rule when only wildcard and regex match", func() {
+			factory = cache.Refresh("group2")
+			factory.AddEntry(`/\.wild\.example$/`) // regex also matches sub.wild.example
+			factory.AddEntry("*.wild.example")     // wildcard matches sub.wild.example
+			factory.Finish()
+
+			Expect(cache.Contains("sub.wild.example", []string{"group2"})).
+				Should(Equal(map[string]string{"group2": "*.wild.example"}))
+		})
+	})
+
 	Describe("Cache refresh", func() {
 		When("cache with 2 groups was created", func() {
 			BeforeEach(func() {

--- a/cache/stringcache/golden_test.go
+++ b/cache/stringcache/golden_test.go
@@ -119,14 +119,14 @@ func canonicalCacheDump(t *testing.T, files ...string) string {
 	var lines []string
 
 	// String cache: enumerate the real built stringMap.
-	if sc, ok := strC.caches[group]; ok && sc != nil {
+	if sc, ok := (*strC.caches.Load())[group]; ok && sc != nil {
 		for _, e := range enumerateStringMap(sc.(stringMap)) {
 			lines = append(lines, "string\t"+e)
 		}
 	}
 
 	// Regex cache: dump each compiled regex's source.
-	if rc, ok := regexC.caches[group]; ok && rc != nil {
+	if rc, ok := (*regexC.caches.Load())[group]; ok && rc != nil {
 		for _, re := range rc.(regexCache) {
 			lines = append(lines, "regex\t"+re.String())
 		}

--- a/cache/stringcache/grouped_cache_interface.go
+++ b/cache/stringcache/grouped_cache_interface.go
@@ -4,6 +4,10 @@ type GroupedStringCache interface {
 	// Contains checks if one or more groups in the cache contains the search string.
 	// Returns a map of matching group -> the rule that matched, or nil/empty when
 	// the string was not found.
+	//
+	// The returned map must be freshly allocated and owned by the caller: callers
+	// (e.g. ChainedGroupedCache) may retain and mutate it. Implementations must not
+	// return a retained, shared, or pooled map.
 	Contains(searchString string, groups []string) map[string]string
 
 	// Refresh creates new factory for the group to be refreshed.

--- a/cache/stringcache/grouped_cache_lookup_bench_test.go
+++ b/cache/stringcache/grouped_cache_lookup_bench_test.go
@@ -1,0 +1,121 @@
+package stringcache
+
+import (
+	"fmt"
+	"testing"
+)
+
+// buildBlockingCache builds a chained grouped cache mirroring the composition that
+// lists.ListCache uses (regex, then wildcard, then string — the catch-all string
+// cache must be last so chainedGroupFactory.AddEntry routes entries correctly).
+// Each group is populated with nRegex regexes, nWild wildcards and nString exact
+// entries so the per-lookup cost of the locking (Tier 2a) and the chain ordering
+// /short-circuit (Tier 2b) is visible.
+func buildBlockingCache(tb testing.TB, groups []string, nRegex, nWild, nString int) *ChainedGroupedCache {
+	tb.Helper()
+
+	c := NewChainedGroupedCache(
+		NewInMemoryGroupedRegexCache(),
+		NewInMemoryGroupedWildcardCache(),
+		NewInMemoryGroupedStringCache(),
+	)
+
+	for _, g := range groups {
+		f := c.Refresh(g)
+
+		for i := range nRegex {
+			f.AddEntry(fmt.Sprintf(`/^regex%d\..*$/`, i))
+		}
+
+		for i := range nWild {
+			f.AddEntry(fmt.Sprintf("*.wild%d.example", i))
+		}
+
+		for i := range nString {
+			f.AddEntry(fmt.Sprintf("string%d.example.com", i))
+		}
+
+		f.Finish()
+	}
+
+	return c
+}
+
+// BenchmarkGroupedCacheStringHit measures looking up a domain that is an exact
+// entry in the (cheapest, last-in-chain) string cache while the group also holds
+// regexes. This is the case Tier 2b targets: today the lookup pays a full linear
+// regex scan before reaching the string match.
+func BenchmarkGroupedCacheStringHit(b *testing.B) {
+	cache := buildBlockingCache(b, []string{"default"}, 200, 200, 5000)
+	groups := []string{"default"}
+	hit := "string1234.example.com"
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if m := cache.Contains(hit, groups); len(m) == 0 {
+			b.Fatalf("expected %q to match", hit)
+		}
+	}
+}
+
+// BenchmarkGroupedCacheMiss measures a domain present in none of the sub-caches.
+// A miss must consult every sub-cache regardless of ordering, so this is the
+// floor that short-circuiting cannot improve — kept to confirm it does not
+// regress.
+func BenchmarkGroupedCacheMiss(b *testing.B) {
+	cache := buildBlockingCache(b, []string{"default"}, 200, 200, 5000)
+	groups := []string{"default"}
+	miss := "not-present.example.org"
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if m := cache.Contains(miss, groups); len(m) != 0 {
+			b.Fatalf("expected %q to miss", miss)
+		}
+	}
+}
+
+// BenchmarkGroupedCacheLockContention isolates the per-group locking cost (Tier 2a):
+// tiny caches make the actual matching work negligible, many groups multiply the
+// number of lock acquisitions per lookup, and RunParallel hammers the shared
+// reader-count cache line that an RWMutex maintains but a lock-free atomic load
+// does not.
+func BenchmarkGroupedCacheLockContention(b *testing.B) {
+	groups := make([]string, 16)
+	for i := range groups {
+		groups[i] = fmt.Sprintf("group%d", i)
+	}
+
+	cache := buildBlockingCache(b, groups, 0, 0, 1)
+	hit := "string0.example.com"
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if m := cache.Contains(hit, groups); len(m) != len(groups) {
+				b.Fatalf("expected %q to match all groups, got %d", hit, len(m))
+			}
+		}
+	})
+}
+
+// BenchmarkGroupedCacheParallel measures concurrent lookups across several groups.
+// It surfaces the Tier 2a cost: the per-group RWMutex RLock/RUnlock contends the
+// reader-count cache line across in-flight requests, where a lock-free atomic load
+// would not.
+func BenchmarkGroupedCacheParallel(b *testing.B) {
+	groups := []string{"default", "kids", "guests", "iot"}
+	cache := buildBlockingCache(b, groups, 50, 200, 5000)
+	hit := "string1234.example.com"
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if m := cache.Contains(hit, groups); len(m) != len(groups) {
+				b.Fatalf("expected %q to match all groups, got %d", hit, len(m))
+			}
+		}
+	})
+}

--- a/cache/stringcache/in_memory_grouped_cache.go
+++ b/cache/stringcache/in_memory_grouped_cache.go
@@ -1,41 +1,48 @@
 package stringcache
 
-import "sync"
+import (
+	"maps"
+	"sync"
+	"sync/atomic"
+)
 
 type stringCacheFactoryFn func() cacheFactory
 
+// InMemoryGroupedCache holds one stringCache per group. The group map only changes
+// on list refresh, while it is read on every query, so it is kept behind an
+// atomic.Pointer and replaced copy-on-write: lookups are a single lock-free atomic
+// load with no per-group locking, and refreshes (serialised by writeLock) swap in a
+// fresh map. This avoids the reader-count cache-line contention an RWMutex would
+// incur across in-flight requests.
 type InMemoryGroupedCache struct {
-	caches    map[string]stringCache
-	lock      sync.RWMutex
+	caches    atomic.Pointer[map[string]stringCache]
+	writeLock sync.Mutex
 	factoryFn stringCacheFactoryFn
 }
 
+func newInMemoryGroupedCache(factoryFn stringCacheFactoryFn) *InMemoryGroupedCache {
+	c := &InMemoryGroupedCache{factoryFn: factoryFn}
+
+	empty := make(map[string]stringCache)
+	c.caches.Store(&empty)
+
+	return c
+}
+
 func NewInMemoryGroupedStringCache() *InMemoryGroupedCache {
-	return &InMemoryGroupedCache{
-		caches:    make(map[string]stringCache),
-		factoryFn: newStringCacheFactory,
-	}
+	return newInMemoryGroupedCache(newStringCacheFactory)
 }
 
 func NewInMemoryGroupedRegexCache() *InMemoryGroupedCache {
-	return &InMemoryGroupedCache{
-		caches:    make(map[string]stringCache),
-		factoryFn: newRegexCacheFactory,
-	}
+	return newInMemoryGroupedCache(newRegexCacheFactory)
 }
 
 func NewInMemoryGroupedWildcardCache() *InMemoryGroupedCache {
-	return &InMemoryGroupedCache{
-		caches:    make(map[string]stringCache),
-		factoryFn: newWildcardCacheFactory,
-	}
+	return newInMemoryGroupedCache(newWildcardCacheFactory)
 }
 
 func (c *InMemoryGroupedCache) ElementCount(group string) int {
-	c.lock.RLock()
-	cache, found := c.caches[group]
-	c.lock.RUnlock()
-
+	cache, found := (*c.caches.Load())[group]
 	if !found {
 		return 0
 	}
@@ -47,12 +54,12 @@ func (c *InMemoryGroupedCache) Contains(searchString string, groups []string) ma
 	// result is allocated lazily so the common no-match case stays allocation-free.
 	var result map[string]string
 
-	for _, group := range groups {
-		c.lock.RLock()
-		cache, found := c.caches[group]
-		c.lock.RUnlock()
+	// Single lock-free load: the snapshot is immutable, so it is safe to read for
+	// the whole lookup even if a concurrent refresh swaps in a new map.
+	caches := *c.caches.Load()
 
-		if found {
+	for _, group := range groups {
+		if cache, found := caches[group]; found {
 			if rule, ok := cache.findMatch(searchString); ok {
 				if result == nil {
 					result = make(map[string]string, len(groups))
@@ -68,18 +75,31 @@ func (c *InMemoryGroupedCache) Contains(searchString string, groups []string) ma
 
 func (c *InMemoryGroupedCache) Refresh(group string) GroupFactory {
 	return &inMemoryGroupFactory{
-		factory: c.factoryFn(),
-		finishFn: func(sc stringCache) {
-			c.lock.Lock()
-			defer c.lock.Unlock()
-
-			if sc != nil {
-				c.caches[group] = sc
-			} else {
-				delete(c.caches, group)
-			}
-		},
+		factory:  c.factoryFn(),
+		finishFn: func(sc stringCache) { c.storeGroup(group, sc) },
 	}
+}
+
+// storeGroup copy-on-write replaces a single group's cache (or removes it when sc is
+// nil). Writers are serialised by writeLock so concurrent group refreshes cannot
+// lose each other's updates; readers never block, they just observe the previous or
+// the new snapshot.
+func (c *InMemoryGroupedCache) storeGroup(group string, sc stringCache) {
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+
+	old := *c.caches.Load()
+
+	updated := make(map[string]stringCache, len(old)+1)
+	maps.Copy(updated, old)
+
+	if sc != nil {
+		updated[group] = sc
+	} else {
+		delete(updated, group)
+	}
+
+	c.caches.Store(&updated)
 }
 
 type inMemoryGroupFactory struct {

--- a/cache/stringcache/in_memory_grouped_cache_concurrency_test.go
+++ b/cache/stringcache/in_memory_grouped_cache_concurrency_test.go
@@ -1,0 +1,75 @@
+package stringcache_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/0xERR0R/blocky/cache/stringcache"
+)
+
+// TestInMemoryGroupedCacheConcurrentRefreshAndLookup exercises lookups running
+// concurrently with group refreshes. It is a safety net for the lock-free
+// copy-on-write lookup path: run with -race, a torn map read or a lost refresh
+// update is reported as a data race. A seed entry that every refresh re-adds must
+// stay continuously matchable throughout.
+func TestInMemoryGroupedCacheConcurrentRefreshAndLookup(t *testing.T) {
+	t.Parallel()
+
+	const (
+		groups    = 4
+		readers   = 8
+		refreshes = 150
+	)
+
+	cache := stringcache.NewInMemoryGroupedStringCache()
+
+	groupNames := make([]string, groups)
+	for g := range groupNames {
+		groupNames[g] = fmt.Sprintf("group%d", g)
+
+		f := cache.Refresh(groupNames[g])
+		f.AddEntry("seed.example")
+		f.Finish()
+	}
+
+	stop := make(chan struct{})
+
+	var readWG sync.WaitGroup
+
+	for range readers {
+		readWG.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if m := cache.Contains("seed.example", groupNames); len(m) != groups {
+						t.Errorf("seed entry must match all %d groups, got %d", groups, len(m))
+
+						return
+					}
+
+					cache.ElementCount(groupNames[0])
+				}
+			}
+		})
+	}
+
+	var writeWG sync.WaitGroup
+
+	for gi, group := range groupNames {
+		writeWG.Go(func() {
+			for j := range refreshes {
+				f := cache.Refresh(group)
+				f.AddEntry(fmt.Sprintf("e%d-%d.example", gi, j))
+				f.AddEntry("seed.example") // keep the invariant the readers assert
+				f.Finish()
+			}
+		})
+	}
+
+	writeWG.Wait()
+	close(stop)
+	readWG.Wait()
+}

--- a/querylog/dnstap_writer.go
+++ b/querylog/dnstap_writer.go
@@ -82,15 +82,15 @@ func NewDnstapWriter(target string, flushInterval time.Duration, instanceID stri
 	return d, nil
 }
 
-// run is the only goroutine that touches d.writer. socketWriter.WriteFrame may
-// block indefinitely while the collector is unreachable, but that no longer stalls
-// the resolver's writeLog goroutine (Write enqueues without blocking). When frames
-// is closed, the queue drains and the socket is flushed and closed.
+// run is the only goroutine that touches d.writer: WriteFrame in the loop and the
+// deferred Close below are the sole accesses, so the dnstap socketWriter (which is
+// not safe for concurrent WriteFrame/Close) is never reached from two goroutines.
+// socketWriter.WriteFrame may block indefinitely while the collector is unreachable,
+// but that no longer stalls the resolver's writeLog goroutine (Write enqueues without
+// blocking). Close signals shutdown by closing d.frames; run then stops and closes the
+// socket here.
 func (d *DnstapWriter) run() {
 	defer func() {
-		if d.closed.Load() {
-			return
-		}
 		if err := d.writer.Close(); err != nil {
 			d.logger.WithError(err).Warn("failed to close dnstap writer")
 		}
@@ -184,16 +184,15 @@ func (d *DnstapWriter) Write(entry *LogEntry) {
 // happens in Close instead.
 func (d *DnstapWriter) CleanUp() {}
 
-// Close signals shutdown: it stops accepting frames so the run goroutine drains the
-// queue and closes the socket. It returns immediately and never waits on an in-flight
-// WriteFrame, so a stuck collector connection cannot hang shutdown.
+// Close signals shutdown: it stops accepting frames so the run goroutine stops and
+// closes the socket itself. It deliberately does not touch d.writer — run owns it, and
+// the dnstap socketWriter is not safe for a Close concurrent with an in-flight
+// WriteFrame — and never waits on an in-flight WriteFrame, so a stuck collector
+// connection cannot hang shutdown.
 func (d *DnstapWriter) Close() error {
 	d.closeOnce.Do(func() {
 		d.closed.Store(true)
 		close(d.frames)
-		if err := d.writer.Close(); err != nil {
-			d.logger.WithError(err).Warn("failed to close dnstap writer on shutdown")
-		}
 	})
 
 	return nil

--- a/querylog/dnstap_writer_test.go
+++ b/querylog/dnstap_writer_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/0xERR0R/blocky/log"
@@ -304,5 +306,69 @@ var _ = Describe("DnstapWriter", func() {
 			}
 			Expect(func() { writer.Write(entry) }).ShouldNot(Panic())
 		})
+
+		It("never reaches the writer from Close concurrently with the run goroutine", func() {
+			// Regression guard for the documented invariant "run is the only goroutine
+			// that touches d.writer". The dnstap socketWriter is not safe for concurrent
+			// WriteFrame/Close, so Close must only signal shutdown and let run close the
+			// writer. gateWriter writes an unguarded field from both calls, so if Close
+			// reaches the writer while run is mid-WriteFrame, -race fails this test.
+			fw := newGateWriter()
+			d := &DnstapWriter{
+				writer: fw,
+				logger: log.PrefixedLog("test"),
+				frames: make(chan []byte, 1),
+			}
+
+			go d.run()
+
+			// Park the run goroutine inside WriteFrame so it is actively using the writer.
+			d.frames <- []byte{0x01}
+			Eventually(fw.entered).Should(BeClosed())
+
+			closeReturned := make(chan struct{})
+			go func() {
+				defer close(closeReturned)
+				Expect(d.Close()).Should(Succeed())
+			}()
+
+			// Release the parked WriteFrame: it touches the writer's field here, which
+			// races any Close that wrongly reaches the writer from the other goroutine.
+			close(fw.release)
+
+			Eventually(closeReturned).Should(BeClosed())
+			Eventually(fw.closed.Load).Should(BeTrue())
+		})
 	})
 })
+
+// gateWriter is a dnstap.Writer test double whose WriteFrame and Close both write an
+// unguarded field. run owns WriteFrame; if Close is invoked from a different goroutine
+// while run is mid-WriteFrame, the race detector flags the concurrent access. The
+// entered/release channels let a test park run inside WriteFrame.
+type gateWriter struct {
+	frame   []byte // intentionally unguarded: -race catches a concurrent Close
+	entered chan struct{}
+	release chan struct{}
+	enter   sync.Once
+	closed  atomic.Bool
+}
+
+func newGateWriter() *gateWriter {
+	return &gateWriter{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (w *gateWriter) WriteFrame(p []byte) (int, error) {
+	w.enter.Do(func() { close(w.entered) })
+	<-w.release
+	w.frame = p
+
+	return len(p), nil
+}
+
+func (w *gateWriter) Close() error {
+	w.frame = nil
+	w.closed.Store(true)
+
+	return nil
+}

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -147,15 +147,20 @@ func clientGroupsBlock(cfg config.Blocking) map[string][]scheduledGroup {
 // on every request (see PERFORMANCE.md, finding #8). It is immutable after
 // construction.
 type clientGroupsIndex struct {
-	// byID maps an exact, already-lowercased identifier (IP literal, FQDN, client
-	// name or "default") to its groups. Used for exact ClientIP and "default"
-	// lookups and iterated for client-name glob matching.
+	// byID maps an exact, already-lowercased identifier (IP literal, FQDN, literal
+	// client name or "default") to its groups. Used for exact ClientIP, "default"
+	// and literal client-name lookups. Identifiers containing glob metacharacters
+	// are not kept here; they live in names and are matched via filepath.Match.
 	byID map[string][]scheduledGroup
 	// cidrs holds identifiers that parse as a CIDR, with the network pre-parsed.
 	cidrs []cidrGroups
 	// fqdns holds identifiers classified as FQDN candidates (resolved via the
 	// fqdnIPCache at query time).
 	fqdns []fqdnGroups
+	// names holds identifiers containing glob metacharacters, matched against
+	// client names with filepath.Match. This is usually a tiny set, so literal
+	// client names avoid scanning it via the byID exact lookup.
+	names []nameGlob
 }
 
 type cidrGroups struct {
@@ -168,12 +173,36 @@ type fqdnGroups struct {
 	groups     []scheduledGroup
 }
 
+type nameGlob struct {
+	pattern string
+	groups  []scheduledGroup
+}
+
+// isClientNameGlob reports whether an identifier contains filepath.Match
+// metacharacters. Only such identifiers need a per-name filepath.Match; everything
+// else matches a client name exactly and is resolved via the byID map.
+func isClientNameGlob(identifier string) bool {
+	return strings.ContainsAny(identifier, `*?[\`)
+}
+
 func newClientGroupsIndex(cfg config.Blocking) clientGroupsIndex {
 	byID := clientGroupsBlock(cfg)
 
 	idx := clientGroupsIndex{byID: byID}
 
 	for id, groups := range byID {
+		// Move glob identifiers out of byID into the names bucket: they are only
+		// ever matched against client names via filepath.Match, never by exact
+		// lookup, and a glob string is neither a valid CIDR nor a resolvable FQDN.
+		// Removing them keeps the exact byID lookup faithful (a client whose name
+		// literally equals a glob pattern must not match it as a literal).
+		if isClientNameGlob(id) {
+			idx.names = append(idx.names, nameGlob{pattern: id, groups: groups})
+			delete(byID, id)
+
+			continue
+		}
+
 		// Pre-parse CIDR identifiers so per-query matching is a cheap
 		// ipNet.Contains instead of a net.ParseCIDR allocation per entry.
 		if _, ipNet, err := net.ParseCIDR(id); err == nil {
@@ -621,9 +650,17 @@ func (r *BlockingResolver) collectGroupsForClient(request *model.Request) []sche
 	for _, cName := range request.ClientNames {
 		lowerName := strings.ToLower(cName)
 
-		for identifier, groupsByName := range cg.byID {
-			if matched, _ := filepath.Match(identifier, lowerName); matched {
-				groups = append(groups, groupsByName...)
+		// Literal identifiers (the vast majority — IPs, FQDNs, plain names) match a
+		// client name exactly, so resolve them with a single map lookup instead of
+		// running filepath.Match against every entry.
+		if groupsByName, found := cg.byID[lowerName]; found {
+			groups = append(groups, groupsByName...)
+		}
+
+		// Only the (usually tiny) set of glob identifiers needs a pattern match.
+		for _, ng := range cg.names {
+			if matched, _ := filepath.Match(ng.pattern, lowerName); matched {
+				groups = append(groups, ng.groups...)
 			}
 		}
 	}

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -577,7 +577,8 @@ func extractEntryToCheckFromResponse(rr dns.RR) (entryToCheck, tName string) {
 		entryToCheck = v.A.String()
 		tName = "IP"
 	case *dns.AAAA:
-		entryToCheck = strings.ToLower(v.AAAA.String())
+		// net.IP.String already emits lower-case hex, so no ToLower is needed.
+		entryToCheck = v.AAAA.String()
 		tName = "IP"
 	case *dns.CNAME:
 		entryToCheck = util.ExtractDomainOnly(v.Target)
@@ -625,7 +626,11 @@ func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) []stri
 		result = append(result, sg.group)
 	}
 
-	sort.Strings(result)
+	// formatBlockReason renders groups in a stable order; a 0/1-element result is
+	// already sorted, so only sort when there is something to order.
+	if len(result) > 1 {
+		sort.Strings(result)
+	}
 
 	return result
 }

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -504,6 +504,13 @@ func (r *BlockingResolver) handleDenylist(ctx context.Context, groupsToCheck []s
 
 // Resolve checks the query against the denylist and delegates to next resolver if domain is not blocked
 func (r *BlockingResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
+	// When no client groups are configured there is nothing to block, so skip the
+	// per-request logger derivation and group resolution entirely (matches the
+	// disabled-path early-return in hosts_file/rebinding resolvers).
+	if !r.IsEnabled() {
+		return r.next.Resolve(ctx, request)
+	}
+
 	ctx, logger := r.log(ctx)
 	groupsToCheck := r.groupsToCheckForClient(request)
 

--- a/resolver/blocking_resolver_bench_test.go
+++ b/resolver/blocking_resolver_bench_test.go
@@ -1,0 +1,82 @@
+package resolver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0xERR0R/blocky/config"
+
+	"github.com/miekg/dns"
+)
+
+// benchClientGroupsBlock builds a clientGroupsBlock mapping of the shape a busy
+// deployment accumulates: many IP/CIDR/FQDN identifiers plus a handful of literal
+// client names and a couple of glob name patterns. It stresses the client-name
+// resolution path that Tier 2d targets, where filepath.Match was run against every
+// identifier in the map for each client name.
+func benchClientGroupsBlock() map[string][]string {
+	m := make(map[string][]string)
+
+	for i := range 200 {
+		m[fmt.Sprintf("10.0.%d.%d", i/256, i%256)] = []string{"gr-ip"}
+	}
+
+	for i := range 20 {
+		m[fmt.Sprintf("172.16.%d.0/24", i)] = []string{"gr-cidr"}
+	}
+
+	for i := range 20 {
+		m[fmt.Sprintf("host%d.lan.example.com", i)] = []string{"gr-fqdn"}
+	}
+
+	for i := range 10 {
+		m[fmt.Sprintf("laptop-%d", i)] = []string{"gr-name"}
+	}
+
+	m["wildcard[0-9]*"] = []string{"gr-glob"}
+	m["kiosk-*"] = []string{"gr-glob"}
+	m["default"] = []string{"gr-default"}
+
+	return m
+}
+
+func newBenchBlockingResolver() *BlockingResolver {
+	cfg := config.Blocking{ClientGroupsBlock: benchClientGroupsBlock()}
+
+	return &BlockingResolver{
+		clientGroups: newClientGroupsIndex(cfg),
+		status:       &status{enabled: true},
+	}
+}
+
+// BenchmarkBlockingGroupsToCheckLiteralName resolves the groups for a request whose
+// client name is a literal (the common case). Today every identifier in the map is
+// run through filepath.Match; an exact map lookup plus a tiny glob scan should be
+// far cheaper.
+func BenchmarkBlockingGroupsToCheckLiteralName(b *testing.B) {
+	r := newBenchBlockingResolver()
+	req := newRequestWithClient("example.com.", dns.Type(dns.TypeA), "10.0.0.5", "laptop-7")
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if got := r.groupsToCheckForClient(req); len(got) == 0 {
+			b.Fatal("expected at least one group")
+		}
+	}
+}
+
+// BenchmarkBlockingGroupsToCheckGlobName resolves the groups for a request whose
+// client name only matches a glob pattern, keeping filepath.Match on the hot path.
+func BenchmarkBlockingGroupsToCheckGlobName(b *testing.B) {
+	r := newBenchBlockingResolver()
+	req := newRequestWithClient("example.com.", dns.Type(dns.TypeA), "10.0.0.5", "kiosk-lobby")
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if got := r.groupsToCheckForClient(req); len(got) == 0 {
+			b.Fatal("expected at least one group")
+		}
+	}
+}

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -81,6 +81,19 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 		})
 	})
 
+	Describe("Resolve when blocking is not configured", func() {
+		It("delegates straight to the next resolver", func() {
+			Expect(sut.Resolve(ctx, newRequestWithClient("example.com.", A, "1.2.1.2", "client1"))).
+				Should(
+					SatisfyAll(
+						HaveResponseType(ResponseTypeRESOLVED),
+						HaveReturnCode(dns.RcodeSuccess),
+					))
+
+			m.AssertExpectations(GinkgoT())
+		})
+	})
+
 	Describe("LogConfig", func() {
 		It("should log something", func() {
 			logger, hook := log.NewMockEntry()

--- a/resolver/hotpath_logging_bench_test.go
+++ b/resolver/hotpath_logging_bench_test.go
@@ -1,0 +1,113 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/0xERR0R/blocky/log"
+	"github.com/0xERR0R/blocky/model"
+	"github.com/0xERR0R/blocky/util"
+
+	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
+)
+
+// loggingPassthrough mimics a real chained resolver's per-request logger plumbing:
+// it derives the prefixed context logger (`r.log(ctx)`) exactly as every resolver does
+// at the top of Resolve, discards the logger (nothing is logged at Info level), and
+// delegates to the next resolver. A chain of these measures the Tier-1 cost: the
+// logrus Entry copies + Data-map clone + context.WithValue paid per resolver per
+// request regardless of log level.
+type loggingPassthrough struct {
+	typed
+	NextResolver
+}
+
+func (loggingPassthrough) IsEnabled() bool         { return true }
+func (loggingPassthrough) LogConfig(*logrus.Entry) {}
+
+func (r *loggingPassthrough) Resolve(ctx context.Context, req *model.Request) (*model.Response, error) {
+	ctx, logger := r.log(ctx)
+	_ = logger // not used at Info level — this is the whole point
+
+	return r.next.Resolve(ctx, req)
+}
+
+// BenchmarkChainLoggingPlumbing measures the per-request logger overhead of a chain
+// of resolvers at the default (Info) level, where Debug/Trace lines never print but
+// the prefixed context logger is still rebuilt in every resolver.
+//
+//	go test -run=^$ -bench=BenchmarkChainLoggingPlumbing -benchmem ./resolver/
+func BenchmarkChainLoggingPlumbing(b *testing.B) {
+	const chainDepth = 15 // ~ resolvers traversed on a cache miss
+
+	// production default: Info — Debug/Trace disabled
+	prev := log.Log().Level
+	log.Log().SetLevel(logrus.InfoLevel)
+	b.Cleanup(func() { log.Log().SetLevel(prev) })
+
+	resolvers := make([]Resolver, 0, chainDepth+1)
+	for i := range chainDepth {
+		resolvers = append(resolvers, &loggingPassthrough{typed: withType(chainNodeName(i))})
+	}
+	resolvers = append(resolvers, benchBackend{})
+
+	sut := Chain(resolvers...)
+
+	req := &model.Request{
+		Req:      util.NewMsgWithQuestion("example.com.", dns.Type(dns.TypeA)),
+		Protocol: model.RequestProtocolUDP,
+	}
+
+	// seed the request context with the same fields the server attaches per request
+	// (req_id / question / client_ip), so the cloned Data map has a realistic size.
+	baseCtx, _ := log.CtxWithFields(context.Background(), logrus.Fields{
+		"req_id":    "00000000-0000-0000-0000-000000000000",
+		"question":  "A (example.com.)",
+		"client_ip": "192.168.1.100",
+	})
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_, _ = sut.Resolve(baseCtx, req)
+	}
+}
+
+// BenchmarkDebugFieldBuild_Avoided measures the per-call cost of building the
+// answer log field (util.Obfuscate(util.AnswerToString(...))) that the IsLevelEnabled
+// guards now skip on the cache-miss path when Debug is disabled (the production default).
+// Each guarded site (upstream logResponse, parallel_best, conditional) avoids this work.
+//
+//	go test -run=^$ -bench=BenchmarkDebugFieldBuild_Avoided -benchmem ./resolver/
+func BenchmarkDebugFieldBuild_Avoided(b *testing.B) {
+	answer := []dns.RR{
+		mustRR("example.com. 3600 IN A 1.2.3.4"),
+		mustRR("example.com. 3600 IN A 5.6.7.8"),
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_ = util.Obfuscate(util.AnswerToString(answer))
+	}
+}
+
+func mustRR(s string) dns.RR {
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return rr
+}
+
+func chainNodeName(i int) string {
+	names := []string{
+		"stats", "rate_limiting", "filtering", "fqdn_only", "client_names",
+		"ede", "query_logging", "metrics", "custom_dns", "hosts_file",
+		"rebinding", "blocking", "dnssec", "caching", "conditional",
+	}
+
+	return names[i%len(names)]
+}


### PR DESCRIPTION
## Tier 2 — blocking-path hot-path optimizations

Reduces locking, redundant scans, and wasted work on the per-request blocking path
(the grouped allow/deny caches and `BlockingResolver`). All changes are
behavior-preserving; each commit is independent and benchmarked.

### Changes

| # | Change | Measured win¹ |
|---|--------|---------------|
| **2a** | `InMemoryGroupedCache`: replace `map`+`RWMutex` with `atomic.Pointer[map]`, copy-on-write on refresh → lock-free lookups (writers serialised by a mutex) | **−16%** ns/op on the lock-isolated path (16 groups, parallel); scales with cores & in-flight concurrency; no change at realistic list sizes |
| **2b** | `ChainedGroupedCache.Contains`: query sub-caches cheapest-first (string → wildcard → regex, the reverse of construction order) with per-group short-circuit; adopt the first matching sub-cache map instead of allocating a second | exact denylist hit **8157ns → 617ns (−92%)**, 10 → 8 allocs; parallel multi-group hit **−71%**, 28 → 26 allocs; **denylist miss unchanged** |
| **2c** | `BlockingResolver.Resolve`: early-return to `next` when `IsEnabled()` is false (no `clientGroupsBlock`), matching `hosts_file`/`rebinding` | skips per-request logger derivation + group resolution when blocking is unconfigured |
| **2d** | `clientGroupsIndex`: classify glob identifiers into a dedicated `names` bucket at config load; literal client names resolve via an exact `byID` lookup, `filepath.Match` runs only over the (tiny) glob set | client-name resolution **14.1µs → 0.69µs (−95%)** for both literal and glob names (~250 identifiers) |
| **2e** | Drop the redundant `strings.ToLower` on AAAA answer records (`net.IP.String` is already lower-case); skip `sort.Strings` for ≤1 resolved group | small per-request trims |

¹ Intel i9-9980HK, `-benchmem -count≥8`, `benchstat` (p<0.01 unless noted). Benchmarks added in this PR: `cache/stringcache/grouped_cache_lookup_bench_test.go`, `resolver/blocking_resolver_bench_test.go`.

### Behavior preservation

- **2b** reports the same per-group rule as before: reverse-first-match equals the
  previous forward-last-match under short-circuiting. New characterization tests pin
  the multi-sub-cache rule selection.
- **2d** keeps the pathological "client literally named like a glob" case faithful by
  removing glob identifiers from `byID` (so the exact lookup can't match a glob key).
- Existing client-name (literal/glob/altname/IP/CIDR), FQDN-identifier, and
  response-IP-blocking tests all stay green.

### Not done (deviation from the analysis)

Caching `ClientIP.String()` on `model.Request` was evaluated and **dropped**:
`blocking_resolver_concurrency_test` calls `groupsToCheckForClient` on a *shared*
request from 8 goroutines, so a lazy memo races (confirmed with `-race`). A safe
variant needs an exported constructor (the field would be unexported and
`model.Request` is struct-literal-built across packages) or a `sync.Once`/atomic
field whose per-request weight offsets the ~32B/req saving — not worth it given
2a/2b/2d already carry the path. The other 2e trims are kept.

### Verification

- `go test -race ./cache/stringcache/` — ok (incl. a new concurrent refresh-vs-lookup test)
- `go test -race ./resolver/ ./model/` — ok (incl. the shared-request blocking concurrency test)
- `go test ./lists/... ./server/... ./config/... ./querylog/` — ok (downstream consumers)
- `gofmt` clean; `go vet` clean

New tests: multi-sub-cache rule-selection characterization, disabled-path
passthrough, concurrent refresh-vs-lookup safety net, plus the two benchmark suites.
