### PR TITLE
fix(stats): count only true blocks (BLOCKED) as blocked

### DIFF
--- a/api/api_interface_impl.go
+++ b/api/api_interface_impl.go
@@ -220,6 +220,7 @@ func toAPIStats(r stats.Result) ApiStats {
 			Cached:        r.Summary.Cached,
 			Forwarded:     r.Summary.Forwarded,
 			Blocked:       r.Summary.Blocked,
+			Filtered:      r.Summary.Filtered,
 			Local:         r.Summary.Local,
 			Dropped:       r.Summary.Dropped,
 			Errors:        r.Summary.Errors,

--- a/api/api_types.gen.go
+++ b/api/api_types.gen.go
@@ -105,14 +105,19 @@ type ApiStats struct {
 
 // ApiStatsSummary Curated outcome categories over the window (server computes the mapping).
 type ApiStatsSummary struct {
-	AvgResponseMs int     `json:"avgResponseMs"`
-	Blocked       int     `json:"blocked"`
-	CacheHitRate  float64 `json:"cacheHitRate"`
-	Cached        int     `json:"cached"`
-	Dropped       int     `json:"dropped"`
-	Errors        int     `json:"errors"`
-	Forwarded     int     `json:"forwarded"`
-	Local         int     `json:"local"`
+	AvgResponseMs int `json:"avgResponseMs"`
+
+	// Blocked Real blocklist hits only (excludes query-type filtered / NOTFQDN).
+	Blocked      int     `json:"blocked"`
+	CacheHitRate float64 `json:"cacheHitRate"`
+	Cached       int     `json:"cached"`
+	Dropped      int     `json:"dropped"`
+	Errors       int     `json:"errors"`
+
+	// Filtered Query-type filtered (e.g. AAAA) and NOTFQDN responses.
+	Filtered  int `json:"filtered"`
+	Forwarded int `json:"forwarded"`
+	Local     int `json:"local"`
 
 	// Queries Total queries received in the window.
 	Queries int `json:"queries"`

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -103,6 +103,7 @@ func renderSummary(w io.Writer, s *api.ApiStats) {
 	t.AppendRow(table.Row{"Cached", withPercent(sum.Cached, sum.Queries)})
 	t.AppendRow(table.Row{"Forwarded", formatInt(sum.Forwarded)})
 	t.AppendRow(table.Row{"Blocked", withPercent(sum.Blocked, sum.Queries)})
+	t.AppendRow(table.Row{"Filtered", withPercent(sum.Filtered, sum.Queries)})
 	t.AppendRow(table.Row{"Local", formatInt(sum.Local)})
 	t.AppendRow(table.Row{"Dropped", formatInt(sum.Dropped)})
 	t.AppendRow(table.Row{"Errors", formatInt(sum.Errors)})

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -279,6 +279,10 @@ components:
           type: integer
         blocked:
           type: integer
+          description: Real blocklist hits only (excludes query-type filtered / NOTFQDN).
+        filtered:
+          type: integer
+          description: Query-type filtered (e.g. AAAA) and NOTFQDN responses.
         local:
           type: integer
         dropped:
@@ -295,6 +299,7 @@ components:
         - cached
         - forwarded
         - blocked
+        - filtered
         - local
         - dropped
         - errors

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -58,6 +58,7 @@ type Summary struct {
 	Cached        int
 	Forwarded     int
 	Blocked       int
+	Filtered      int
 	Local         int
 	Dropped       int
 	Errors        int
@@ -380,6 +381,7 @@ const (
 	categoryCached
 	categoryForwarded
 	categoryBlocked
+	categoryFiltered
 	categoryLocal
 )
 
@@ -392,9 +394,13 @@ func categorize(rtype string) responseCategory {
 		return categoryCached
 	case model.ResponseTypeRESOLVED.String(), model.ResponseTypeCONDITIONAL.String():
 		return categoryForwarded
-	case model.ResponseTypeBLOCKED.String(), model.ResponseTypeFILTERED.String(),
-		model.ResponseTypeNOTFQDN.String():
+	case model.ResponseTypeBLOCKED.String():
 		return categoryBlocked
+	case model.ResponseTypeFILTERED.String(), model.ResponseTypeNOTFQDN.String():
+		// Query-type filtering (e.g. AAAA via filtering.queryTypes) and NOTFQDN
+		// rejections are not blocklist hits, so they get their own bucket and no
+		// longer inflate "blocked" or the Top Blocked table (#2151).
+		return categoryFiltered
 	case model.ResponseTypeCUSTOMDNS.String(), model.ResponseTypeHOSTSFILE.String(),
 		model.ResponseTypeSPECIAL.String(), model.ResponseTypeSYNTHESIZED.String():
 		return categoryLocal
@@ -403,7 +409,10 @@ func categorize(rtype string) responseCategory {
 	}
 }
 
-// isBlockedRType reports whether a response type counts as "blocked".
+// isBlockedRType reports whether a response type is a true blocklist hit
+// (BLOCKED). Query-type-filtered / NOTFQDN responses are deliberately excluded
+// so the Top Blocked table and the per-hour blocked series count only real
+// blocks (#2151).
 func isBlockedRType(rtype string) bool {
 	return categorize(rtype) == categoryBlocked
 }
@@ -428,6 +437,8 @@ func curatedSummary(rt map[string]int, dropped, errs int, answeredDurationSum in
 			s.Forwarded += n
 		case categoryBlocked:
 			s.Blocked += n
+		case categoryFiltered:
+			s.Filtered += n
 		case categoryLocal:
 			s.Local += n
 		case categoryOther:

--- a/stats/collector_test.go
+++ b/stats/collector_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Collector", func() {
 			sut.Record(answered("CONDITIONAL", "A", "NOERROR", "c.com", "c2"))
 			sut.Record(answered("BLOCKED", "A", "NOERROR", "ads.com", "c2"))
 			sut.Record(answered("FILTERED", "AAAA", "NOERROR", "d.com", "c2"))
+			sut.Record(answered("NOTFQDN", "A", "NOERROR", "notfqdn.local", "c2"))
 			sut.Record(answered("HOSTSFILE", "A", "NOERROR", "e.com", "c1"))
 			sut.Record(Sample{Disposition: DispositionDropped, QType: "A", Domain: "x.com", Client: "c3", DurationMs: 1})
 			sut.Record(Sample{Disposition: DispositionErrored, QType: "A", DurationMs: 2})
@@ -38,13 +39,25 @@ var _ = Describe("Collector", func() {
 
 			Expect(res.Summary.Cached).Should(Equal(1))
 			Expect(res.Summary.Forwarded).Should(Equal(2)) // RESOLVED + CONDITIONAL
-			Expect(res.Summary.Blocked).Should(Equal(2))   // BLOCKED + FILTERED
+			Expect(res.Summary.Blocked).Should(Equal(1))   // BLOCKED only
+			Expect(res.Summary.Filtered).Should(Equal(2))  // FILTERED + NOTFQDN
 			Expect(res.Summary.Local).Should(Equal(1))     // HOSTSFILE
 			Expect(res.Summary.Dropped).Should(Equal(1))
 			Expect(res.Summary.Errors).Should(Equal(1))
-			Expect(res.Summary.Queries).Should(Equal(8))
-			// 6 answered queries × 10ms each / 6; drop (1ms) and error (2ms) latency is excluded.
+			Expect(res.Summary.Queries).Should(Equal(9))
+			// 7 answered queries × 10ms each / 7; drop (1ms) and error (2ms) latency is excluded.
 			Expect(res.Summary.AvgResponseMs).Should(Equal(10))
+		})
+
+		It("counts only true blocks in Top Blocked, not query-type filtered responses", func() {
+			sut.Record(answered("BLOCKED", "A", "NOERROR", "ads.com", "c1"))
+			sut.Record(answered("FILTERED", "AAAA", "NOERROR", "example.com", "c1"))
+			sut.Record(answered("NOTFQDN", "A", "NOERROR", "notfqdn.local", "c1"))
+
+			names := namesOf(sut.Snapshot().TopBlockedDomains)
+			Expect(names).Should(ContainElement("ads.com"))
+			Expect(names).ShouldNot(ContainElement("example.com"))
+			Expect(names).ShouldNot(ContainElement("notfqdn.local"))
 		})
 
 		It("computes cacheHitRate as cached/(cached+forwarded)", func() {


### PR DESCRIPTION
Fixes #2151.

Following the direction in #2151 (blocked should mean `BLOCKED` only), `categorize()` no longer folds query-type-filtered responses into "blocked":

- `FILTERED` (e.g. an `AAAA` lookup dropped by `filtering.queryTypes`) and `NOTFQDN` now map to a new `filtered` category instead of `blocked`.
- `isBlockedRType` — which feeds the **Top Blocked** table and the per-hour `blocked` series — now matches `BLOCKED` only. Domains that resolve fine on their `A` record but had a filtered `AAAA` query (the case reported in #2151) no longer show up as blocked.

User-facing:
- Stats API `summary` gains a `filtered` field (`api/*.gen.go` regenerated via `go generate`).
- `blocky stats` prints a new **Filtered** row.

Alternative, if a smaller API surface is preferred: drop the separate `filtered` field and let those responses fall into the unnamed remainder instead. That is a one-line change — say which you want.

Tested (`go test ./stats/... ./cmd/... ./api/...` green): new specs assert `Blocked` counts `BLOCKED` only, `Filtered` counts `FILTERED`+`NOTFQDN`, and Top Blocked excludes filtered domains. gofmt / vet / golangci-lint v2.12.2 clean.
