### PR TITLE
fix(cmd): healthcheck follows ports.dns from the config

### DIFF
--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -18,7 +18,16 @@ func NewHealthcheckCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "healthcheck",
 		Short: "performs healthcheck",
-		RunE:  healthcheck,
+		// Load the configuration like every other subcommand, so the defaults below can
+		// follow `ports.dns`. A missing or unreadable config must not break the
+		// healthcheck: it then keeps working with the flag defaults, exactly as before.
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			_ = args
+			_ = initConfig()
+
+			return nil
+		},
+		RunE: healthcheck,
 	}
 
 	c.Flags().Uint16P("port", "p", defaultDNSPort, "blocky port")
@@ -31,6 +40,15 @@ func healthcheck(cmd *cobra.Command, args []string) error {
 	_ = args
 	port, _ := cmd.Flags().GetUint16("port")
 	bindIP, _ := cmd.Flags().GetString("bindip")
+
+	// An explicitly given flag always wins; otherwise follow the loaded configuration.
+	if !cmd.Flags().Changed("port") {
+		port = dnsPort
+	}
+
+	if !cmd.Flags().Changed("bindip") {
+		bindIP = dnsHost
+	}
 
 	c := new(dns.Client)
 	c.Net = "tcp"

--- a/cmd/issue_2218_test.go
+++ b/cmd/issue_2218_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/0xERR0R/blocky/helpertest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Reproduces #2218: the Docker image runs `blocky healthcheck` with no flags, but the
+// command defaults to port 53 and never looks at `ports.dns`, so a container that
+// listens on a different DNS port is reported unhealthy.
+var _ = Describe("Healthcheck derives the port from the config (#2218)", func() {
+	var cfgFile string
+
+	writeConfig := func(body string) {
+		dir := GinkgoT().TempDir()
+		cfgFile = filepath.Join(dir, "config.yml")
+		Expect(os.WriteFile(cfgFile, []byte(body), 0o600)).Should(Succeed())
+
+		GinkgoT().Setenv("BLOCKY_CONFIG_FILE", cfgFile)
+
+		// initConfig() only consults the env var while configPath is still the default.
+		old := configPath
+		configPath = defaultConfigPath
+		DeferCleanup(func() { configPath = old })
+	}
+
+	It("probes the DNS port from ports.dns when no flag is given", func() {
+		ip := "127.0.0.1"
+		port := helpertest.GetStringPort(65111)
+		hostPort := helpertest.GetHostPort(ip, 65111)
+
+		srv := createMockServer(hostPort)
+		go func() {
+			defer GinkgoRecover()
+			Expect(srv.ListenAndServe()).Should(Succeed())
+		}()
+
+		writeConfig("ports:\n  dns: " + port + "\nupstreams:\n  groups:\n    default:\n      - 1.1.1.1\n")
+
+		Eventually(func() error {
+			c := NewHealthcheckCommand()
+			c.SetArgs([]string{})
+
+			return c.Execute()
+		}, "2s").Should(Succeed())
+	})
+
+	It("still lets an explicit --port win over the config", func() {
+		ip := "127.0.0.1"
+		port := helpertest.GetStringPort(65112)
+		hostPort := helpertest.GetHostPort(ip, 65112)
+
+		srv := createMockServer(hostPort)
+		go func() {
+			defer GinkgoRecover()
+			Expect(srv.ListenAndServe()).Should(Succeed())
+		}()
+
+		// Config points somewhere nothing is listening; the flag must take precedence.
+		writeConfig("ports:\n  dns: 65113\nupstreams:\n  groups:\n    default:\n      - 1.1.1.1\n")
+
+		Eventually(func() error {
+			c := NewHealthcheckCommand()
+			c.SetArgs([]string{"-p", port, "-b", ip})
+
+			return c.Execute()
+		}, "2s").Should(Succeed())
+	})
+
+	It("keeps working when no config file exists at all", func() {
+		ip := "127.0.0.1"
+		port := helpertest.GetStringPort(65114)
+		hostPort := helpertest.GetHostPort(ip, 65114)
+
+		srv := createMockServer(hostPort)
+		go func() {
+			defer GinkgoRecover()
+			Expect(srv.ListenAndServe()).Should(Succeed())
+		}()
+
+		GinkgoT().Setenv("BLOCKY_CONFIG_FILE", filepath.Join(GinkgoT().TempDir(), "does-not-exist.yml"))
+		old := configPath
+		configPath = defaultConfigPath
+		DeferCleanup(func() { configPath = old })
+
+		Eventually(func() error {
+			c := NewHealthcheckCommand()
+			c.SetArgs([]string{"-p", port, "-b", ip})
+
+			return c.Execute()
+		}, "2s").Should(Succeed())
+	})
+})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,8 @@ var (
 	configPath string
 	apiHost    string
 	apiPort    uint16
+	dnsHost    = defaultIPAddress
+	dnsPort    = uint16(defaultDNSPort)
 )
 
 const (
@@ -116,7 +118,37 @@ func initConfig() error {
 		apiPort = port
 	}
 
+	if len(cfg.Ports.DNS) != 0 {
+		host, port, err := splitListenAddress(cfg.Ports.DNS[0])
+		if err != nil {
+			return fmt.Errorf("can't parse DNS listen address '%s': %w", cfg.Ports.DNS[0], err)
+		}
+
+		if host != "" {
+			dnsHost = host
+		}
+
+		dnsPort = port
+	}
+
 	return nil
+}
+
+// splitListenAddress splits a `ports.*` entry into host and port. Entries are normalized
+// to ":port" when no host is given, so an empty host means "all interfaces".
+func splitListenAddress(addr string) (host string, port uint16, err error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Not a host:port pair - treat the whole value as a port.
+		host, portStr = "", addr
+	}
+
+	port, err = config.ConvertPort(portStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("can't convert port '%s' to number (1 - 65535): %w", portStr, err)
+	}
+
+	return host, port, nil
 }
 
 // Execute starts the command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,7 +125,9 @@ func initConfig() error {
 		}
 
 		if host != "" {
-			dnsHost = host
+			if ip := net.ParseIP(host); ip == nil || !ip.IsUnspecified() {
+				dnsHost = host
+			}
 		}
 
 		dnsPort = port


### PR DESCRIPTION
Fixes #2218.

The image's own `HEALTHCHECK` runs `/app/blocky healthcheck` without flags (`Dockerfile:82`), but the command defaults to port 53 and never loads the configuration. A container listening on a different DNS port is therefore reported unhealthy while it is serving correctly.

**`healthcheck` was the only subcommand that does not load the config.** `lists`, `cache`, `stats`, `blocking`, `serve` and `query` all wire `PersistentPreRunE: initConfigPreRun`, and `validate` calls `initConfig()` directly. `initConfig()` also already derives `apiHost`/`apiPort` from `ports.http` — this change does the same for `ports.dns`, so the existing mechanism now covers the DNS side too. The image already exports `BLOCKY_CONFIG_FILE=/app/config.yml` (`Dockerfile:78`), which `initConfig()` reads, so the healthcheck finds the config without any change to the Dockerfile.

Behaviour kept intact:

- An explicitly given `--port`/`--bindip` still wins over the config (checked via `Flags().Changed`), so the documented workaround `healthcheck -p 3000` keeps working.
- A missing or unreadable config does **not** fail the healthcheck — the error is ignored and the previous flag defaults (`127.0.0.1:53`) apply, exactly as before.
- Only the new `ports.dns` path uses `net.SplitHostPort`; the existing `ports.http` parsing is untouched.

**Tests** (`cmd/issue_2218_test.go`, ginkgo): three specs — port taken from `ports.dns` when no flag is given (this one fails without the fix), explicit `--port` beating the config, and no-config-file still working. The latter two are regression guards and pass both before and after.

**Verification** (isolated container, `golang:1.26`):

```
go test ./cmd/                                   # RED before the fix: 1 of 57 specs fails
                                                 # GREEN after: ok
go test -race $(go list ./... | grep -v /e2e)    # 20 packages ok
gofmt -l ./cmd ./config                          # clean
go vet ./cmd/... ./config/...                    # clean
golangci-lint v2.12.2 run                        # 0 issues
```
