### PR TITLE
ci: build sponsor avatar URLs from the login to avoid HTML escaping

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -70,7 +70,7 @@ jobs:
           file: README.md
           marker: gold
           minimum: 2500
-          template: '<a href="https://github.com/{{ login }}"><img src="{{ avatarUrl }}" width="60px" alt="Gold sponsor: {{ login }}" /></a>'
+          template: '<a href="https://github.com/{{ login }}"><img src="https://github.com/{{ login }}.png" width="60px" alt="Gold sponsor: {{ login }}" /></a>'
           fallback: '<em><a href="https://github.com/sponsors/0xERR0R">Become a gold sponsor</a> to appear here.</em>'
 
       - name: Generate sponsors
@@ -81,7 +81,7 @@ jobs:
           file: README.md
           marker: sponsors
           maximum: 2499
-          template: '<a href="https://github.com/{{ login }}"><img src="{{ avatarUrl }}" width="60px" alt="Sponsor: {{ login }}" /></a>'
+          template: '<a href="https://github.com/{{ login }}"><img src="https://github.com/{{ login }}.png" width="60px" alt="Sponsor: {{ login }}" /></a>'
           fallback: '<em><a href="https://github.com/sponsors/0xERR0R">Become a sponsor</a> to appear here.</em>'
 
       # Two independent failure modes, both of which otherwise leave this job

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Even a small recurring contribution makes a real difference and is hugely apprec
 
 ### 🥇 Gold sponsors
 
-<!-- gold --><a href="https://github.com/GeoffreyvanOostveen"><img src="https://github.com/GeoffreyvanOostveen.png" width="60px" alt="Gold sponsor: GeoffreyvanOostveen" /></a> <!-- gold -->
+<!-- gold --><a href="https://github.com/GeoffreyvanOostveen"><img src="https://github.com/GeoffreyvanOostveen.png" width="60px" alt="Gold sponsor: GeoffreyvanOostveen" /></a><!-- gold -->
 
 ### Sponsors
 


### PR DESCRIPTION
Follow-up to #2175.

The first successful run (#2176, closed) generated correct sponsor data but
wrote the avatar URLs as `https:&#x2F;&#x2F;github.com&#x2F;<login>.png`.

## Cause

The action renders templates with mustache 4.2.0, whose escaper maps
`/` to `&#x2F;`. It also rewrites `{{{` to `{{` before rendering, so escaping
cannot be opted out of. `{{ avatarUrl }}` was the only variable containing
slashes, which is why `href` stayed clean and `src` did not.

GitHub decodes the entities when rendering, so the avatars displayed
correctly. This is a readability fix for the README source, not a bug fix.

## Change

The action's GraphQL query never requests `avatarUrl`, so it always falls
back to `https://github.com/<login>.png`. Building that URL from
`{{ login }}` keeps the slashes as literal template text, and GitHub logins
contain no characters mustache escapes.

Also removes the trailing space seeded in #2173 to exercise pull request
creation, which has now been verified end to end.

## Verification

README content was regenerated by a script that reads the templates from the
workflow itself and models the action's full pipeline, including
`sanitizeAndClean()` and mustache escaping:

```
gold      matches workflow output
sponsors  matches workflow output

=> next run produces ZERO diff
```