### PR TITLE
test: seed a trailing space to re-verify sponsors pull request creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Even a small recurring contribution makes a real difference and is hugely apprec
 
 ### 🥇 Gold sponsors
 
-<!-- gold --><a href="https://github.com/GeoffreyvanOostveen"><img src="https://github.com/GeoffreyvanOostveen.png" width="60px" alt="Gold sponsor: GeoffreyvanOostveen" /></a><!-- gold -->
+<!-- gold --><a href="https://github.com/GeoffreyvanOostveen"><img src="https://github.com/GeoffreyvanOostveen.png" width="60px" alt="Gold sponsor: GeoffreyvanOostveen" /></a> <!-- gold -->
 
 ### Sponsors
 


### PR DESCRIPTION
Re-verifies that the sponsors workflow still opens a pull request, using the
final template from #2177.

The workflow currently produces no diff, which is the correct steady state,
but means pull request creation has not been exercised since the template
changed.

This seeds a single trailing space inside the gold marker. GitHub's Markdown
renderer emits it as trailing whitespace at the end of a block, so the
rendered README is visually unchanged.

After merging, dispatching the workflow should open a pull request whose diff
is exactly that one space. Merging that pull request restores the steady
state, and no further pull requests should appear until sponsors actually
change.