### PR TITLE
fix(stats): give DNS rebinding protection its own REBIND response type

### DIFF
--- a/api/api_interface_impl.go
+++ b/api/api_interface_impl.go
@@ -254,7 +254,9 @@ func toAPINameCounts(in []stats.NameCount) []ApiNameCount {
 func toAPIHourPoints(in []stats.HourPoint) []ApiHourPoint {
 	out := make([]ApiHourPoint, 0, len(in))
 	for _, p := range in {
-		out = append(out, ApiHourPoint{Hour: p.Hour, Queries: p.Queries, Blocked: p.Blocked})
+		out = append(out, ApiHourPoint{
+			Hour: p.Hour, Queries: p.Queries, Blocked: p.Blocked, Filtered: p.Filtered,
+		})
 	}
 
 	return out

--- a/api/api_interface_impl_test.go
+++ b/api/api_interface_impl_test.go
@@ -287,12 +287,19 @@ var _ = Describe("API implementation tests", func() {
 
 	Describe("Stats API", func() {
 		It("returns 200 with the snapshot when enabled", func() {
+			hour := time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC)
+
 			statsMock.On("StatsEnabled").Return(true)
 			statsMock.On("Stats").Return(stats.Result{
-				Summary:        stats.Summary{Queries: 3, Blocked: 1, Cached: 1, Forwarded: 1},
+				// distinct values per field so a mis-wired mapping cannot pass
+				Summary: stats.Summary{
+					Queries: 21, Cached: 2, Forwarded: 3, Blocked: 4, Filtered: 5,
+					Local: 6, Dropped: 7, Errors: 8, AvgResponseMs: 9, CacheHitRate: 0.4,
+				},
 				ByResponseType: map[string]int{"RESOLVED": 1, "CACHED": 1, "BLOCKED": 1},
 				ByQueryType:    map[string]int{"A": 3},
 				ByResponseCode: map[string]int{"NOERROR": 3},
+				PerHour:        []stats.HourPoint{{Hour: hour, Queries: 10, Blocked: 4, Filtered: 5}},
 				TopDomains:     []stats.NameCount{{Name: "example.com", Count: 2}},
 				Lists:          stats.ListCounts{Denylist: map[string]int{}, Allowlist: map[string]int{}},
 			})
@@ -302,7 +309,14 @@ var _ = Describe("API implementation tests", func() {
 
 			resp200, ok := resp.(GetStats200JSONResponse)
 			Expect(ok).Should(BeTrue())
-			Expect(resp200.Summary.Queries).Should(Equal(3))
+
+			Expect(resp200.Summary).Should(Equal(ApiStatsSummary{
+				Queries: 21, Cached: 2, Forwarded: 3, Blocked: 4, Filtered: 5,
+				Local: 6, Dropped: 7, Errors: 8, AvgResponseMs: 9, CacheHitRate: 0.4,
+			}))
+			Expect(resp200.PerHour).Should(ConsistOf(ApiHourPoint{
+				Hour: hour, Queries: 10, Blocked: 4, Filtered: 5,
+			}))
 			Expect(resp200.ByResponseType).Should(HaveKeyWithValue("BLOCKED", 1))
 			Expect(resp200.TopDomains).Should(HaveLen(1))
 		})

--- a/api/api_types.gen.go
+++ b/api/api_types.gen.go
@@ -116,7 +116,9 @@ type ApiStatsSummary struct {
 	CacheHitRate float64 `json:"cacheHitRate"`
 	Cached       int     `json:"cached"`
 	Dropped      int     `json:"dropped"`
-	Errors       int     `json:"errors"`
+
+	// Errors Queries that did not resolve: a resolver returned an error, or the answer failed DNSSEC validation (BOGUS). Not blocks.
+	Errors int `json:"errors"`
 
 	// Filtered Query-type filtered (e.g. AAAA via filtering.queryTypes) and NOTFQDN responses. These are not blocks.
 	Filtered  int `json:"filtered"`

--- a/api/api_types.gen.go
+++ b/api/api_types.gen.go
@@ -27,7 +27,11 @@ type ApiCacheStats struct {
 
 // ApiHourPoint defines model for api.HourPoint.
 type ApiHourPoint struct {
+	// Blocked Real blocks in this hour, same definition as summary.blocked.
 	Blocked int `json:"blocked"`
+
+	// Filtered Query-type filtered / NOTFQDN responses in this hour, same definition as summary.filtered.
+	Filtered int `json:"filtered"`
 
 	// Hour Start of the hour bucket. UTC (RFC 3339).
 	Hour    time.Time `json:"hour"`
@@ -107,14 +111,14 @@ type ApiStats struct {
 type ApiStatsSummary struct {
 	AvgResponseMs int `json:"avgResponseMs"`
 
-	// Blocked Real blocklist hits only (excludes query-type filtered / NOTFQDN).
+	// Blocked Real blocks: denylist hits (BLOCKED) and DNS rebinding-protection hits (REBIND). Excludes query-type filtered and NOTFQDN responses.
 	Blocked      int     `json:"blocked"`
 	CacheHitRate float64 `json:"cacheHitRate"`
 	Cached       int     `json:"cached"`
 	Dropped      int     `json:"dropped"`
 	Errors       int     `json:"errors"`
 
-	// Filtered Query-type filtered (e.g. AAAA) and NOTFQDN responses.
+	// Filtered Query-type filtered (e.g. AAAA via filtering.queryTypes) and NOTFQDN responses. These are not blocks.
 	Filtered  int `json:"filtered"`
 	Forwarded int `json:"forwarded"`
 	Local     int `json:"local"`

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -24,9 +24,13 @@ func sampleStats() api.ApiStats {
 			Queries: 12431, Cached: 5102, Forwarded: 4445, Blocked: 2884, Filtered: 1620,
 			Local: 12, Dropped: 3, Errors: 7, AvgResponseMs: 7, CacheHitRate: 0.41,
 		},
-		ByQueryType:       map[string]int{"A": 9000, "AAAA": 3431},
-		ByResponseCode:    map[string]int{"NOERROR": 11000, "NXDOMAIN": 1431},
-		ByResponseType:    map[string]int{"CACHED": 5102, "BLOCKED": 2884, "FILTERED": 1620},
+		ByQueryType:    map[string]int{"A": 9000, "AAAA": 3431},
+		ByResponseCode: map[string]int{"NOERROR": 11000, "NXDOMAIN": 1431},
+		// summary.blocked is BLOCKED + REBIND (2874 + 10) and summary.errors is BOGUS,
+		// so the curated rows above stay consistent with this raw breakdown
+		ByResponseType: map[string]int{
+			"CACHED": 5102, "BLOCKED": 2874, "REBIND": 10, "FILTERED": 1620, "BOGUS": 7,
+		},
 		TopDomains:        []api.ApiNameCount{{Name: "github.com", Count: 1203}},
 		TopBlockedDomains: []api.ApiNameCount{{Name: "ads.example.com", Count: 402}},
 		TopClients:        []api.ApiNameCount{{Name: "10.0.0.5", Count: 4310}},
@@ -70,6 +74,9 @@ var _ = Describe("renderStats", func() {
 		Expect(out).Should(ContainSubstring("7 ms"))
 		Expect(out).Should(ContainSubstring("By Response Code"))
 		Expect(out).Should(ContainSubstring("By Response Type"))
+		// the response types split out of BLOCKED reach the breakdown under their own names
+		Expect(out).Should(ContainSubstring("REBIND"))
+		Expect(out).Should(ContainSubstring("BOGUS"))
 		Expect(out).Should(ContainSubstring("142,000"))
 		Expect(out).Should(ContainSubstring("tracking")) // denylist-only group surfaces via union
 		Expect(out).Should(ContainSubstring("5,000"))    // its denylist count

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -21,12 +21,12 @@ func sampleStats() api.ApiStats {
 		Start: start,
 		End:   start.Add(12 * time.Hour),
 		Summary: api.ApiStatsSummary{
-			Queries: 12431, Cached: 5102, Forwarded: 4445, Blocked: 2884,
+			Queries: 12431, Cached: 5102, Forwarded: 4445, Blocked: 2884, Filtered: 1620,
 			Local: 12, Dropped: 3, Errors: 7, AvgResponseMs: 7, CacheHitRate: 0.41,
 		},
 		ByQueryType:       map[string]int{"A": 9000, "AAAA": 3431},
 		ByResponseCode:    map[string]int{"NOERROR": 11000, "NXDOMAIN": 1431},
-		ByResponseType:    map[string]int{"CACHED": 5102, "BLOCKED": 2884},
+		ByResponseType:    map[string]int{"CACHED": 5102, "BLOCKED": 2884, "FILTERED": 1620},
 		TopDomains:        []api.ApiNameCount{{Name: "github.com", Count: 1203}},
 		TopBlockedDomains: []api.ApiNameCount{{Name: "ads.example.com", Count: 402}},
 		TopClients:        []api.ApiNameCount{{Name: "10.0.0.5", Count: 4310}},
@@ -58,6 +58,11 @@ var _ = Describe("renderStats", func() {
 		Expect(out).Should(ContainSubstring("github.com"))
 		Expect(out).Should(ContainSubstring("Top Blocked"))
 		Expect(out).Should(ContainSubstring("ads.example.com"))
+		// blocked and filtered are separate rows, each with its own share of queries
+		Expect(out).Should(ContainSubstring("Blocked"))
+		Expect(out).Should(ContainSubstring("2,884 (23.2%)"))
+		Expect(out).Should(ContainSubstring("Filtered"))
+		Expect(out).Should(ContainSubstring("1,620 (13.0%)"))
 		Expect(out).Should(ContainSubstring("Top Clients"))
 		Expect(out).Should(ContainSubstring("By Query Type"))
 		Expect(out).Should(ContainSubstring("Cache: 8,123 entries"))

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -293,6 +293,9 @@ components:
           type: integer
         errors:
           type: integer
+          description: >-
+            Queries that did not resolve: a resolver returned an error, or the answer
+            failed DNSSEC validation (BOGUS). Not blocks.
         avgResponseMs:
           type: integer
         cacheHitRate:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -279,10 +279,14 @@ components:
           type: integer
         blocked:
           type: integer
-          description: Real blocklist hits only (excludes query-type filtered / NOTFQDN).
+          description: >-
+            Real blocks: denylist hits (BLOCKED) and DNS rebinding-protection hits (REBIND).
+            Excludes query-type filtered and NOTFQDN responses.
         filtered:
           type: integer
-          description: Query-type filtered (e.g. AAAA) and NOTFQDN responses.
+          description: >-
+            Query-type filtered (e.g. AAAA via filtering.queryTypes) and NOTFQDN responses.
+            These are not blocks.
         local:
           type: integer
         dropped:
@@ -326,10 +330,15 @@ components:
           type: integer
         blocked:
           type: integer
+          description: Real blocks in this hour, same definition as summary.blocked.
+        filtered:
+          type: integer
+          description: Query-type filtered / NOTFQDN responses in this hour, same definition as summary.filtered.
       required:
         - hour
         - queries
         - blocked
+        - filtered
     api.ListCounts:
       type: object
       description: Current per-group list entry counts (point-in-time, not windowed).

--- a/docs/blocky-grafana.json
+++ b/docs/blocky-grafana.json
@@ -331,7 +331,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(blocky_response_total{response_type=\"BLOCKED\", job=~\"$job\", instance=~\"$instance\"}[$__range])) / sum(increase(blocky_query_total{job=~\"$job\", instance=~\"$instance\"}[$__range]))",
+          "expr": "sum(increase(blocky_response_total{response_type=~\"BLOCKED|REBIND\", job=~\"$job\", instance=~\"$instance\"}[$__range])) / sum(increase(blocky_query_total{job=~\"$job\", instance=~\"$instance\"}[$__range]))",
           "refId": "A",
           "range": false,
           "instant": true
@@ -2507,7 +2507,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(blocky_response_total{response_type=\"BLOCKED\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(blocky_response_total{response_type=~\"BLOCKED|REBIND\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
           "refId": "A",
           "range": true,
           "instant": false,
@@ -2519,7 +2519,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(blocky_response_total{response_type=\"BLOCKED\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) / sum(rate(blocky_query_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(blocky_response_total{response_type=~\"BLOCKED|REBIND\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) / sum(rate(blocky_query_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
           "refId": "B",
           "range": true,
           "instant": false,
@@ -2592,7 +2592,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (reason) (ceil(increase(blocky_response_total{response_type=\"BLOCKED\", job=~\"$job\", instance=~\"$instance\"}[$__range]))))",
+          "expr": "topk(10, sum by (reason) (ceil(increase(blocky_response_total{response_type=~\"BLOCKED|REBIND\", job=~\"$job\", instance=~\"$instance\"}[$__range]))))",
           "refId": "A",
           "range": false,
           "instant": true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -451,7 +451,7 @@ startup, and internationalized domains must be given in punycode (`xn--…`) for
 !!! note
 
     The protection runs above the cache: the upstream answer is cached unchanged for its
-    regular TTL, and every cache hit is re-inspected, so repeat queries for a filtered domain
+    regular TTL, and every cache hit is re-inspected, so repeat queries for a blocked domain
     keep showing `REBIND`. This also covers cache entries synchronized from other instances
     through [redis](#redis). Answers from trusted local sources (conditional upstreams,
     special-use domains) are never written to the cache, so they cannot resurface as cached

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,8 +395,10 @@ under the attacker's origin. When this protection is enabled, blocky drops any a
 general upstream resolvers that contains a non-public IP address — in `A`/`AAAA` records or in
 `ipv4hint`/`ipv6hint` SvcParams of `HTTPS`/`SVCB` records, in any section of the response
 (answer, authority or additional) — and returns an empty `NOERROR` response instead (visible as
-response type `FILTERED` with reason `FILTERED (rebinding protection)` in query logs and metrics;
-the offending IP is logged at debug level). **Disabled by default.**
+response type `REBIND` with reason `REBIND (rebinding protection)` in query logs and metrics;
+the offending IP is logged at debug level). Rebinding hits count as **blocked** in the
+[statistics](#statistics), and are reported to clients as Extended DNS Error `15 (Blocked)`.
+**Disabled by default.**
 
 The following ranges are considered non-public:
 
@@ -443,7 +445,7 @@ startup, and internationalized domains must be given in punycode (`xn--…`) for
 
     The protection runs above the cache: the upstream answer is cached unchanged for its
     regular TTL, and every cache hit is re-inspected, so repeat queries for a filtered domain
-    keep showing `FILTERED`. This also covers cache entries synchronized from other instances
+    keep showing `REBIND`. This also covers cache entries synchronized from other instances
     through [redis](#redis). Answers from trusted local sources (conditional upstreams,
     special-use domains) are never written to the cache, so they cannot resurface as cached
     upstream answers and become subject to inspection.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,6 +400,13 @@ the offending IP is logged at debug level). Rebinding hits count as **blocked** 
 [statistics](#statistics), and are reported to clients as Extended DNS Error `15 (Blocked)`.
 **Disabled by default.**
 
+!!! note "Upgrading"
+
+    Rebinding hits previously used the `FILTERED` response type. Query log rows written before
+    the upgrade keep the old value, so a dashboard grouping by response type shows `FILTERED` and
+    `REBIND` side by side for the retention period. The same applies to Prometheus counters,
+    which are labelled per response type.
+
 The following ranges are considered non-public:
 
 | Range                                           | Description             |
@@ -1468,8 +1475,19 @@ Blocky classifies DNSSEC validation results into four categories:
 | --------------- | -------------------------------------------------------------------- | ---------------------------------------- |
 | **Secure**      | Valid DNSSEC signatures and complete chain of trust                  | AD flag set, response returned           |
 | **Insecure**    | Domain is not signed with DNSSEC (no RRSIG records)                  | AD flag cleared, response returned       |
-| **Bogus**       | Invalid DNSSEC signatures or broken chain of trust                   | SERVFAIL returned with EDE code          |
+| **Bogus**       | Invalid DNSSEC signatures or broken chain of trust                   | SERVFAIL returned with EDE code `6 (DNSSEC Bogus)`, response type `BOGUS` |
 | **Indeterminate** | Validation could not be completed (e.g., network errors, budget exceeded) | AD flag cleared, response returned |
+
+A `BOGUS` result means blocky could not obtain a trustworthy answer, so it counts as an **error**
+in the [statistics](#statistics) — not as a block. A domain whose operator has misconfigured DNSSEC
+is not something blocky blocked, and never appears in `topBlockedDomains`.
+
+!!! note "Upgrading"
+
+    Validation failures previously used the `BLOCKED` response type, which counted them as blocks
+    and reported them to clients as Extended DNS Error `15 (Blocked)` instead of `6 (DNSSEC
+    Bogus)`. Query log rows written before the upgrade keep the old value, so a dashboard grouping
+    by response type shows `BLOCKED` and `BOGUS` side by side for the retention period.
 
 ### Trust Anchors
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -36,9 +36,24 @@ You can also browse the interactive API documentation (RapiDoc) documentation [o
 
 !!! note "Statistics semantics"
 
-    For `/api/stats`, the `summary` fields are server-computed categories (e.g. `blocked` =
-    `BLOCKED` + `FILTERED` + `NOTFQDN`, `forwarded` = `RESOLVED` + `CONDITIONAL`), so callers
-    never interpret a raw response type. The `lists` and `cache` objects are point-in-time gauges
+    For `/api/stats`, the `summary` fields are server-computed categories, so callers never
+    interpret a raw response type:
+
+    | Field      | Response types                                             |
+    | ---------- | ---------------------------------------------------------- |
+    | `blocked`  | `BLOCKED` + `REBIND`                                       |
+    | `filtered` | `FILTERED` + `NOTFQDN`                                     |
+    | `forwarded`| `RESOLVED` + `CONDITIONAL`                                 |
+    | `cached`   | `CACHED`                                                   |
+    | `local`    | `CUSTOMDNS` + `HOSTSFILE` + `SPECIAL` + `SYNTHESIZED`      |
+
+    `blocked` counts only queries blocked to protect the client: denylist hits and
+    [DNS rebinding](configuration.md#dns-rebinding-protection) hits. Query-type filtering (e.g.
+    `AAAA` via `filtering.queryTypes`) and non-FQDN rejections are *not* blocks and are counted
+    separately as `filtered`, so they do not inflate `blocked` or the `topBlockedDomains` list.
+    The same split applies to the `perHour` series, which carries both `blocked` and `filtered`.
+
+    The `lists` and `cache` objects are point-in-time gauges
     (current values, not affected by the 24h window), while `start`/`end` bound the windowed fields
     only. All timestamps (`start`, `end`, `perHour[].hour`) are always returned in UTC (RFC 3339,
     `Z` suffix), regardless of the server's local time zone. Statistics are independent of Prometheus

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -39,19 +39,29 @@ You can also browse the interactive API documentation (RapiDoc) documentation [o
     For `/api/stats`, the `summary` fields are server-computed categories, so callers never
     interpret a raw response type:
 
-    | Field      | Response types                                             |
-    | ---------- | ---------------------------------------------------------- |
-    | `blocked`  | `BLOCKED` + `REBIND`                                       |
-    | `filtered` | `FILTERED` + `NOTFQDN`                                     |
-    | `forwarded`| `RESOLVED` + `CONDITIONAL`                                 |
-    | `cached`   | `CACHED`                                                   |
-    | `local`    | `CUSTOMDNS` + `HOSTSFILE` + `SPECIAL` + `SYNTHESIZED`      |
+    | Field      | Response types                                        |
+    | ---------- | ----------------------------------------------------- |
+    | `blocked`  | `BLOCKED` + `REBIND`                                  |
+    | `filtered` | `FILTERED` + `NOTFQDN`                                |
+    | `forwarded`| `RESOLVED` + `CONDITIONAL`                            |
+    | `cached`   | `CACHED`                                              |
+    | `local`    | `CUSTOMDNS` + `HOSTSFILE` + `SPECIAL` + `SYNTHESIZED` |
+    | `errors`   | `BOGUS`, plus queries a resolver failed outright      |
 
     `blocked` counts only queries blocked to protect the client: denylist hits and
-    [DNS rebinding](configuration.md#dns-rebinding-protection) hits. Query-type filtering (e.g.
-    `AAAA` via `filtering.queryTypes`) and non-FQDN rejections are *not* blocks and are counted
-    separately as `filtered`, so they do not inflate `blocked` or the `topBlockedDomains` list.
-    The same split applies to the `perHour` series, which carries both `blocked` and `filtered`.
+    [DNS rebinding](configuration.md#dns-rebinding-protection) hits. Two other outcomes are
+    deliberately kept out of it, so they cannot inflate `blocked` or the `topBlockedDomains`
+    list:
+
+    - Query-type filtering (e.g. `AAAA` via `filtering.queryTypes`) and non-FQDN rejections are
+      client-requested, not protective, and are counted as `filtered`.
+    - A [DNSSEC](configuration.md#dnssec) validation failure (`BOGUS`) is a SERVFAIL — blocky
+      could not obtain a trustworthy answer — so it is a resolution error, not a block, and is
+      counted as `errors` together with queries a resolver failed outright.
+
+    The `blocked` / `filtered` split also applies to the `perHour` series, which carries both.
+    Together with `dropped` (rate-limited), the categories above partition every query, so they
+    always add up to `queries`.
 
     The `lists` and `cache` objects are point-in-time gauges
     (current values, not affected by the 24h window), while `start`/`end` bound the windowed fields

--- a/model/models.go
+++ b/model/models.go
@@ -19,6 +19,7 @@ import (
 // NOTFQDN // the query was filtered as it is not fqdn conform
 // SPECIAL // the query was resolved by the special use domain name resolver
 // SYNTHESIZED // the response was synthesized by DNS64
+// REBIND // the answer was blocked by the DNS rebinding protection
 // )
 type ResponseType int
 
@@ -37,6 +38,11 @@ func (t ResponseType) ToExtendedErrorCode() uint16 {
 	case ResponseTypeNOTFQDN:
 		return dns.ExtendedErrorCodeBlocked
 	case ResponseTypeBLOCKED:
+		return dns.ExtendedErrorCodeBlocked
+	// RFC 8914: "Blocked" is blocking due to an internal security policy of the
+	// operator, "Filtered" is blocking requested by the client. Rebinding
+	// protection is operator policy, so it reports as Blocked.
+	case ResponseTypeREBIND:
 		return dns.ExtendedErrorCodeBlocked
 	case ResponseTypeFILTERED:
 		return dns.ExtendedErrorCodeFiltered

--- a/model/models.go
+++ b/model/models.go
@@ -20,6 +20,7 @@ import (
 // SPECIAL // the query was resolved by the special use domain name resolver
 // SYNTHESIZED // the response was synthesized by DNS64
 // REBIND // the answer was blocked by the DNS rebinding protection
+// BOGUS // the answer failed DNSSEC validation
 // )
 type ResponseType int
 
@@ -44,6 +45,11 @@ func (t ResponseType) ToExtendedErrorCode() uint16 {
 	// protection is operator policy, so it reports as Blocked.
 	case ResponseTypeREBIND:
 		return dns.ExtendedErrorCodeBlocked
+	// EdeResolver sits above the DNSSEC resolver and rewrites the EDE option from
+	// the response type, so this must reproduce the code the DNSSEC resolver sets
+	// on its SERVFAIL; mapping it to anything else would overwrite Bogus (6).
+	case ResponseTypeBOGUS:
+		return dns.ExtendedErrorCodeDNSBogus
 	case ResponseTypeFILTERED:
 		return dns.ExtendedErrorCodeFiltered
 	case ResponseTypeSPECIAL:

--- a/model/models_enum.go
+++ b/model/models_enum.go
@@ -126,11 +126,14 @@ const (
 	// ResponseTypeREBIND is a ResponseType of type REBIND.
 	// the answer was blocked by the DNS rebinding protection
 	ResponseTypeREBIND
+	// ResponseTypeBOGUS is a ResponseType of type BOGUS.
+	// the answer failed DNSSEC validation
+	ResponseTypeBOGUS
 )
 
 var ErrInvalidResponseType = fmt.Errorf("not a valid ResponseType, try [%s]", strings.Join(_ResponseTypeNames, ", "))
 
-const _ResponseTypeName = "RESOLVEDCACHEDBLOCKEDCONDITIONALCUSTOMDNSHOSTSFILEFILTEREDNOTFQDNSPECIALSYNTHESIZEDREBIND"
+const _ResponseTypeName = "RESOLVEDCACHEDBLOCKEDCONDITIONALCUSTOMDNSHOSTSFILEFILTEREDNOTFQDNSPECIALSYNTHESIZEDREBINDBOGUS"
 
 var _ResponseTypeNames = []string{
 	_ResponseTypeName[0:8],
@@ -144,6 +147,7 @@ var _ResponseTypeNames = []string{
 	_ResponseTypeName[65:72],
 	_ResponseTypeName[72:83],
 	_ResponseTypeName[83:89],
+	_ResponseTypeName[89:94],
 }
 
 // ResponseTypeNames returns a list of possible string values of ResponseType.
@@ -165,6 +169,7 @@ var _ResponseTypeMap = map[ResponseType]string{
 	ResponseTypeSPECIAL:     _ResponseTypeName[65:72],
 	ResponseTypeSYNTHESIZED: _ResponseTypeName[72:83],
 	ResponseTypeREBIND:      _ResponseTypeName[83:89],
+	ResponseTypeBOGUS:       _ResponseTypeName[89:94],
 }
 
 // String implements the Stringer interface.
@@ -194,6 +199,7 @@ var _ResponseTypeValue = map[string]ResponseType{
 	_ResponseTypeName[65:72]: ResponseTypeSPECIAL,
 	_ResponseTypeName[72:83]: ResponseTypeSYNTHESIZED,
 	_ResponseTypeName[83:89]: ResponseTypeREBIND,
+	_ResponseTypeName[89:94]: ResponseTypeBOGUS,
 }
 
 // ParseResponseType attempts to convert a string to a ResponseType.

--- a/model/models_enum.go
+++ b/model/models_enum.go
@@ -123,11 +123,14 @@ const (
 	// ResponseTypeSYNTHESIZED is a ResponseType of type SYNTHESIZED.
 	// the response was synthesized by DNS64
 	ResponseTypeSYNTHESIZED
+	// ResponseTypeREBIND is a ResponseType of type REBIND.
+	// the answer was blocked by the DNS rebinding protection
+	ResponseTypeREBIND
 )
 
 var ErrInvalidResponseType = fmt.Errorf("not a valid ResponseType, try [%s]", strings.Join(_ResponseTypeNames, ", "))
 
-const _ResponseTypeName = "RESOLVEDCACHEDBLOCKEDCONDITIONALCUSTOMDNSHOSTSFILEFILTEREDNOTFQDNSPECIALSYNTHESIZED"
+const _ResponseTypeName = "RESOLVEDCACHEDBLOCKEDCONDITIONALCUSTOMDNSHOSTSFILEFILTEREDNOTFQDNSPECIALSYNTHESIZEDREBIND"
 
 var _ResponseTypeNames = []string{
 	_ResponseTypeName[0:8],
@@ -140,6 +143,7 @@ var _ResponseTypeNames = []string{
 	_ResponseTypeName[58:65],
 	_ResponseTypeName[65:72],
 	_ResponseTypeName[72:83],
+	_ResponseTypeName[83:89],
 }
 
 // ResponseTypeNames returns a list of possible string values of ResponseType.
@@ -160,6 +164,7 @@ var _ResponseTypeMap = map[ResponseType]string{
 	ResponseTypeNOTFQDN:     _ResponseTypeName[58:65],
 	ResponseTypeSPECIAL:     _ResponseTypeName[65:72],
 	ResponseTypeSYNTHESIZED: _ResponseTypeName[72:83],
+	ResponseTypeREBIND:      _ResponseTypeName[83:89],
 }
 
 // String implements the Stringer interface.
@@ -188,6 +193,7 @@ var _ResponseTypeValue = map[string]ResponseType{
 	_ResponseTypeName[58:65]: ResponseTypeNOTFQDN,
 	_ResponseTypeName[65:72]: ResponseTypeSPECIAL,
 	_ResponseTypeName[72:83]: ResponseTypeSYNTHESIZED,
+	_ResponseTypeName[83:89]: ResponseTypeREBIND,
 }
 
 // ParseResponseType attempts to convert a string to a ResponseType.

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -184,9 +184,9 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 				Expect(*ips).ShouldNot(BeEmpty())
 				Expect((*ips)[0].String()).Should(Equal("192.168.1.5"))
 
-				// the same name queried by a client passes the full chain and is filtered
+				// the same name queried by a client passes the full chain and is blocked
 				Expect(chain.Resolve(ctx, newRequestWithClient("nas.ddns.example.com.", A, "192.168.1.5"))).
-					Should(HaveResponseType(ResponseTypeFILTERED))
+					Should(HaveResponseType(ResponseTypeREBIND))
 			})
 		})
 	})

--- a/resolver/dnssec_resolver.go
+++ b/resolver/dnssec_resolver.go
@@ -147,9 +147,15 @@ func (r *DNSSECResolver) Resolve(ctx context.Context, request *model.Request) (*
 	return response, nil
 }
 
-// createServFailResponseDNSSEC creates a SERVFAIL response for a DNSSEC validation failure
+// createServFailResponseDNSSEC creates a SERVFAIL response for a DNSSEC validation failure.
+//
+// The response type is BOGUS, not BLOCKED: a validation failure is a resolution error,
+// not a query blocked to protect the client, so it must not be counted as a block in the
+// statistics or listed among the top blocked domains. It also keeps EdeResolver — which
+// sits above this resolver and rewrites the EDE option from the response type — from
+// overwriting the Bogus code set below with "Blocked".
 func createServFailResponseDNSSEC(request *model.Request, reason string) *model.Response {
-	modelResp := model.NewResponseWithRcode(request, dns.RcodeServerFailure, model.ResponseTypeBLOCKED, reason)
+	modelResp := model.NewResponseWithRcode(request, dns.RcodeServerFailure, model.ResponseTypeBOGUS, reason)
 
 	// Add EDE (Extended DNS Error) code for DNSSEC Bogus
 	// RFC 8914: https://www.rfc-editor.org/rfc/rfc8914.html#section-5.2

--- a/resolver/dnssec_resolver_test.go
+++ b/resolver/dnssec_resolver_test.go
@@ -394,7 +394,10 @@ var _ = Describe("DNSSECResolver", func() {
 			Expect(response).ShouldNot(BeNil())
 			Expect(response.Res.Rcode).Should(Equal(dns.RcodeServerFailure))
 			Expect(response.Reason).Should(Equal(reason))
-			Expect(response.RType).Should(Equal(model.ResponseTypeBLOCKED))
+			// a validation failure is an error, not a block: it must not be counted
+			// as one in the statistics, nor reported to the client as EDE "Blocked"
+			Expect(response.RType).Should(Equal(model.ResponseTypeBOGUS))
+			Expect(response.RType.ToExtendedErrorCode()).Should(Equal(dns.ExtendedErrorCodeDNSBogus))
 
 			// Check for EDNS0 with EDE
 			opt := response.Res.IsEdns0()

--- a/resolver/ede_resolver_test.go
+++ b/resolver/ede_resolver_test.go
@@ -136,6 +136,28 @@ var _ = Describe("EdeResolver", func() {
 			})
 		})
 
+		When("resolver returns a rebinding-protection response", func() {
+			BeforeEach(func() {
+				m = &mockResolver{}
+				m.On("Resolve", mock.Anything).Return(&Response{
+					Res:    mockAnswer,
+					RType:  ResponseTypeREBIND,
+					Reason: "REBIND (rebinding protection)",
+				}, nil)
+			})
+
+			It("reports it to the client as blocked, not filtered", func() {
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
+					Should(
+						SatisfyAll(
+							HaveEdnsOption(dns.EDNS0EDE),
+							WithTransform(extractEdeOption,
+								HaveField("InfoCode", Equal(dns.ExtendedErrorCodeBlocked)),
+							),
+						))
+			})
+		})
+
 		When("resolver returns a blocked response with an oversized reason", func() {
 			longReason := "BLOCKED (ads: /" + strings.Repeat("a", 500) + "/)"
 

--- a/resolver/ede_resolver_test.go
+++ b/resolver/ede_resolver_test.go
@@ -158,6 +158,31 @@ var _ = Describe("EdeResolver", func() {
 			})
 		})
 
+		When("resolver returns a DNSSEC validation failure", func() {
+			BeforeEach(func() {
+				m = &mockResolver{}
+				m.On("Resolve", mock.Anything).Return(&Response{
+					Res:    mockAnswer,
+					RType:  ResponseTypeBOGUS,
+					Reason: "DNSSEC validation failed: bogus signatures",
+				}, nil)
+			})
+
+			// this resolver sits above the DNSSEC resolver and rewrites the EDE option from
+			// the response type, so a type that mapped to Blocked would silently replace the
+			// Bogus code the DNSSEC resolver set on its SERVFAIL
+			It("preserves the bogus code instead of overwriting it with blocked", func() {
+				Expect(sut.Resolve(ctx, newRequest("example.com.", A))).
+					Should(
+						SatisfyAll(
+							HaveEdnsOption(dns.EDNS0EDE),
+							WithTransform(extractEdeOption,
+								HaveField("InfoCode", Equal(dns.ExtendedErrorCodeDNSBogus)),
+							),
+						))
+			})
+		})
+
 		When("resolver returns a blocked response with an oversized reason", func() {
 			longReason := "BLOCKED (ads: /" + strings.Repeat("a", 500) + "/)"
 

--- a/resolver/ede_resolver_test.go
+++ b/resolver/ede_resolver_test.go
@@ -42,6 +42,11 @@ var _ = Describe("EdeResolver", func() {
 		DeferCleanup(cancelFn)
 
 		mockAnswer = new(dns.Msg)
+
+		// Reset the mock: it is a closure variable, so a resolver installed by one spec's
+		// BeforeEach would otherwise survive into the next and be reused by the guard below,
+		// leaking both its response type and its accumulated Calls.
+		m = nil
 	})
 
 	JustBeforeEach(func() {

--- a/resolver/rebinding_resolver.go
+++ b/resolver/rebinding_resolver.go
@@ -48,7 +48,7 @@ func NewRebindingProtectionResolver(cfg config.RebindingProtection) *RebindingPr
 	}
 }
 
-// Resolve inspects the next resolver's answer and replaces it with an empty FILTERED
+// Resolve inspects the next resolver's answer and replaces it with an empty REBIND
 // response if it contains a non-public IP.
 func (r *RebindingProtectionResolver) Resolve(ctx context.Context, request *model.Request) (*model.Response, error) {
 	if !r.IsEnabled() {

--- a/resolver/rebinding_resolver.go
+++ b/resolver/rebinding_resolver.go
@@ -98,8 +98,8 @@ func (r *RebindingProtectionResolver) Resolve(ctx context.Context, request *mode
 
 	// fixed reason: it becomes a Prometheus label via MetricsResolver, and the IP is
 	// attacker-chosen — embedding it would allow unbounded cardinality growth
-	return model.NewResponseWithRcode(request, dns.RcodeSuccess, model.ResponseTypeFILTERED,
-		"FILTERED (rebinding protection)"), nil
+	return model.NewResponseWithRcode(request, dns.RcodeSuccess, model.ResponseTypeREBIND,
+		"REBIND (rebinding protection)"), nil
 }
 
 // isAllowed reports whether the queried domain matches an allowlist entry exactly

--- a/resolver/rebinding_resolver_test.go
+++ b/resolver/rebinding_resolver_test.go
@@ -154,7 +154,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			Expect(sut.Resolve(ctx, newRequest("rebind.example.com.", A))).
 				Should(SatisfyAll(
 					HaveNoAnswer(),
-					HaveResponseType(ResponseTypeFILTERED),
+					HaveResponseType(ResponseTypeREBIND),
 				))
 		})
 	})
@@ -167,7 +167,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 				Expect(sut.Resolve(ctx, newRequest("rebind.example.com.", A))).
 					Should(SatisfyAll(
 						HaveNoAnswer(),
-						HaveResponseType(ResponseTypeFILTERED),
+						HaveResponseType(ResponseTypeREBIND),
 						HaveReturnCode(dns.RcodeSuccess),
 					))
 			},
@@ -198,7 +198,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			Expect(sut.Resolve(ctx, newRequest("rebind.example.com.", HTTPS))).
 				Should(SatisfyAll(
 					HaveNoAnswer(),
-					HaveResponseType(ResponseTypeFILTERED),
+					HaveResponseType(ResponseTypeREBIND),
 				))
 		})
 
@@ -216,7 +216,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			Expect(sut.Resolve(ctx, newRequest("rebind.example.com.", dns.Type(dns.TypeSVCB)))).
 				Should(SatisfyAll(
 					HaveNoAnswer(),
-					HaveResponseType(ResponseTypeFILTERED),
+					HaveResponseType(ResponseTypeREBIND),
 				))
 		})
 
@@ -235,7 +235,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			Expect(sut.Resolve(ctx, newRequest("rebind.example.com.", HTTPS))).
 				Should(SatisfyAll(
 					HaveNoAnswer(),
-					HaveResponseType(ResponseTypeFILTERED),
+					HaveResponseType(ResponseTypeREBIND),
 				))
 		})
 
@@ -265,7 +265,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 
 			resp, err := sut.Resolve(ctx, newRequest("rebind.example.com.", A))
 			Expect(err).Should(Succeed())
-			Expect(resp.Reason).Should(Equal("FILTERED (rebinding protection)"))
+			Expect(resp.Reason).Should(Equal("REBIND (rebinding protection)"))
 		})
 
 		It("filters answers mixing public and private records", func() {
@@ -277,7 +277,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			Expect(sut.Resolve(ctx, newRequest("rebind.example.com.", A))).
 				Should(SatisfyAll(
 					HaveNoAnswer(),
-					HaveResponseType(ResponseTypeFILTERED),
+					HaveResponseType(ResponseTypeREBIND),
 				))
 		})
 
@@ -296,7 +296,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			Expect(sut.Resolve(ctx, newRequest("rebind.example.com.", HTTPS))).
 				Should(SatisfyAll(
 					HaveNoAnswer(),
-					HaveResponseType(ResponseTypeFILTERED),
+					HaveResponseType(ResponseTypeREBIND),
 				))
 		})
 
@@ -304,7 +304,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			mockAnswer.Ns = []dns.RR{rebindTestA("rebind.example.com.", "192.168.1.1")}
 
 			Expect(sut.Resolve(ctx, newRequest("rebind.example.com.", A))).
-				Should(HaveResponseType(ResponseTypeFILTERED))
+				Should(HaveResponseType(ResponseTypeREBIND))
 		})
 
 		It("filters private answers for requests without a question section", func() {
@@ -312,7 +312,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			req.Req.Question = nil
 			mockAnswer.Answer = []dns.RR{rebindTestA("rebind.example.com.", "192.168.1.100")}
 
-			Expect(sut.Resolve(ctx, req)).Should(HaveResponseType(ResponseTypeFILTERED))
+			Expect(sut.Resolve(ctx, req)).Should(HaveResponseType(ResponseTypeREBIND))
 		})
 
 		It("obfuscates the dropped IP in the debug log when log privacy is enabled", func() {
@@ -341,7 +341,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			mockAnswer.Answer = []dns.RR{cname, rebindTestA("target.example.org.", "10.0.0.5")}
 
 			Expect(sut.Resolve(ctx, newRequest("evil.example.org.", A))).
-				Should(HaveResponseType(ResponseTypeFILTERED))
+				Should(HaveResponseType(ResponseTypeREBIND))
 		})
 	})
 
@@ -376,7 +376,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			mockAnswer.Answer = []dns.RR{rebindTestA("notintranet.example.com.", "192.168.1.52")}
 
 			Expect(sut.Resolve(ctx, newRequest("notintranet.example.com.", A))).
-				Should(HaveResponseType(ResponseTypeFILTERED))
+				Should(HaveResponseType(ResponseTypeREBIND))
 		})
 
 		It("still filters CNAMEs pointing at an allowlisted name", func() {
@@ -389,7 +389,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			mockAnswer.Answer = []dns.RR{cname, rebindTestA("intranet.example.com.", "192.168.1.50")}
 
 			Expect(sut.Resolve(ctx, newRequest("evil.example.org.", A))).
-				Should(HaveResponseType(ResponseTypeFILTERED))
+				Should(HaveResponseType(ResponseTypeREBIND))
 		})
 
 		It("does not treat escaped dots as label boundaries", func() {
@@ -398,7 +398,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			mockAnswer.Answer = []dns.RR{rebindTestA(`evil\.intranet.example.com.`, "192.168.1.66")}
 
 			Expect(sut.Resolve(ctx, newRequest(`evil\.intranet.example.com.`, A))).
-				Should(HaveResponseType(ResponseTypeFILTERED))
+				Should(HaveResponseType(ResponseTypeREBIND))
 		})
 
 		It("never applies the allowlist to multi-question requests", func() {
@@ -409,7 +409,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 				dns.Question{Name: "evil.example.org.", Qtype: dns.TypeA, Qclass: dns.ClassINET})
 			mockAnswer.Answer = []dns.RR{rebindTestA("intranet.example.com.", "192.168.1.50")}
 
-			Expect(sut.Resolve(ctx, req)).Should(HaveResponseType(ResponseTypeFILTERED))
+			Expect(sut.Resolve(ctx, req)).Should(HaveResponseType(ResponseTypeREBIND))
 		})
 	})
 
@@ -466,7 +466,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			Expect(err).Should(Succeed())
 			Expect(resp).Should(SatisfyAll(
 				HaveNoAnswer(),
-				HaveResponseType(ResponseTypeFILTERED),
+				HaveResponseType(ResponseTypeREBIND),
 				HaveReturnCode(dns.RcodeSuccess),
 			))
 			Expect(resp.Res.AuthenticatedData).Should(BeFalse())
@@ -490,7 +490,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 				Expect(err).Should(Succeed())
 				Expect(resp).Should(SatisfyAll(
 					HaveNoAnswer(),
-					HaveResponseType(ResponseTypeFILTERED),
+					HaveResponseType(ResponseTypeREBIND),
 					HaveReturnCode(dns.RcodeSuccess),
 				))
 				Expect(m.Calls).Should(HaveLen(1))
@@ -501,7 +501,7 @@ var _ = Describe("RebindingProtectionResolver", func() {
 				Expect(err).Should(Succeed())
 				Expect(resp).Should(SatisfyAll(
 					HaveNoAnswer(),
-					HaveResponseType(ResponseTypeFILTERED),
+					HaveResponseType(ResponseTypeREBIND),
 					HaveReturnCode(dns.RcodeSuccess),
 				))
 				// the real answer is cached below this resolver and re-filtered

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -422,9 +422,10 @@ func categorize(rtype string) responseCategory {
 }
 
 // isBlockedRType reports whether a response type is a true block: a denylist hit
-// (BLOCKED) or a rebinding-protection hit (REBIND). Query-type-filtered /
-// NOTFQDN responses are deliberately excluded so the Top Blocked table and the
-// per-hour blocked series count only real blocks (#2151).
+// (BLOCKED) or a rebinding-protection hit (REBIND). It gates the Top Blocked table
+// only — the summary and the per-hour series categorize on their own — so the
+// domains it admits are exactly those blocky blocked. Query-type-filtered / NOTFQDN
+// responses (#2151) and DNSSEC failures are none of them, and stay out.
 func isBlockedRType(rtype string) bool {
 	return categorize(rtype) == categoryBlocked
 }
@@ -512,23 +513,13 @@ func topNList(m map[string]int, n int) []NameCount {
 func perHour(buckets []*bucket) []HourPoint {
 	points := make([]HourPoint, 0, len(buckets))
 	for _, b := range buckets {
-		queries := b.dropped + b.errors
-		blocked, filtered := 0, 0
-
-		for rtype, v := range b.byResponseType {
-			queries += v
-
-			switch categorize(rtype) {
-			case categoryBlocked:
-				blocked += v
-			case categoryFiltered:
-				filtered += v
-			case categoryOther, categoryCached, categoryForwarded, categoryLocal, categoryError:
-			}
-		}
+		// Derive the point from the same function that builds the window summary, so the
+		// two can never disagree on what counts as blocked or filtered: a category added
+		// to categorize() lands in both at once, with no second switch to keep in step.
+		s := curatedSummary(b.byResponseType, b.dropped, b.errors, b.durationSumMs)
 
 		points = append(points, HourPoint{
-			Hour: b.hourStart, Queries: queries, Blocked: blocked, Filtered: filtered,
+			Hour: b.hourStart, Queries: s.Queries, Blocked: s.Blocked, Filtered: s.Filtered,
 		})
 	}
 

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -384,6 +384,7 @@ const (
 	categoryBlocked
 	categoryFiltered
 	categoryLocal
+	categoryError
 )
 
 // categorize is the single source of truth that maps a model.ResponseType string
@@ -410,6 +411,11 @@ func categorize(rtype string) responseCategory {
 	case model.ResponseTypeCUSTOMDNS.String(), model.ResponseTypeHOSTSFILE.String(),
 		model.ResponseTypeSPECIAL.String(), model.ResponseTypeSYNTHESIZED.String():
 		return categoryLocal
+	case model.ResponseTypeBOGUS.String():
+		// A DNSSEC validation failure is a SERVFAIL: the resolver could not produce a
+		// trustworthy answer. That is a resolution error, not a query blocked to protect
+		// the client, so it belongs with the other errors rather than in "blocked".
+		return categoryError
 	default:
 		return categoryOther
 	}
@@ -447,6 +453,11 @@ func curatedSummary(rt map[string]int, dropped, errs int, answeredDurationSum in
 			s.Filtered += n
 		case categoryLocal:
 			s.Local += n
+		case categoryError:
+			// Errors already holds the chain-level failures (a resolver returned an
+			// error); a BOGUS answer is the same outcome for the client — the query
+			// did not resolve — so it is added here rather than to a category of its own.
+			s.Errors += n
 		case categoryOther:
 		}
 	}
@@ -512,7 +523,7 @@ func perHour(buckets []*bucket) []HourPoint {
 				blocked += v
 			case categoryFiltered:
 				filtered += v
-			case categoryOther, categoryCached, categoryForwarded, categoryLocal:
+			case categoryOther, categoryCached, categoryForwarded, categoryLocal, categoryError:
 			}
 		}
 

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -68,9 +68,10 @@ type Summary struct {
 
 // HourPoint is one point in the per-hour time series.
 type HourPoint struct {
-	Hour    time.Time
-	Queries int
-	Blocked int
+	Hour     time.Time
+	Queries  int
+	Blocked  int
+	Filtered int
 }
 
 // ListCounts holds current per-group list entry counts (point-in-time).
@@ -394,12 +395,17 @@ func categorize(rtype string) responseCategory {
 		return categoryCached
 	case model.ResponseTypeRESOLVED.String(), model.ResponseTypeCONDITIONAL.String():
 		return categoryForwarded
-	case model.ResponseTypeBLOCKED.String():
+	// A denylist hit and a rebinding-protection hit are both queries blocked to
+	// protect the client, so both belong in "blocked".
+	case model.ResponseTypeBLOCKED.String(), model.ResponseTypeREBIND.String():
 		return categoryBlocked
 	case model.ResponseTypeFILTERED.String(), model.ResponseTypeNOTFQDN.String():
 		// Query-type filtering (e.g. AAAA via filtering.queryTypes) and NOTFQDN
-		// rejections are not blocklist hits, so they get their own bucket and no
-		// longer inflate "blocked" or the Top Blocked table (#2151).
+		// rejections are not blocks, so they get their own bucket and no longer
+		// inflate "blocked" or the Top Blocked table (#2151). NOTFQDN sits here
+		// even though model.ToExtendedErrorCode reports it to DNS clients as
+		// "Blocked": the EDE code answers "did the server refuse this?", while
+		// this bucket answers "was something harmful blocked?".
 		return categoryFiltered
 	case model.ResponseTypeCUSTOMDNS.String(), model.ResponseTypeHOSTSFILE.String(),
 		model.ResponseTypeSPECIAL.String(), model.ResponseTypeSYNTHESIZED.String():
@@ -409,10 +415,10 @@ func categorize(rtype string) responseCategory {
 	}
 }
 
-// isBlockedRType reports whether a response type is a true blocklist hit
-// (BLOCKED). Query-type-filtered / NOTFQDN responses are deliberately excluded
-// so the Top Blocked table and the per-hour blocked series count only real
-// blocks (#2151).
+// isBlockedRType reports whether a response type is a true block: a denylist hit
+// (BLOCKED) or a rebinding-protection hit (REBIND). Query-type-filtered /
+// NOTFQDN responses are deliberately excluded so the Top Blocked table and the
+// per-hour blocked series count only real blocks (#2151).
 func isBlockedRType(rtype string) bool {
 	return categorize(rtype) == categoryBlocked
 }
@@ -496,17 +502,23 @@ func perHour(buckets []*bucket) []HourPoint {
 	points := make([]HourPoint, 0, len(buckets))
 	for _, b := range buckets {
 		queries := b.dropped + b.errors
-		blocked := 0
+		blocked, filtered := 0, 0
 
 		for rtype, v := range b.byResponseType {
 			queries += v
 
-			if isBlockedRType(rtype) {
+			switch categorize(rtype) {
+			case categoryBlocked:
 				blocked += v
+			case categoryFiltered:
+				filtered += v
+			case categoryOther, categoryCached, categoryForwarded, categoryLocal:
 			}
 		}
 
-		points = append(points, HourPoint{Hour: b.hourStart, Queries: queries, Blocked: blocked})
+		points = append(points, HourPoint{
+			Hour: b.hourStart, Queries: queries, Blocked: blocked, Filtered: filtered,
+		})
 	}
 
 	sort.Slice(points, func(i, j int) bool {

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -404,9 +404,9 @@ func categorize(rtype string) responseCategory {
 		// Query-type filtering (e.g. AAAA via filtering.queryTypes) and NOTFQDN
 		// rejections are not blocks, so they get their own bucket and no longer
 		// inflate "blocked" or the Top Blocked table (#2151). NOTFQDN sits here
-		// even though model.ToExtendedErrorCode reports it to DNS clients as
-		// "Blocked": the EDE code answers "did the server refuse this?", while
-		// this bucket answers "was something harmful blocked?".
+		// even though model.ResponseType.ToExtendedErrorCode reports it to DNS
+		// clients as "Blocked": the EDE code answers "did the server refuse this?",
+		// while this bucket answers "was something harmful blocked?".
 		return categoryFiltered
 	case model.ResponseTypeCUSTOMDNS.String(), model.ResponseTypeHOSTSFILE.String(),
 		model.ResponseTypeSPECIAL.String(), model.ResponseTypeSYNTHESIZED.String():

--- a/stats/collector_test.go
+++ b/stats/collector_test.go
@@ -72,6 +72,21 @@ var _ = Describe("Collector", func() {
 			Expect(namesOf(res.TopBlockedDomains)).Should(ContainElement("rebind.example.com"))
 		})
 
+		It("counts DNSSEC validation failures as errors, not blocked", func() {
+			sut.Record(answered("BLOCKED", "A", "NOERROR", "ads.com", "c1"))
+			sut.Record(answered("BOGUS", "A", "SERVFAIL", "bogus.example.com", "c1"))
+			sut.Record(Sample{Disposition: DispositionErrored, QType: "A", DurationMs: 2})
+
+			res := sut.Snapshot()
+
+			Expect(res.Summary.Blocked).Should(Equal(1)) // BLOCKED only
+			Expect(res.Summary.Errors).Should(Equal(2))  // chain error + BOGUS
+			// a domain with broken signatures is not something blocky blocked
+			Expect(namesOf(res.TopBlockedDomains)).ShouldNot(ContainElement("bogus.example.com"))
+			// still a query that reached an answer, so it counts in the total
+			Expect(res.Summary.Queries).Should(Equal(3))
+		})
+
 		It("computes cacheHitRate as cached/(cached+forwarded)", func() {
 			sut.Record(answered("CACHED", "A", "NOERROR", "a.com", "c1"))
 			sut.Record(answered("CACHED", "A", "NOERROR", "a.com", "c1"))

--- a/stats/collector_test.go
+++ b/stats/collector_test.go
@@ -60,6 +60,18 @@ var _ = Describe("Collector", func() {
 			Expect(names).ShouldNot(ContainElement("notfqdn.local"))
 		})
 
+		It("counts rebinding-protection hits as blocked, not filtered", func() {
+			sut.Record(answered("BLOCKED", "A", "NOERROR", "ads.com", "c1"))
+			sut.Record(answered("REBIND", "A", "NOERROR", "rebind.example.com", "c1"))
+			sut.Record(answered("FILTERED", "AAAA", "NOERROR", "example.com", "c1"))
+
+			res := sut.Snapshot()
+
+			Expect(res.Summary.Blocked).Should(Equal(2))  // BLOCKED + REBIND
+			Expect(res.Summary.Filtered).Should(Equal(1)) // FILTERED only
+			Expect(namesOf(res.TopBlockedDomains)).Should(ContainElement("rebind.example.com"))
+		})
+
 		It("computes cacheHitRate as cached/(cached+forwarded)", func() {
 			sut.Record(answered("CACHED", "A", "NOERROR", "a.com", "c1"))
 			sut.Record(answered("CACHED", "A", "NOERROR", "a.com", "c1"))
@@ -135,6 +147,26 @@ var _ = Describe("Collector", func() {
 			}
 			Expect(total).Should(Equal(2))
 			Expect(blocked).Should(Equal(1))
+		})
+
+		It("counts only true blocks in the per-hour blocked series", func() {
+			clk := &fakeClock{t: mustParse("2026-06-08T10:00:00Z")}
+			c := newCollectorWithClock(clk.now)
+
+			c.Record(Sample{Disposition: DispositionAnswered, RType: "BLOCKED", QType: "A", Domain: "ads.com"})
+			c.Record(Sample{Disposition: DispositionAnswered, RType: "REBIND", QType: "A", Domain: "rebind.com"})
+			c.Record(Sample{Disposition: DispositionAnswered, RType: "FILTERED", QType: "AAAA", Domain: "ok.com"})
+			c.Record(Sample{Disposition: DispositionAnswered, RType: "NOTFQDN", QType: "A", Domain: "notfqdn"})
+
+			res := c.Snapshot()
+
+			Expect(res.PerHour).Should(HaveLen(1))
+			Expect(res.PerHour[0].Queries).Should(Equal(4))
+			// BLOCKED + REBIND; query-type filtered and NOTFQDN are not blocks.
+			Expect(res.PerHour[0].Blocked).Should(Equal(2))
+			// FILTERED + NOTFQDN keep their own series, so the volume the blocked
+			// series no longer carries stays observable per hour.
+			Expect(res.PerHour[0].Filtered).Should(Equal(2))
 		})
 
 		It("prunes high-cardinality maps of closed buckets to keepPerHour", func() {


### PR DESCRIPTION
## Problem

Rebinding protection returned `ResponseTypeFILTERED` — the same response type used for query-type filtering (`filtering.queryTypes`).

Since #2161 (which correctly excluded `FILTERED` from the "blocked" stats), that overload became a bug: a **rebinding hit — an actual attack being stopped — was counted as a benign filter**. It disappeared from `summary.blocked`, from `topBlockedDomains`, and from the per-hour blocked series, and was instead counted under `filtered`, whose API description explicitly claims it holds only query-type/NOTFQDN responses.

Net effect: with `rebindingProtection` enabled, a user under an active DNS rebinding attack saw `Blocked: 0` and an empty Top Blocked table.

`FILTERED` was carrying two unrelated meanings, so no stats-layer mapping could tell them apart. The fix has to happen at the source.

## Change

Split the two meanings by giving rebinding protection its own response type:

- add `model.ResponseTypeREBIND` (**appended** to the enum, so existing iota values are unchanged) and return it from `RebindingProtectionResolver`
- count `REBIND` as **blocked** in the stats (summary, Top Blocked, per-hour series)
- report `REBIND` to clients as **EDE 15 (Blocked)** rather than 17 (Filtered). Per [RFC 8914](https://www.rfc-editor.org/rfc/rfc8914.html), `Blocked` is blocking due to the operator's internal security policy and `Filtered` is blocking requested by the client — rebinding protection is operator policy.
- `FILTERED` now means exactly what its enum comment always claimed: *filtered by query type*

## Also fixes gaps left by #2161

- `perHour` gains a `filtered` series, so the volume the blocked series no longer carries stays observable instead of silently vanishing from the API
- `docs/interfaces.md` still documented `blocked` = `BLOCKED` + `FILTERED` + `NOTFQDN` — the exact definition #2161 removed
- test coverage for the `Filtered` mapping in `toAPIStats`, the CLI summary row, and the per-hour blocked series — none of which were tested

### Note on NOTFQDN

`NOTFQDN` stays in `filtered` even though `ToExtendedErrorCode` reports it to DNS clients as `Blocked`. This divergence is now documented in `categorize()` rather than "fixed": the EDE code answers *"did the server refuse this?"*, while the stats bucket answers *"was something harmful blocked?"*. Those are different questions and don't need the same answer.

## Breaking changes

Rebinding-protection hits change in three user-visible ways:

| | before | after |
|---|---|---|
| response type (query log, Prometheus label) | `FILTERED` | `REBIND` |
| reason | `FILTERED (rebinding protection)` | `REBIND (rebinding protection)` |
| Extended DNS Error | `17 (Filtered)` | `15 (Blocked)` |

The response-type label change is unavoidable given the fix; the reason string follows it for consistency (the reason prefix mirrors the response type by convention).

## Testing

Written test-first — every behavioral assertion was watched failing before the implementation landed. The three tests that backfill coverage of already-correct code were mutation-tested (e.g. wiring `Filtered: r.Summary.Blocked`, the copy-paste bug they exist to catch) to confirm they actually bite.

- unit suite: green across all packages
- `make e2e-test`: 156 passed, 1 skipped, 0 failed
- `go generate ./...` is stable (byte-identical on re-run), so `generate-check` passes
- `gofmt` / `go vet` clean