### PR TITLE
fix(server): compress responses larger than 512 bytes

### DIFF
--- a/server/client_query.go
+++ b/server/client_query.go
@@ -93,6 +93,15 @@ func (q clientQuery) normalizeResponse(res *dns.Msg) {
 	// uncompressed and enables it when compression is needed to fit, so we let it decide rather
 	// than forcing Compress=true and paying a compression-map alloc + packing on every response.
 	res.Truncate(q.maxResponseSize)
+
+	// Fitting the buffer the client advertised isn't enough on its own: that client may be a
+	// forwarder relaying our answer to a stub with a smaller buffer, and it can only truncate
+	// what it received. Compress anything that wouldn't fit a bare 512-byte UDP message so it
+	// survives that hop; below that there is nothing to gain and the compression map costs more
+	// than the bytes it would save.
+	if !res.Compress && res.Len() > dns.MinMsgSize {
+		res.Compress = true
+	}
 }
 
 // For TCP returns 64k

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1487,6 +1487,39 @@ var _ = Describe("Running DNS server", func() {
 				Expect(resp.Res.Truncated).Should(BeFalse())
 			})
 		})
+
+		When("the response fits the client buffer uncompressed but exceeds 512 bytes", func() {
+			// A forwarder in front of blocky advertises its own (large) EDNS0 buffer, so the
+			// buffer we truncate against is not the one the real client behind it uses. Sending
+			// such an answer uncompressed makes the forwarder truncate it for its 512-byte
+			// clients, which costs them the whole answer section.
+			It("compresses it so a forwarder can relay it to a 512-byte client", func() {
+				res := new(dns.Msg)
+				for i := range 20 {
+					rr, err := dns.NewRR(fmt.Sprintf("example.com. 123 IN A 1.2.3.%d", i))
+					Expect(err).Should(Succeed())
+					res.Answer = append(res.Answer, rr)
+				}
+
+				s := newServerWithResponse(res)
+
+				query := util.NewMsgWithQuestion("example.com.", A)
+				query.SetEdns0(1232, false)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP, query)
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				// guard the scenario: it fits the advertised 1232 uncompressed, so Truncate
+				// leaves the answer complete and sees no reason to compress.
+				Expect(resp.Res.Truncated).Should(BeFalse())
+				Expect(resp.Res.Answer).Should(HaveLen(20))
+
+				packed, err := resp.Res.Pack()
+				Expect(err).Should(Succeed())
+				Expect(len(packed)).Should(BeNumerically("<=", dns.MinMsgSize))
+			})
+		})
 	})
 
 	Describe("secureHeadersMiddleware", func() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1515,6 +1515,12 @@ var _ = Describe("Running DNS server", func() {
 				Expect(resp.Res.Truncated).Should(BeFalse())
 				Expect(resp.Res.Answer).Should(HaveLen(20))
 
+				// guard the scenario: the answer must not fit 512 bytes on its own, otherwise
+				// this passes without the response ever needing compression.
+				uncompressed := resp.Res.Copy()
+				uncompressed.Compress = false
+				Expect(uncompressed.Len()).Should(BeNumerically(">", dns.MinMsgSize))
+
 				packed, err := resp.Res.Pack()
 				Expect(err).Should(Succeed())
 				Expect(len(packed)).Should(BeNumerically("<=", dns.MinMsgSize))


### PR DESCRIPTION
Fixes #2212.

Since #2102 the server lets `Truncate` decide compression, and `Truncate` clears `Compress` whenever the message already fits uncompressed. Fitting the buffer the client advertised turns out not to be sufficient: that client may be a forwarder relaying our answer to a stub resolver with a smaller buffer, and it can only truncate what it received.

A query arriving through such a forwarder carries the *forwarder's* OPT record, so `getMaxResponseSize` returns its buffer (1232 or more) rather than 512. For the reporter's name, eight A records are 562 bytes uncompressed and 202 compressed — both fit 1232, so we send the uncompressed one, and the forwarder has to truncate it for its non-EDNS0 clients. Most do that by dropping every section, so the client is left with TC and no answer at all. Before #2102 the same response went out compressed, fit in 512, and was relayed intact.

Compressing anything that wouldn't fit a bare 512-byte UDP message restores that, while keeping #2102's optimization where it pays: short responses still skip the compression map.

### Reproduction

`dig +noedns` → dnsmasq (`add-subnet=32,128`, forwarding to blocky) → blocky → upstream returning 8 A records:

```
before
;; flags: qr tc rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; MSG SIZE  rcvd: 63

after
;; flags: qr rd ra; QUERY: 1, ANSWER: 8, AUTHORITY: 0, ADDITIONAL: 0
;; MSG SIZE  rcvd: 191
```

Both match the reporter's v0.34 and v0.31 output byte for byte.

### Also fixed

The same change bounds response size in general. Sixty A records, client advertising 4096:

| | wire size |
| --- | --- |
| before | 3734 B |
| after | 1034 B |

A 3734-byte UDP response fragments on a 1500-byte MTU path, and it raises the amplification factor for anything reachable from outside.

### Tests

New case in `server_test.go` under `response compression`: a response that fits the advertised 1232-byte buffer uncompressed but exceeds 512 must pack to 512 bytes or less, with the answer section intact. It fails on `main` and passes here. The two existing cases from #2102 are unchanged — a single-A-record response still goes out uncompressed.

`go test ./server/... ./resolver/... ./util/...` is green.
