### PR TITLE
fix(cache): set DO bit on prefetch reloads to keep DNSSEC-signed entry valid

### DIFF
--- a/resolver/bootstrap.go
+++ b/resolver/bootstrap.go
@@ -100,7 +100,7 @@ func NewBootstrap(ctx context.Context, cfg *config.Config) (b *Bootstrap, err er
 	}
 
 	b.bootstraped = bootstraped
-	cachingResolver, _ := newCachingResolver(ctx, cachingCfg, nil, false)
+	cachingResolver, _ := newCachingResolver(ctx, cachingCfg, config.DNSSEC{}, nil, false)
 
 	b.resolver = Chain(
 		NewFilteringResolver(cfg.Filtering),

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -59,6 +59,11 @@ type CachingResolver struct {
 
 	emitMetricEvents bool // disabled by Bootstrap
 
+	// prefetchDO makes prefetch reloads request DNSSEC records (DO bit) so a
+	// reload can't replace a signed entry with an unsigned one. Set from
+	// dnssec.validate — unsigned caches shouldn't grow with RRSIGs.
+	prefetchDO bool
+
 	resultCache cache.ExpiringCache[[]byte]
 
 	compiledExclusions []*regexp.Regexp
@@ -67,13 +72,15 @@ type CachingResolver struct {
 // NewCachingResolver creates a new resolver instance
 func NewCachingResolver(ctx context.Context,
 	cfg config.Caching,
+	dnssecCfg config.DNSSEC,
 	decorator CacheDecorator,
 ) (*CachingResolver, error) {
-	return newCachingResolver(ctx, cfg, decorator, true)
+	return newCachingResolver(ctx, cfg, dnssecCfg, decorator, true)
 }
 
 func newCachingResolver(ctx context.Context,
 	cfg config.Caching,
+	dnssecCfg config.DNSSEC,
 	decorator CacheDecorator,
 	emitMetricEvents bool,
 ) (*CachingResolver, error) {
@@ -81,6 +88,7 @@ func newCachingResolver(ctx context.Context,
 		configurable:     withConfig(&cfg),
 		typed:            withType("caching"),
 		emitMetricEvents: emitMetricEvents,
+		prefetchDO:       dnssecCfg.Validate,
 	}
 
 	configureCaches(ctx, c, &cfg)
@@ -162,11 +170,14 @@ func (r *CachingResolver) reloadCacheEntry(ctx context.Context, cacheKey string)
 	logger.Debugf("prefetching '%s' (%s)", util.Obfuscate(domainName), qType)
 
 	req := newRequest(dns.Fqdn(domainName), qType)
+
 	// Prefetch reloads bypass the resolvers above the cache, including the DNSSEC
-	// resolver that sets DO on normal queries. Request DNSSEC records so a reload
-	// can't replace a signed entry with an unsigned one (which would then fail
-	// re-validation as bogus on the next hit).
-	req.Req.SetEdns0(ednsUDPSize, true)
+	// resolver that sets DO on normal queries. When validation is enabled, request
+	// DNSSEC records so a reload can't replace a signed entry with an unsigned one
+	// (which would then fail re-validation as bogus on the next hit).
+	if r.prefetchDO {
+		req.Req.SetEdns0(ednsUDPSize, true)
+	}
 
 	response, err := r.next.Resolve(ctx, req)
 	if err != nil {

--- a/resolver/caching_resolver.go
+++ b/resolver/caching_resolver.go
@@ -162,6 +162,12 @@ func (r *CachingResolver) reloadCacheEntry(ctx context.Context, cacheKey string)
 	logger.Debugf("prefetching '%s' (%s)", util.Obfuscate(domainName), qType)
 
 	req := newRequest(dns.Fqdn(domainName), qType)
+	// Prefetch reloads bypass the resolvers above the cache, including the DNSSEC
+	// resolver that sets DO on normal queries. Request DNSSEC records so a reload
+	// can't replace a signed entry with an unsigned one (which would then fail
+	// re-validation as bogus on the next hit).
+	req.Req.SetEdns0(ednsUDPSize, true)
+
 	response, err := r.next.Resolve(ctx, req)
 	if err != nil {
 		util.LogOnError(ctx, fmt.Sprintf("can't prefetch '%s' ", domainName), err)

--- a/resolver/caching_resolver_benchmark_test.go
+++ b/resolver/caching_resolver_benchmark_test.go
@@ -49,7 +49,7 @@ func BenchmarkCachingResolverResolve(b *testing.B) {
 
 	ctx := b.Context()
 
-	sut, err := NewCachingResolver(ctx, cfg, nil)
+	sut, err := NewCachingResolver(ctx, cfg, config.DNSSEC{}, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -142,6 +142,22 @@ var _ = Describe("CachingResolver", func() {
 							HaveTTL(BeNumerically("<=", 2))))
 				Eventually(prefetchHitDomain, "6s").Should(Receive(Equal(true)))
 			})
+
+			It("sets the DO bit on prefetch reloads so a signed entry isn't replaced by an unsigned one", func() {
+				var reloadReqHadDO bool
+				m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
+					opt := req.Req.IsEdns0()
+					reloadReqHadDO = opt != nil && opt.Do()
+
+					return &Response{Res: mockAnswer, RType: ResponseTypeRESOLVED}, nil
+				}
+
+				// reloadCacheEntry is the ReloadFn the prefetching cache invokes on expiry.
+				_, ttl := sut.reloadCacheEntry(ctx, util.GenerateCacheKey(A, "example.com."))
+
+				Expect(reloadReqHadDO).Should(BeTrue(), "prefetch reload must set the DO bit")
+				Expect(ttl).Should(BeNumerically(">", 0))
+			})
 		})
 		When("caching with default values is enabled", func() {
 			BeforeEach(func() {

--- a/resolver/caching_resolver_test.go
+++ b/resolver/caching_resolver_test.go
@@ -25,6 +25,7 @@ var _ = Describe("CachingResolver", func() {
 	var (
 		sut        *CachingResolver
 		sutConfig  config.Caching
+		sutDNSSEC  config.DNSSEC
 		m          *mockResolver
 		mockAnswer *dns.Msg
 		ctx        context.Context
@@ -40,6 +41,7 @@ var _ = Describe("CachingResolver", func() {
 
 	BeforeEach(func() {
 		sutConfig = config.Caching{}
+		sutDNSSEC = config.DNSSEC{}
 		if err := defaults.Set(&sutConfig); err != nil {
 			panic(err)
 		}
@@ -50,7 +52,7 @@ var _ = Describe("CachingResolver", func() {
 		ctx, cancelFn = context.WithCancel(context.Background())
 		DeferCleanup(cancelFn)
 
-		sut, _ = NewCachingResolver(ctx, sutConfig, nil)
+		sut, _ = NewCachingResolver(ctx, sutConfig, sutDNSSEC, nil)
 		m = &mockResolver{}
 		cacheMock = cache.NewMockExpiringCache[[]byte](GinkgoT())
 		m.On("Resolve", mock.Anything).Return(&Response{Res: mockAnswer}, nil)
@@ -139,23 +141,46 @@ var _ = Describe("CachingResolver", func() {
 							HaveResponseType(ResponseTypeCACHED),
 							HaveReturnCode(dns.RcodeSuccess),
 							BeDNSRecord("example.com.", A, "123.122.121.120"),
-							HaveTTL(BeNumerically("<=", 2))))
+							HaveTTL(BeNumerically("<=", 2)),
+						),
+					)
 				Eventually(prefetchHitDomain, "6s").Should(Receive(Equal(true)))
 			})
 
-			It("sets the DO bit on prefetch reloads so a signed entry isn't replaced by an unsigned one", func() {
-				var reloadReqHadDO bool
+			When("dnssec validation is enabled", func() {
+				BeforeEach(func() {
+					sutDNSSEC = config.DNSSEC{Validate: true}
+				})
+
+				It("sets the DO bit on prefetch reloads so a signed entry isn't replaced by an unsigned one", func() {
+					var reloadReqHadDO bool
+					m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
+						opt := req.Req.IsEdns0()
+						reloadReqHadDO = opt != nil && opt.Do()
+
+						return &Response{Res: mockAnswer, RType: ResponseTypeRESOLVED}, nil
+					}
+
+					// reloadCacheEntry is the ReloadFn the prefetching cache invokes on expiry.
+					_, ttl := sut.reloadCacheEntry(ctx, util.GenerateCacheKey(A, "example.com."))
+
+					Expect(reloadReqHadDO).Should(BeTrue(), "prefetch reload must set the DO bit")
+					Expect(ttl).Should(BeNumerically(">", 0))
+				})
+			})
+
+			It("does not request DNSSEC records on prefetch reloads by default, keeping unsigned caches small", func() {
+				var reloadReqHadEdns bool
 				m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
-					opt := req.Req.IsEdns0()
-					reloadReqHadDO = opt != nil && opt.Do()
+					reloadReqHadEdns = req.Req.IsEdns0() != nil
 
 					return &Response{Res: mockAnswer, RType: ResponseTypeRESOLVED}, nil
 				}
 
-				// reloadCacheEntry is the ReloadFn the prefetching cache invokes on expiry.
 				_, ttl := sut.reloadCacheEntry(ctx, util.GenerateCacheKey(A, "example.com."))
 
-				Expect(reloadReqHadDO).Should(BeTrue(), "prefetch reload must set the DO bit")
+				Expect(reloadReqHadEdns).Should(BeFalse(),
+					"without dnssec.validate, prefetch reloads must stay EDNS-free as before")
 				Expect(ttl).Should(BeNumerically(">", 0))
 			})
 		})
@@ -931,7 +956,7 @@ var _ = Describe("CachingResolver", func() {
 			sutConfig = config.Caching{Exclude: exclude}
 			mockAnswer, _ = util.NewMsgWithAnswer(domain, 1000, A, "10.0.0.1")
 			request = newRequest(domain, A)
-			sut, _ = NewCachingResolver(ctx, sutConfig, nil)
+			sut, _ = NewCachingResolver(ctx, sutConfig, config.DNSSEC{}, nil)
 			m.On("Resolve", mock.Anything, mock.Anything).Return(&Response{Res: mockAnswer}, nil)
 			cacheMock.On("Get", mock.Anything).Maybe().Return((*[]byte)(nil), 10*time.Second)
 			cacheMock.On("Put", mock.Anything, mock.Anything, mock.Anything).Maybe().Return()
@@ -941,7 +966,7 @@ var _ = Describe("CachingResolver", func() {
 
 		When("Exclude settings are wrong", func() {
 			It("should fail", func() {
-				_, err := NewCachingResolver(ctx, config.Caching{Exclude: []string{"/[]/"}}, nil)
+				_, err := NewCachingResolver(ctx, config.Caching{Exclude: []string{"/[]/"}}, config.DNSSEC{}, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cache exclusion configuration '/[]/' fail because"))
 			})
@@ -949,7 +974,7 @@ var _ = Describe("CachingResolver", func() {
 
 		When("Exclude settings are wrong because of missing slashes", func() {
 			It("should fail", func() {
-				_, err := NewCachingResolver(ctx, config.Caching{Exclude: []string{"lan"}}, nil)
+				_, err := NewCachingResolver(ctx, config.Caching{Exclude: []string{"lan"}}, config.DNSSEC{}, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cache exclusion configuration 'lan' fail because of missing slashes"))
 			})

--- a/resolver/ecs_client_resolver_test.go
+++ b/resolver/ecs_client_resolver_test.go
@@ -135,7 +135,7 @@ var _ = Describe("ECS as client across the resolver chain (issue #2140)", func()
 		var cachingCfg config.Caching
 		Expect(defaults.Set(&cachingCfg)).Should(Succeed())
 
-		caching, err := NewCachingResolver(ctx, cachingCfg, nil)
+		caching, err := NewCachingResolver(ctx, cachingCfg, config.DNSSEC{}, nil)
 		Expect(err).Should(Succeed())
 		caching.Next(upstream)
 

--- a/resolver/rebinding_resolver_test.go
+++ b/resolver/rebinding_resolver_test.go
@@ -480,7 +480,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			cachingCfg, err := config.WithDefaults[config.Caching]()
 			Expect(err).Should(Succeed())
 
-			cachingRes, err := NewCachingResolver(ctx, cachingCfg, nil)
+			cachingRes, err := NewCachingResolver(ctx, cachingCfg, config.DNSSEC{}, nil)
 			Expect(err).Should(Succeed())
 
 			chained := Chain(sut, cachingRes, m)
@@ -524,7 +524,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			cachingCfg, err := config.WithDefaults[config.Caching]()
 			Expect(err).Should(Succeed())
 
-			cachingRes, err := NewCachingResolver(ctx, cachingCfg, nil)
+			cachingRes, err := NewCachingResolver(ctx, cachingCfg, config.DNSSEC{}, nil)
 			Expect(err).Should(Succeed())
 
 			chained := Chain(sut, cachingRes, m)

--- a/server/server.go
+++ b/server/server.go
@@ -505,7 +505,9 @@ func createQueryResolver(
 		decorator = nil
 	}
 
-	cachingResolver, crErr := resolver.NewCachingResolver(ctx, cfg.Caching, decorator)
+	// cfg.DNSSEC gates the DO bit on prefetch reloads (they bypass the DNSSEC
+	// resolver above the cache).
+	cachingResolver, crErr := resolver.NewCachingResolver(ctx, cfg.Caching, cfg.DNSSEC, decorator)
 	// Pass upstreamTree to DNSSEC resolver so it can query for DNSKEY/DS records
 	dnssecResolver, dsErr := resolver.NewDNSSECResolver(ctx, cfg.DNSSEC, upstreamTree)
 


### PR DESCRIPTION
With `dnssec.validate: true` and `caching.prefetching: true`, signed domains in the cache may return EDE 6 (DNSSEC Bogus) after working on a cold lookup, and then remain broken. Additional note: this seems to happen only when using `1.1.1.1` as the upstream. ~If I use `tcp-tls:1.1.1.1`, it works, although the issue may be intermittent~ reduced prefetch time and was able to reproduce over tcp-tls as well.


Here's my config

```
upstreams:
  timeout: 5s
  groups:
    default:
      - tcp-tls:1.1.1.1 
      - 
      
dnssec:
  validate: true

caching:
  prefetching: true

  # force prefetch to reproduce reliably.
  minTime: 1s 
  maxTime: 2s
  prefetchThreshold: 0 

  
ports:
  dns: 127.0.0.1:15399

log:
  level: info
```


It works for a bit until TTL expires 

```

blocky on HEAD rancher-mel-m1-infra > dig @127.0.0.1 -p 15399 +dnssec cloudflare.com A

; <<>> DiG 9.10.6 <<>> @127.0.0.1 -p 15399 +dnssec cloudflare.com A
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 11084
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;cloudflare.com.			IN	A

;; ANSWER SECTION:
cloudflare.com.		75	IN	A	104.16.133.229
cloudflare.com.		75	IN	A	104.16.132.229
cloudflare.com.		75	IN	RRSIG	A 13 2 300 20260708093530 20260706073530 34505 cloudflare.com. WZGmgY9gPQg0jlcy0tKTLscHI0fqp37kM/ZsTD9elX0riNjA5P7h4tG2 xWG1QIOP2hfJyjtKUFzqObHJmUY                   72A==

;; Query time: 24 msec
;; SERVER: 127.0.0.1#15399(127.0.0.1)
;; WHEN: Tue Jul 07 18:39:25 AEST 2026
;; MSG SIZE  rcvd: 216

```

Then stops working

```
blocky on HEAD rancher-mel-m1-infra > dig @127.0.0.1 -p 15399 +dnssec cloudflare.com A

; <<>> DiG 9.10.6 <<>> @127.0.0.1 -p 15399 +dnssec cloudflare.com A
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 24848
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
; OPT=15: 00 06 44 4e 53 53 45 43 20 76 61 6c 69 64 61 74 69 6f 6e 20 66 61 69 6c 65 64 3a 20 62 6f 67 75 73 20 73 69 67 6e 61 74 75 72 65 73 ("..DNSSEC validation failed: bogus signatures")
;; QUESTION SECTION:
;cloudflare.com.			IN	A

;; Query time: 1 msec
;; SERVER: 127.0.0.1#15399(127.0.0.1)
;; WHEN: Tue Jul 07 18:41:40 AEST 2026
;; MSG SIZE  rcvd: 91

```

logs:

```
[2026-07-07 19:38:29]  INFO bootstrap: bootstrapDns is not configured, will use system resolver
[2026-07-07 19:38:29]  INFO dnssec: DNSSEC resolver initialized with 2 root trust anchor(s)
[2026-07-07 19:38:29]  INFO server: current configuration:
[2026-07-07 19:38:29]  INFO server: -> query_logging:
[2026-07-07 19:38:29]  INFO server:      type: console
[2026-07-07 19:38:29]  INFO server:      logRetentionDays: 0
[2026-07-07 19:38:29]  INFO server:      flushInterval: 30 seconds
[2026-07-07 19:38:29]  INFO server:      fields: [clientIP clientName responseReason responseAnswer question duration]
[2026-07-07 19:38:29]  INFO server:      ignore:
[2026-07-07 19:38:29]  INFO server:        sudn: false
[2026-07-07 19:38:29]  INFO server: -> dnssec:
[2026-07-07 19:38:29]  INFO server:      Validation = true
[2026-07-07 19:38:29]  INFO server:      Using default root trust anchors
[2026-07-07 19:38:29]  INFO server:      Max chain depth = 10
[2026-07-07 19:38:29]  INFO server:      Cache expiration = 1 hour(s)
[2026-07-07 19:38:29]  INFO server:      Max NSEC3 iterations = 150
[2026-07-07 19:38:29]  INFO server:      Max upstream queries per validation = 30
[2026-07-07 19:38:29]  INFO server:      Clock skew tolerance = 3600 second(s)
[2026-07-07 19:38:29]  INFO server: -> caching:
[2026-07-07 19:38:29]  INFO server:      minTime = 1 second
[2026-07-07 19:38:29]  INFO server:      maxTime = 2 seconds
[2026-07-07 19:38:29]  INFO server:      cacheTimeNegative = 30 minutes
[2026-07-07 19:38:29]  INFO server:      exclude:
[2026-07-07 19:38:29]  INFO server:      prefetching:
[2026-07-07 19:38:29]  INFO server:        expires   = 2 hours
[2026-07-07 19:38:29]  INFO server:        threshold = 0
[2026-07-07 19:38:29]  INFO server:        maxItems  = 0
[2026-07-07 19:38:29]  INFO server:      cache entries = 0
[2026-07-07 19:38:29]  INFO server: -> special_use_domains:
[2026-07-07 19:38:29]  INFO server: -> parallel_best:
[2026-07-07 19:38:29]  INFO server:      group: default
[2026-07-07 19:38:29]  INFO server:      upstreams:
[2026-07-07 19:38:29]  INFO server:        - tcp-tls:1.1.1.1
[2026-07-07 19:38:29]  INFO server: listeners:
[2026-07-07 19:38:29]  INFO server:   DNS      = [127.0.0.1:15399]
[2026-07-07 19:38:29]  INFO server:   TLS      = []
[2026-07-07 19:38:29]  INFO server:   HTTP     = []
[2026-07-07 19:38:29]  INFO server:   HTTPS    = []
[2026-07-07 19:38:29]  INFO server:   DOHPath  = /dns-query
[2026-07-07 19:38:29]  INFO server:   FreeBind = false
[2026-07-07 19:38:29]  INFO server:   PROXY protocol = []
[2026-07-07 19:38:29]  INFO server: runtime information:
[2026-07-07 19:38:29]  INFO server:   numCPU =       14
[2026-07-07 19:38:29]  INFO server:   numGoroutine = 12
[2026-07-07 19:38:29]  INFO server:   memory:
[2026-07-07 19:38:29]  INFO server:     heap =              3 MB
[2026-07-07 19:38:29]  INFO server:     sys =              22 MB
[2026-07-07 19:38:29]  INFO server:     numGC =             6
[2026-07-07 19:38:29]  INFO server: Starting server
[2026-07-07 19:38:29]  INFO server: TCP server is up and running on address 127.0.0.1:15399
[2026-07-07 19:38:29]  INFO server: UDP server is up and running on address 127.0.0.1:15399
[2026-07-07 19:38:32]  INFO queryLog: query resolved answer=A (104.16.133.229), A (104.16.132.229), cloudflare.com.	2	IN	RRSIG	A 13 2 300 20260708103647 20260706083647 34505 cloudfla                re.com. negFG+MLI0dbz4dIzwiDwgok+ZIUUEEiUFfMGJ8buQSEqP6BWRwZmQngyjW0KFQeNCBaWscig98VOIfqbQIuWQ== client_ip=127.0.0.1 client_names=127.0.0.1 duration_ms=228 instance=Gravitons-MacBook-Pro-2.local question_name=cloudflare.com. question_type=A response_code=NOERROR response_reason=RESOLVED (tcp-tls:1.1.1.1) response_type=RESOLVED
[2026-07-07 19:38:55]  WARN dnssec: No RRSIG for cloudflare.com. but zone is secure - treating unsigned answer as bogus
[2026-07-07 19:38:55]  WARN dnssec: DNSSEC validation failed for cloudflare.com. - returning SERVFAIL client_ip=127.0.0.1 client_names=127.0.0.1 question=A (cloudflare.com.) req_id=0b3d964b-9370-4469-9699-14e574dd90d9
[2026-07-07 19:38:55]  INFO queryLog: query resolved client_ip=127.0.0.1 client_names=127.0.0.1 instance=Gravitons-MacBook-Pro-2.local question_name=cloudflare.com. question_type=A response_code=SERVFAIL response_reason=DNSSEC validation failed: bogus signatures response_type=BLOCKED
^C[2026-07-07 19:39:03]  INFO Terminating...
[2026-07-07 19:39:03]  INFO server: Stopping server
```

Other examples

```
15:30:18	sqm.telemetry.microsoft.com	A	BLOCKED (static list)	Pro Filtering (Hagezi) 	3
15:30:04	substrate.office.com	AAAA	DNSSEC validation failed: bogus signatures	—	14
15:30:04	substrate.office.com	A	DNSSEC validation failed: bogus signatures	—	29
15:30:02	ecs.office.com	AAAA	DNSSEC validation failed: bogus signatures	—	15
15:29:19	checkonline.home-assistant.io	A	DNSSEC validation failed: bogus signatures	—	687
15:28:46	ecs.office.com	A	DNSSEC validation failed: bogus signatures	—	7
```

Suggesting to set DO on the prefetch reload so it can't replace a signed entry with an unsigned one:

```
req.Req.SetEdns0(ednsUDPSize, true)
```

Could be related to #2139 #2120 but a separate issue.