### PR TITLE
perf(queryLog): skip per-request LogEntry build when off or ignored

### DIFF
--- a/resolver/query_logging_resolver.go
+++ b/resolver/query_logging_resolver.go
@@ -201,6 +201,12 @@ func (r *QueryLoggingResolver) doCleanUp() {
 
 // Resolve logs the query, duration and the result
 func (r *QueryLoggingResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
+	// Query logging disabled: nothing this resolver does has any effect, so skip
+	// the per-request work (logger derivation, entry building) entirely.
+	if r.cfg.Type == config.QueryLogTypeNone {
+		return r.next.Resolve(ctx, request)
+	}
+
 	ctx, logger := r.log(ctx)
 
 	start := time.Now()
@@ -211,21 +217,27 @@ func (r *QueryLoggingResolver) Resolve(ctx context.Context, request *model.Reque
 		return nil, err
 	}
 
-	entry := r.createLogEntry(request, resp, start, duration)
+	if r.ignore(request, resp) {
+		// Build the entry only to explain (in the debug log) why it was ignored,
+		// and only when that debug line would actually be emitted.
+		if isDebugEnabled(logger) {
+			if entry := r.createLogEntry(request, resp, start, duration); entry != nil {
+				logger.WithFields(querylog.LogEntryFields(entry)).Debug("ignored querylog entry")
+			}
+		}
 
+		return resp, nil
+	}
+
+	entry := r.createLogEntry(request, resp, start, duration)
 	if entry == nil {
 		return resp, nil
 	}
 
-	if r.ignore(request, resp) {
-		// Log to the console for debugging purposes
-		logger.WithFields(querylog.LogEntryFields(entry)).Debug("ignored querylog entry")
-	} else {
-		select {
-		case r.logChan <- entry:
-		default:
-			logger.Error("query log writer is too slow, log entry will be dropped")
-		}
+	select {
+	case r.logChan <- entry:
+	default:
+		logger.Error("query log writer is too slow, log entry will be dropped")
 	}
 
 	return resp, nil

--- a/resolver/query_logging_resolver_test.go
+++ b/resolver/query_logging_resolver_test.go
@@ -126,6 +126,27 @@ var _ = Describe("QueryLoggingResolver", func() {
 			})
 		})
 
+		When("type is none", func() {
+			BeforeEach(func() {
+				sutConfig = config.QueryLog{
+					Type:             config.QueryLogTypeNone,
+					CreationAttempts: 1,
+					CreationCooldown: config.Duration(time.Millisecond),
+				}
+			})
+			It("should pass the request through without building a log entry", func() {
+				Expect(sut.Resolve(ctx, newRequestWithClient("example.com.", A, "192.168.178.25", "client1"))).
+					Should(
+						SatisfyAll(
+							HaveResponseType(ResponseTypeRESOLVED),
+							HaveReturnCode(dns.RcodeSuccess),
+						))
+
+				m.AssertExpectations(GinkgoT())
+				Expect(sut.logChan).Should(BeEmpty())
+			})
+		})
+
 		Describe("ignore", func() {
 			var ignored *log.MockLoggerHook
 
@@ -384,8 +405,10 @@ var _ = Describe("QueryLoggingResolver", func() {
 	Describe("Slow writer", func() {
 		When("writer is too slow", func() {
 			BeforeEach(func() {
+				// Console keeps the resolver enabled (None now short-circuits) without
+				// needing a target; the writer is replaced with SlowMockWriter below.
 				sutConfig = config.QueryLog{
-					Type:             config.QueryLogTypeNone,
+					Type:             config.QueryLogTypeConsole,
 					CreationAttempts: 1,
 					CreationCooldown: config.Duration(time.Millisecond),
 				}


### PR DESCRIPTION
## What

`QueryLoggingResolver.Resolve` built the full `LogEntry` on **every** request — before the `ignore()` check and regardless of writer type. So even with query logging effectively off (`type: none`) or for ignored queries at the default Info level, every request still paid for:

- `request.ClientIP.String()`
- `util.Obfuscate(util.AnswerToString(...))` — `fmt.Sprintf` (reflection) per answer record + `strings.Join` (the most expensive item)
- `util.Obfuscate(request.Req.Question[0].Name)`
- a heap-allocated `*LogEntry`

## Changes

- **Early-return to `next` when `type == none`** — logging is disabled, so the resolver becomes a pure pass-through and skips logger derivation + entry building entirely.
- **Build `createLogEntry` only after `ignore()` returns false.**
- **Gate the ignore-debug line on `IsLevelEnabled(Debug)`** — ignored queries skip entry construction at the default Info level (the entry was only being built to feed a debug line that gets dropped).

The normal logged path is unchanged.

## Behavior / tests

- Added a spec asserting `type: none` passes through to `next` without enqueuing an entry.
- The existing "Slow writer" spec used `type: none` only as a no-target stand-in (then swapped in a slow writer); since `none` now short-circuits, it now uses `console` — its real intent (channel-full dropping) is preserved.
- Full `resolver` suite passes (692/692).

## Measured impact

Quantified locally with a benchmark (not included in this PR) via `benchstat`, n=10:

| scenario | time | bytes/op | allocs/op |
|---|---|---|---|
| `type=none` | 1221 ns → 2.8 ns (−99.8%) | 1152 → 0 (−100%) | 14 → 0 (−100%) |
| `ignored` (Info) | 4718 ns → 944 ns (−80%) | 2737 → 784 (−71%) | 32 → 8 (−75%) |
| `active` (control) | ~unchanged (p=0.53) | unchanged | unchanged |

The 8 allocs remaining on the `ignored` path come from the per-resolver logger derivation (`r.log(ctx)`), which is a separate, broader concern (Tier 1) and out of scope here.

This addresses Tier 3b of the hot-path performance analysis.