### PR TITLE
fix(docker): pre-create writable /app/cache and /logs owned by UID 100

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,12 @@ ARG TARGETVARIANT
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} make build
 
+# Empty dir, copied into the final stage to seed writable mount points. Docker
+# propagates the ownership of an existing image directory to a fresh named
+# volume mounted over it, so pre-creating these makes `-v blocky_cache:/app/cache`
+# writable by the unprivileged container user without any host-side setup.
+RUN mkdir -p /seed-dir
+
 # ----------- stage: final
 FROM scratch
 
@@ -64,6 +70,10 @@ USER 100
 WORKDIR /app
 
 COPY --from=build /bin/blocky /app/blocky
+
+# Writable mount points owned by the container user (see comment in build stage).
+COPY --from=build --chown=100:100 /seed-dir /app/cache
+COPY --from=build --chown=100:100 /seed-dir /logs
 
 ENV BLOCKY_CONFIG_FILE=/app/config.yml
 

--- a/config/config.go
+++ b/config/config.go
@@ -623,7 +623,9 @@ type Downloader struct {
 	// Directory for the on-disk download cache. When empty (default), downloads are
 	// fully stateless: nothing is written to disk and every source is downloaded in
 	// full on every refresh. When set, blocky uses HTTP conditional requests and
-	// serves unchanged/unavailable sources from this directory.
+	// serves unchanged/unavailable sources from this directory. Must be writable by
+	// the user blocky runs as (UID 100 in the container image), otherwise caching is
+	// silently skipped and downloads stay stateless.
 	CachePath string `yaml:"cachePath"`
 }
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -439,7 +439,7 @@
                 },
                 "cachePath": {
                   "type": "string",
-                  "description": "Directory for the on-disk download cache. When empty (default), downloads are\nfully stateless: nothing is written to disk and every source is downloaded in\nfull on every refresh. When set, blocky uses HTTP conditional requests and\nserves unchanged/unavailable sources from this directory."
+                  "description": "Directory for the on-disk download cache. When empty (default), downloads are\nfully stateless: nothing is written to disk and every source is downloaded in\nfull on every refresh. When set, blocky uses HTTP conditional requests and\nserves unchanged/unavailable sources from this directory. Must be writable by\nthe user blocky runs as (UID 100 in the container image), otherwise caching is\nsilently skipped and downloads stay stateless."
                 }
               },
               "additionalProperties": false,
@@ -1286,7 +1286,7 @@
                 },
                 "cachePath": {
                   "type": "string",
-                  "description": "Directory for the on-disk download cache. When empty (default), downloads are\nfully stateless: nothing is written to disk and every source is downloaded in\nfull on every refresh. When set, blocky uses HTTP conditional requests and\nserves unchanged/unavailable sources from this directory."
+                  "description": "Directory for the on-disk download cache. When empty (default), downloads are\nfully stateless: nothing is written to disk and every source is downloaded in\nfull on every refresh. When set, blocky uses HTTP conditional requests and\nserves unchanged/unavailable sources from this directory. Must be writable by\nthe user blocky runs as (UID 100 in the container image), otherwise caching is\nsilently skipped and downloads stay stateless."
                 }
               },
               "additionalProperties": false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1892,6 +1892,17 @@ after a restart re-downloads each source. When unset, downloads are fully statel
 Mount this directory on a persistent volume in containerized setups.
 Note: when you remove or change a source URL, its previous cache file is left on disk — blocky does not delete orphaned cache files automatically. They are harmless and bounded; clear the cache directory manually if you want to reclaim the space.
 
+!!! warning "The directory must be writable by blocky"
+
+    If blocky cannot write to `cachePath`, it logs
+    `cannot create temp cache file in <path>, serving without caching` and keeps
+    resolving normally — only the on-disk cache is disabled, so this degrades
+    performance rather than breaking DNS.
+
+    In Docker, blocky runs as **UID 100**. Use the pre-created `/app/cache` directory
+    with a named volume, or make your own path writable by UID 100. See
+    [writable mounts and file permissions](installation.md#run-blocky).
+
 !!! example
 
     ```yaml
@@ -1901,6 +1912,15 @@ Note: when you remove or change a source URL, its previous cache file is left on
         attempts: 5
         cooldown: 10s
         cachePath: /var/cache/blocky/lists
+    ```
+
+    In a container, prefer the pre-created cache directory and mount a named volume
+    over it (`-v blocky_cache:/app/cache`):
+
+    ```yaml
+    loading:
+      downloads:
+        cachePath: /app/cache
     ```
 
 ### Strategy

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,6 +73,29 @@ ports:
           `securityContext.capabilities.add: ["NET_BIND_SERVICE"]`, or
           `docker run --cap-add NET_BIND_SERVICE`) or configure a port >= 1024.
 
+    !!! note "Writable mounts and file permissions"
+
+        The container runs as the unprivileged user **UID 100**. Any directory Blocky
+        writes to - the query log target, or `loading.downloads.cachePath` - must be
+        writable by that user, otherwise Blocky logs a `permission denied` error and
+        continues without writing.
+
+        The image ships `/app/cache` and `/logs` pre-created and owned by UID 100, so
+        mounting a **named volume** over either path works with no host-side setup:
+
+        ```sh
+        docker run -v blocky_cache:/app/cache ... spx01/blocky
+        ```
+
+        A **bind mount** always keeps the host directory's ownership, so it needs one of:
+
+        - `chown -R 100:100 /path/on/host` before starting the container, or
+        - run as the host user that owns the directory:
+          `docker run -u "$(id -u):$(id -g)" ...`, or in compose
+          `user: "1000:1000"`.
+
+        Read-only mounts such as `config.yml` are unaffected.
+
     Blocky docker images are deployed to DockerHub (`spx01/blocky`) and GitHub Container Registry (`ghcr.io/0xerr0r/blocky`).
 
     === "docker run"
@@ -162,9 +185,17 @@ path like '/app/allowlists/allowlist.txt' in the config file.
         driver: local
         driver_opts:
           type: cifs
-          o: username=USER,password=PASSWORD,rw
+          # uid=100 is required: the share is mounted root-owned by default and
+          # Blocky runs as UID 100, which could then not write the query logs
+          o: username=USER,password=PASSWORD,uid=100,gid=100,rw
           device: //NAS_HOSTNAME/blocky
     ```
+
+    !!! note
+
+        The `./denylists` and `./allowlists` bind mounts above are only read by Blocky,
+        so they need no ownership changes. See the permission note under
+        [Run Blocky](#run-blocky) if you add a writable bind mount.
 
 ## Multiple configuration files
 


### PR DESCRIPTION
Fixes #2165

## Problem

The image runs as `USER 100` on a `scratch` base, so `/app/blocky` was the only path that existed. Docker only propagates ownership into a fresh named volume when the image already has content at the mount path — with nothing there, the volume is created `root:root 0755` and UID 100 cannot write to it.

This made **every** writable mount fail, named volumes included. Verified by building the image before/after and running real containers:

| Scenario | before | after |
| --- | --- | --- |
| `cachePath` → fresh named volume | ❌ `cannot create temp cache file in /app/cache, serving without caching` | ✅ cache file written, owned by `100` |
| query log → `queryLogs:/logs` named volume | ❌ `can't create/open file … permission denied` | ✅ `2026-07-18_ALL.log` written |
| bind mount, host-owned dir | ❌ denied | ❌ denied (expected — needs `chown`/`--user`, now documented) |

Two things this surfaced beyond the original report:

1. **Named volumes were never a workaround for #2165.** The control run reproduces the reporter's exact error *with* a named volume, so that suggestion wouldn't have helped.
2. **The query-log breakage predates `cachePath`.** Our own [advanced docker-compose example](https://0xerr0r.github.io/blocky/latest/installation/#advanced-docker-compose-setup) mounts `queryLogs:/logs`, which has been silently dropping query logs.

## Change

- **`Dockerfile`** — copy an empty dir into the final stage twice with `--chown=100:100`, seeding `/app/cache` and `/logs`. A fresh named volume mounted over either path now inherits UID 100 ownership and is writable with no host-side setup.
- **`docs/installation.md`** — permission note under *Run Blocky* (UID 100; named volume vs. bind mount, the latter needing `chown 100:100` or a matching `--user`). Adds `uid=100,gid=100` to the CIFS `driver_opts`, which mounts root-owned without it.
- **`docs/configuration.md`** — warning next to `cachePath` making clear this is *degraded, not fatal*: blocky keeps resolving and only the on-disk cache is skipped. The reporter's log line reads like a hard failure.
- **`config/config.go`** + regenerated `docs/config.schema.json` — same caveat on the field doc.

Bind mounts still keep host ownership by design; that's documented rather than worked around.

## Not included

The `cachePath` default is left empty. Pointing it at `/app/cache` would switch on-disk caching on by default — a behavior change beyond this issue. The docs recommend that path for containers instead.

## Verification

- `go build ./...`, `go test ./config/... ./lists/...` — pass
- `mkdocs build --strict` — passes; the new cross-page anchor resolves
- `make generate-check` — passes
- Manual end-to-end: both images built and run against a local list server and live DNS queries, results in the table above