### PR TITLE
fix(stats): attribute filtered and non-FQDN queries to the client name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1080,6 +1080,13 @@ list and cache gauges. Disabled by default; when disabled,
       enable: true
     ```
 
+!!! note
+
+    Clients are identified by their resolved name (see [client name lookup](#client-name-lookup)) and fall
+    back to their IP when no name is available. Queries dropped by the
+    [rate limiter](#rate-limiting-per-client-ip) are always attributed to the client IP: the limiter
+    runs before the client name lookup, so that its bucket key stays the connection's source IP.
+
 ## HTTP/3 (DoH3) {#http3}
 
 Serve DNS-over-HTTPS over HTTP/3 (RFC 9114). When enabled, Blocky

--- a/e2e/stats_client_names_test.go
+++ b/e2e/stats_client_names_test.go
@@ -1,0 +1,113 @@
+package e2e
+
+import (
+	"context"
+	"net"
+
+	"github.com/0xERR0R/blocky/api"
+	. "github.com/0xERR0R/blocky/helpertest"
+	"github.com/0xERR0R/blocky/util"
+
+	"github.com/miekg/dns"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+// Regression test for https://github.com/0xERR0R/blocky/issues/2152
+//
+// Queries that blocky answers on its own above the client-name lookup (a filtered query type,
+// a non-FQDN name) must be attributed to the same client as every other query of that client.
+// Before the fix they carried no client name, so the statistics counted them under the raw
+// client IP and the same client appeared twice in the top-clients list: once by name, once by
+// IP.
+//
+// The client identity is pinned with ecs.useAsClient (as in the #2140 test): the connecting
+// test client is some docker network address, never 10.0.0.1, so a query can only be counted
+// as "ecsclient" if the ECS subnet was adopted as the client and its name was resolved - for
+// filtered and non-FQDN queries alike.
+var _ = Describe("Statistics client identity (issue #2152)", func() {
+	var (
+		e2eNet *testcontainers.DockerNetwork
+		blocky testcontainers.Container
+		err    error
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		e2eNet = getRandomNetwork(ctx)
+
+		_, err = createDNSMokkaContainer(ctx, "moka", e2eNet,
+			`A example.com/NOERROR("A 1.2.3.4 300")`)
+		Expect(err).Should(Succeed())
+
+		blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(`
+			log:
+			  level: warn
+			upstreams:
+			  groups:
+			    default:
+			      - moka
+			clientLookup:
+			  clients:
+			    ecsclient:
+			      - 10.0.0.1
+			ecs:
+			  useAsClient: true
+			filtering:
+			  queryTypes:
+			    - AAAA
+			fqdnOnly:
+			  enable: true
+			statistics:
+			  enable: true
+			ports:
+			  http: 4000
+			`))
+		Expect(err).Should(Succeed())
+	})
+
+	It("counts filtered and non-FQDN queries under the client name, not the client IP",
+		func(ctx context.Context) {
+			host, port, err := getContainerHostPort(ctx, blocky, "4000/tcp")
+			Expect(err).Should(Succeed())
+			statsURL := "http://" + net.JoinHostPort(host, port) + "/api/stats"
+
+			ecsQuery := func(question string, qType dns.Type) (*dns.Msg, error) {
+				msg := util.NewMsgWithQuestion(question, qType)
+				addECSOption(msg, net.ParseIP("10.0.0.1"))
+
+				return doDNSRequest(ctx, blocky, msg)
+			}
+
+			By("sending a query blocky forwards upstream", func() {
+				Expect(ecsQuery("example.com.", A)).Should(BeDNSRecord("example.com.", A, "1.2.3.4"))
+			})
+
+			By("sending a query the filtering resolver answers", func() {
+				resp, err := ecsQuery("example.com.", AAAA)
+				Expect(err).Should(Succeed())
+				Expect(resp.Rcode).Should(Equal(dns.RcodeSuccess))
+				Expect(resp.Answer).Should(BeEmpty())
+			})
+
+			By("sending a query the fqdnOnly resolver answers", func() {
+				// blocky answers NOTFQDN with a message that carries neither the request id nor
+				// the question section, which the DNS client rejects as an id mismatch (the
+				// fqdnOnly e2e test tolerates the same error). The query still reaches blocky
+				// and is counted, which is what this test is about.
+				resp, err := ecsQuery("myserver.", A)
+				if err == nil {
+					Expect(resp.Rcode).Should(Equal(dns.RcodeNameError))
+				}
+			})
+
+			By("reading /api/stats (collection is async, so poll)", func() {
+				Eventually(func(g Gomega) {
+					res := fetchStats(ctx, g, statsURL)
+					g.Expect(res.Summary.Queries).Should(BeNumerically("==", 3))
+					// all three queries are attributed to the one client, none to its IP
+					g.Expect(res.TopClients).Should(ConsistOf(api.ApiNameCount{Name: "ecsclient", Count: 3}))
+				}, "30s", "500ms").Should(Succeed())
+			})
+		})
+})

--- a/server/server.go
+++ b/server/server.go
@@ -525,14 +525,24 @@ func createQueryResolver(
 
 	r := resolver.Chain(
 		resolver.NewStatsResolver(ctx, cfg.Statistics),
+		// stays above the ECS and client-name lookups: its bucket key must remain the
+		// connection's source IP. Keyed on the ECS address instead (ecs.useAsClient), the
+		// key would be attacker-controlled, letting a client both evade its own bucket and
+		// fill the bounded bucket store, which drops queries of every new client once full.
+		// Dropped queries therefore carry no client name and are attributed to the client
+		// IP in the statistics.
 		resolver.NewRateLimitingResolver(ctx, cfg.RateLimit),
-		resolver.NewFilteringResolver(cfg.Filtering),
-		resolver.NewFQDNOnlyResolver(cfg.FQDNOnly),
 		// adopts the ECS subnet as the internal client IP (ecs.useAsClient) before the
 		// client-name lookup, blocking and the cache consume the client identity, so the
 		// ECS client is used for those features and is preserved across cache hits
 		resolver.NewECSClientResolver(cfg.ECS),
+		// above filtering and fqdnOnly, which answer a query on their own: a lookup below
+		// them would leave request.ClientNames empty for every query they short-circuit,
+		// and the statistics would attribute those to the raw client IP while the same
+		// client's other queries are attributed to its name
 		clientNames,
+		resolver.NewFilteringResolver(cfg.Filtering),
+		resolver.NewFQDNOnlyResolver(cfg.FQDNOnly),
 		resolver.NewEDEResolver(cfg.EDE),
 		queryLogging,
 		resolver.NewMetricsResolver(cfg.Prometheus),

--- a/server/stats_client_names_test.go
+++ b/server/stats_client_names_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/0xERR0R/blocky/api"
+	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/model"
+	"github.com/0xERR0R/blocky/resolver"
+	"github.com/0xERR0R/blocky/stats"
+	"github.com/0xERR0R/blocky/util"
+
+	"github.com/miekg/dns"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Queries that are answered above the client-name lookup (filtered query types,
+// non-FQDN names, rate-limited clients) must still be attributed to the client's
+// name in the statistics, otherwise the same client shows up twice in the
+// top-clients list: once by name, once by raw IP. See #2152.
+var _ = Describe("Client identity for queries answered at the head of the chain", func() {
+	const clientName = "laptop"
+
+	var clientIP = net.ParseIP("192.168.1.11")
+
+	newServer := func(ctx context.Context, adapt func(cfg *config.Config)) *Server {
+		GinkgoHelper()
+
+		cfg := &config.Config{
+			Upstreams: config.Upstreams{
+				Groups: map[string][]config.Upstream{
+					"default": {config.Upstream{Net: config.NetProtocolTcpUdp, Host: "4.4.4.4", Port: 53}},
+				},
+			},
+			Blocking:     config.Blocking{BlockType: "zeroIp"},
+			Statistics:   config.Statistics{Enable: true},
+			ClientLookup: config.ClientLookup{ClientnameIPMapping: map[string][]net.IP{clientName: {clientIP}}},
+			Ports:        config.Ports{DOHPath: "/dns-query"},
+		}
+
+		adapt(cfg)
+
+		srv, err := NewServer(ctx, cfg)
+		Expect(err).Should(Succeed())
+
+		return srv
+	}
+
+	topClients := func(srv *Server) func() []stats.NameCount {
+		GinkgoHelper()
+
+		provider, err := resolver.GetFromChainWithType[api.StatsProvider](srv.queryResolver)
+		Expect(err).Should(Succeed())
+
+		return func() []stats.NameCount {
+			return provider.Stats().TopClients
+		}
+	}
+
+	DescribeTable("records the client name, not the client IP",
+		func(ctx context.Context, adapt func(cfg *config.Config), question string, qType dns.Type,
+			expectedRType model.ResponseType,
+		) {
+			srv := newServer(ctx, adapt)
+
+			resp, err := srv.queryResolver.Resolve(ctx, &model.Request{
+				ClientIP:  clientIP,
+				Req:       util.NewMsgWithQuestion(question, qType),
+				RequestTS: time.Now(),
+			})
+
+			Expect(err).Should(Succeed())
+			Expect(resp.RType).Should(Equal(expectedRType))
+
+			Eventually(topClients(srv)).Should(ConsistOf(stats.NameCount{Name: clientName, Count: 1}))
+		},
+		Entry("query type filtered by the filtering resolver",
+			func(cfg *config.Config) {
+				cfg.Filtering = config.Filtering{QueryTypes: config.NewQTypeSet(dns.Type(dns.TypeAAAA))}
+			},
+			"example.com.", dns.Type(dns.TypeAAAA), model.ResponseTypeFILTERED),
+		Entry("non-FQDN query rejected by the fqdnOnly resolver",
+			func(cfg *config.Config) {
+				cfg.FQDNOnly = config.FQDNOnly{Enable: true}
+			},
+			"example.", dns.Type(dns.TypeA), model.ResponseTypeNOTFQDN),
+	)
+
+	// The rate limiter deliberately stays above the client-name lookup so that its bucket
+	// key remains the connection's source IP (see the chain in createQueryResolver), which
+	// leaves the dropped queries without a client name.
+	It("attributes a rate-limited query to the client IP", func(ctx context.Context) {
+		srv := newServer(ctx, func(cfg *config.Config) {
+			cfg.RateLimit = config.RateLimit{Enable: true, Rate: 1, Burst: 1, IPv4Prefix: 32, IPv6Prefix: 64}
+			// answered locally, so the query that passes the limiter needs no upstream
+			cfg.CustomDNS = config.CustomDNS{
+				Mapping: config.CustomDNSMapping{"example.com": {&dns.A{A: net.ParseIP("192.168.1.99")}}},
+			}
+		})
+
+		// the first query passes the limiter, the second one is dropped by it
+		for range 2 {
+			_, _ = srv.queryResolver.Resolve(ctx, &model.Request{
+				ClientIP:  clientIP,
+				Req:       util.NewMsgWithQuestion("example.com.", dns.Type(dns.TypeA)),
+				RequestTS: time.Now(),
+			})
+		}
+
+		Eventually(topClients(srv)).Should(ConsistOf(
+			stats.NameCount{Name: clientName, Count: 1},
+			stats.NameCount{Name: clientIP.String(), Count: 1},
+		))
+	})
+})


### PR DESCRIPTION
Fixes #2152

## The bug

`StatsResolver` sits at the head of the chain and reads `request.ClientNames` back out after the rest of the chain has run, but `clientNames` was placed *below* the resolvers that can answer a query on their own:

```
Stats → RateLimiting → Filtering → FQDNOnly → ECSClient → clientNames → EDE → queryLogging → …
```

`FilteringResolver` (`filtering.queryTypes`) and `FQDNOnlyResolver` return without calling `next.Resolve`, so `ClientNames` is still empty for every query they handle and `clientID()` falls back to the raw client IP. A client with a resolvable name therefore appears **twice** in the top-clients list — once by name, once by IP — with its queries split across the two entries, which is exactly what the reporter sees.

The query log looks fine because `queryLogging` sits below `clientNames`: it never sees those queries at all, so it cannot show the inconsistency.

This is not specific to the hosts file — names from `clientLookup.clients` and from rDNS are affected the same way.

## The fix

Move `ECSClientResolver` + `clientNames` above `Filtering` and `FQDNOnly`, so the client identity is established before anything can short-circuit the chain:

```
Stats → RateLimiting → ECSClient → clientNames → Filtering → FQDNOnly → EDE → queryLogging → …
```

**The rate limiter deliberately stays at the head**, above both. Its bucket key must remain the connection's source IP: `ECSClientResolver` overwrites `request.ClientIP` when `ecs.useAsClient` is set, and keyed on that, the bucket key would be attacker-controlled — a client rotating a `/32` ECS option per query gets a fresh bucket every time (evading its own limit) and fills the bounded bucket store, after which `allowAt` drops the queries of every *new* client. Rate-limited queries consequently carry no client name and stay attributed to the client IP; that is now pinned by a test and documented under `statistics`.

## Tests

- `server/stats_client_names_test.go` — drives requests through the chain built by `createQueryResolver` and asserts the stats snapshot: filtered and non-FQDN queries are counted under the client name, a rate-limited one under the client IP.
- `e2e/stats_client_names_test.go` — regression test. Pins the client identity with `ecs.useAsClient` (as in the #2140 test), sends a forwarded, an AAAA-filtered and a non-FQDN query, and asserts `/api/stats` reports exactly one top-client entry, `{ecsclient: 3}`. Rebuilt against the pre-fix chain order it fails with the reported symptom: `{ecsclient: 1}` plus `{172.18.0.1: 2}`.

Full unit and e2e suites pass.