### PR TITLE
fix(resolver): send the original name to the next resolver for rewritten queries

### DIFF
--- a/config/rewriter.go
+++ b/config/rewriter.go
@@ -11,6 +11,7 @@ type RewriterConfig struct {
 	// Domain rewrite rules applied before resolution; keys are rewritten to their values.
 	Rewrite map[string]string `yaml:"rewrite"`
 	// If true, the original query is sent upstream when the mapped resolver returns an empty answer.
+	// Only has an effect together with Rewrite.
 	FallbackUpstream bool `default:"false" yaml:"fallbackUpstream"`
 }
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -131,7 +131,7 @@
         },
         "fallbackUpstream": {
           "type": "boolean",
-          "description": "If true, the original query is sent upstream when the mapped resolver returns an empty answer.",
+          "description": "If true, the original query is sent upstream when the mapped resolver returns an empty answer.\nOnly has an effect together with Rewrite.",
           "default": false
         },
         "customTTL": {
@@ -193,7 +193,7 @@
         },
         "fallbackUpstream": {
           "type": "boolean",
-          "description": "If true, the original query is sent upstream when the mapped resolver returns an empty answer.",
+          "description": "If true, the original query is sent upstream when the mapped resolver returns an empty answer.\nOnly has an effect together with Rewrite.",
           "default": false
         },
         "mapping": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -650,6 +650,7 @@ hostname belongs to which IP address, all DNS queries for the local network shou
 The optional parameter `rewrite` behaves the same as with custom DNS.
 
 The optional parameter `fallbackUpstream`, if false (default), return empty result if after rewrite, the mapped resolver returned an empty answer. If true, the original query will be sent to the upstream resolver.
+It only has an effect together with `rewrite`; without any rewrite rules it is ignored.
 
 **Usage:** One usecase when having split DNS for internal and external (internet facing) users, but not all subdomains are listed in the internal domain
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -438,10 +438,11 @@ them to the allowlist. Entries match the domain itself and all of its subdomains
 done on the name of the inspected query, so a `CNAME` inside an upstream answer pointing at an
 allowlisted name does not bypass the protection (for `customDNS` `CNAME` entries the inspected
 query is the lookup of the CNAME target, so allowlist the **target** name, not the entry's
-name). If `customDNS.rewrite` rules apply to the query, matching uses the rewritten name —
-allowlist the rewritten form (`conditional.rewrite` rules do not affect matching). Entries must
-be plain domain names: wildcards (`*.example.com`), regexes and whitespace are rejected at
-startup, and internationalized domains must be given in punycode (`xn--…`) form.
+name). Rewrite rules do not affect matching: a `customDNS.rewrite` or `conditional.rewrite`
+target is used only for that resolver's own lookup and is never handed down the chain, so
+allowlist the name the client asks for. Entries must be plain domain names: wildcards
+(`*.example.com`), regexes and whitespace are rejected at startup, and internationalized domains
+must be given in punycode (`xn--…`) form.
 
 !!! example
 

--- a/resolver/conditional_upstream_resolver.go
+++ b/resolver/conditional_upstream_resolver.go
@@ -96,20 +96,21 @@ func (r *ConditionalUpstreamResolver) Resolve(ctx context.Context, request *mode
 		resolved, response, err = r.processRequest(ctx, request)
 	}
 
-	if !resolved && err == nil {
-		logger.WithField("next_resolver", Name(r.next)).Trace("go to next resolver")
-		response, err = r.next.Resolve(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Revert the request
+	// Revert the request before it leaves this resolver: the rewritten name is
+	// meant for the mapped upstream, not for the rest of the chain.
 	request.Req = original
+
+	// processRequest only reports `resolved` for a query it sent to a mapped
+	// upstream, so anything else continues down the chain under its original name.
+	if !resolved {
+		logger.WithField("next_resolver", Name(r.next)).Trace("go to next resolver")
+
+		return r.next.Resolve(ctx, request)
+	}
 
 	// The mapped resolver failed or had nothing: ask the rest of the chain,
 	// using the original name (`fallbackUpstream`).
-	if shouldFallbackUpstream(&r.cfg.RewriterConfig, resolved, response, err) {
+	if shouldFallbackUpstream(&r.cfg.RewriterConfig, response, err) {
 		logger.WithField("next_resolver", Name(r.next)).Trace("fallback to next resolver")
 
 		return r.next.Resolve(ctx, request)

--- a/resolver/conditional_upstream_resolver_test.go
+++ b/resolver/conditional_upstream_resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"errors"
 
 	"github.com/0xERR0R/blocky/config"
 	. "github.com/0xERR0R/blocky/helpertest"
@@ -272,17 +273,9 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 			})
 
 			It("should ask the next resolver with the original name", func() {
-				var seen string
+				var seen *string
 
-				m = &mockResolver{}
-				m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
-				m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
-					seen = req.Req.Question[0].Name
-					resp, err := util.NewMsgWithAnswer(seen, 250, A, "192.192.192.192")
-					Expect(err).Should(Succeed())
-
-					return &Response{Res: resp, RType: ResponseTypeRESOLVED, Reason: "RESOLVED"}, nil
-				}
+				m, seen = newRecordingResolver(A, "192.192.192.192")
 				sut.Next(m)
 
 				Expect(sut.Resolve(ctx, newRequest("www.source.test.", A))).
@@ -293,50 +286,34 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 							HaveReturnCode(dns.RcodeSuccess),
 						))
 
-				Expect(seen).Should(Equal("www.source.test."))
+				Expect(*seen).Should(Equal("www.source.test."))
 			})
 		})
 
 		When("the mapped upstream fails and fallbackUpstream is set", func() {
 			BeforeEach(func() {
-				deadUpstream := NewMockUDPUpstreamServer().WithAnswerRR("dead.box. 123 IN A 1.2.3.4")
-				upstream := deadUpstream.Start()
-				deadUpstream.Close()
-
 				sutConfig.FallbackUpstream = true
-				sutConfig.Mapping.Upstreams["dead.box"] = []config.Upstream{upstream}
-				sutConfig.Rewrite = map[string]string{"source.test": "dead.box"}
+				sutConfig.Mapping.Upstreams["broken.box"] = []config.Upstream{NewBrokenUDPUpstreamServer()}
+				sutConfig.Rewrite = map[string]string{"source.test": "broken.box"}
 			})
 
 			It("should ask the next resolver with the original name", func() {
-				var seen string
+				var seen *string
 
-				m = &mockResolver{}
-				m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
-				m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
-					seen = req.Req.Question[0].Name
-					resp, err := util.NewMsgWithAnswer(seen, 250, A, "192.192.192.192")
-					Expect(err).Should(Succeed())
-
-					return &Response{Res: resp, RType: ResponseTypeRESOLVED, Reason: "RESOLVED"}, nil
-				}
+				m, seen = newRecordingResolver(A, "192.192.192.192")
 				sut.Next(m)
 
 				Expect(sut.Resolve(ctx, newRequest("www.source.test.", A))).
 					Should(HaveResponseType(ResponseTypeRESOLVED))
 
-				Expect(seen).Should(Equal("www.source.test."))
+				Expect(*seen).Should(Equal("www.source.test."))
 			})
 		})
 
 		When("the mapped upstream fails and fallbackUpstream is not set", func() {
 			BeforeEach(func() {
-				deadUpstream := NewMockUDPUpstreamServer().WithAnswerRR("dead.box. 123 IN A 1.2.3.4")
-				upstream := deadUpstream.Start()
-				deadUpstream.Close()
-
-				sutConfig.Mapping.Upstreams["dead.box"] = []config.Upstream{upstream}
-				sutConfig.Rewrite = map[string]string{"source.test": "dead.box"}
+				sutConfig.Mapping.Upstreams["broken.box"] = []config.Upstream{NewBrokenUDPUpstreamServer()}
+				sutConfig.Rewrite = map[string]string{"source.test": "broken.box"}
 			})
 
 			It("should return the error", func() {
@@ -369,6 +346,48 @@ var _ = Describe("ConditionalUpstreamResolver", Label("conditionalResolver"), fu
 						))
 
 				Expect(m.Calls).Should(BeEmpty())
+			})
+		})
+
+		When("the rewritten name matches no conditional mapping", func() {
+			BeforeEach(func() {
+				sutConfig.Rewrite = map[string]string{"source.test": "nomatch.example"}
+			})
+
+			It("should ask the next resolver with the original name", func() {
+				var seen *string
+
+				m, seen = newRecordingResolver(A, "192.192.192.192")
+				sut.Next(m)
+
+				Expect(sut.Resolve(ctx, newRequest("www.source.test.", A))).
+					Should(
+						SatisfyAll(
+							BeDNSRecord("www.source.test.", A, "192.192.192.192"),
+							HaveResponseType(ResponseTypeRESOLVED),
+							HaveReturnCode(dns.RcodeSuccess),
+						))
+
+				Expect(*seen).Should(Equal("www.source.test."))
+				Expect(m.Calls).Should(HaveLen(1))
+			})
+		})
+
+		When("the next resolver fails for a rewritten query", func() {
+			BeforeEach(func() {
+				sutConfig.Rewrite = map[string]string{"source.test": "nomatch.example"}
+			})
+
+			It("should restore the original request before returning", func() {
+				m = &mockResolver{}
+				m.On("Resolve", mock.Anything).Return(nil, errors.New("next resolver failed"))
+				sut.Next(m)
+
+				request := newRequest("www.source.test.", A)
+
+				_, err := sut.Resolve(ctx, request)
+				Expect(err).Should(HaveOccurred())
+				Expect(request.Req.Question[0].Name).Should(Equal("www.source.test."))
 			})
 		})
 

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -127,19 +127,23 @@ func (r *CustomDNSResolver) handleReverseDNS(request *model.Request) *model.Resp
 	return nil
 }
 
+// processRequest resolves a query from the configured mapping. It reports
+// whether the mapping handled the query at all; when it did not, the caller
+// continues down the chain itself, so that it can restore a rewritten request
+// first.
 func (r *CustomDNSResolver) processRequest(
 	ctx context.Context,
 	logger *logrus.Entry,
 	request *model.Request,
 	resolvedCnames []string,
-) (*model.Response, error) {
+) (handled bool, response *model.Response, err error) {
 	question := request.Req.Question[0]
 	domain := util.ExtractDomain(question)
 	var answers []dns.RR
 
 	for len(domain) > 0 {
 		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("context cancelled during custom DNS resolution: %w", err)
+			return true, nil, fmt.Errorf("context cancelled during custom DNS resolution: %w", err)
 		}
 
 		entries, found := r.mapping[domain]
@@ -148,7 +152,7 @@ func (r *CustomDNSResolver) processRequest(
 			for _, entry := range entries {
 				result, err := r.processDNSEntry(ctx, logger, request, resolvedCnames, question, entry)
 				if err != nil {
-					return nil, err
+					return true, nil, err
 				}
 
 				answers = append(answers, result...)
@@ -160,7 +164,7 @@ func (r *CustomDNSResolver) processRequest(
 					logFieldDomain: util.Obfuscate(domain),
 				}).Debugf("returning custom dns entry")
 
-				return model.NewResponseWithAnswers(request, answers, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS"), nil
+				return true, model.NewResponseWithAnswers(request, answers, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS"), nil
 			}
 
 			// Mapping exists for this domain, but for another type
@@ -171,11 +175,11 @@ func (r *CustomDNSResolver) processRequest(
 
 			// return NOERROR/NODATA with an SOA record in the authority section (RFC 2308),
 			// so caching resolvers know how long to cache the negative result
-			response := model.NewResponseWithReason(request, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS")
+			nodata := model.NewResponseWithReason(request, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS")
 			soa := util.CreateSOAForNegativeResponse(question, r.cfg.CustomTTL.SecondsU32())
-			response.Res.Ns = []dns.RR{soa}
+			nodata.Res.Ns = []dns.RR{soa}
 
-			return response, nil
+			return true, nodata, nil
 		}
 
 		if i := strings.IndexRune(domain, '.'); i >= 0 {
@@ -185,9 +189,7 @@ func (r *CustomDNSResolver) processRequest(
 		}
 	}
 
-	logger.WithField("next_resolver", Name(r.next)).Trace("go to next resolver")
-
-	return r.next.Resolve(ctx, request)
+	return false, nil, nil
 }
 
 func (r *CustomDNSResolver) processDNSEntry(
@@ -230,16 +232,21 @@ func (r *CustomDNSResolver) Resolve(ctx context.Context, request *model.Request)
 		request.Req = rewritten
 	}
 
-	response, err := r.processRequest(ctx, logger, request, make([]string, 0, len(r.cfg.Mapping)))
+	handled, response, err := r.processRequest(ctx, logger, request, make([]string, 0, len(r.cfg.Mapping)))
 
-	// Revert the request
+	// Revert the request before it leaves this resolver: the rewritten name is
+	// meant for the mapping, not for the rest of the chain.
 	request.Req = original
 
-	// A response we produced ourselves without an answer means the mapping had
-	// nothing for this query: ask the rest of the chain, using the original
-	// name (`fallbackUpstream`).
-	answered := err == nil && response != nil && response.RType == model.ResponseTypeCUSTOMDNS
-	if shouldFallbackUpstream(&r.cfg.RewriterConfig, answered, response, nil) {
+	if !handled {
+		logger.WithField("next_resolver", Name(r.next)).Trace("go to next resolver")
+
+		return r.next.Resolve(ctx, request)
+	}
+
+	// The mapping failed or had nothing for this query: ask the rest of the
+	// chain, using the original name (`fallbackUpstream`).
+	if shouldFallbackUpstream(&r.cfg.RewriterConfig, response, err) {
 		logger.WithField("next_resolver", Name(r.next)).Trace("fallback to next resolver")
 
 		return r.next.Resolve(ctx, request)
@@ -333,9 +340,18 @@ func (r *CustomDNSResolver) processCNAME(
 	targetRequest := newRequestWithClientID(targetWithoutDot, dns.Type(question.Qtype), clientIP, clientID)
 
 	// resolve the target recursively
-	targetResp, err := r.processRequest(ctx, logger, targetRequest, cnames)
+	handled, targetResp, err := r.processRequest(ctx, logger, targetRequest, cnames)
 	if err != nil {
 		return nil, err
+	}
+
+	if !handled {
+		// the target is outside the mapping: resolve it via the rest of the chain
+		logger.WithField("next_resolver", Name(r.next)).Trace("go to next resolver")
+
+		if targetResp, err = r.next.Resolve(ctx, targetRequest); err != nil {
+			return nil, err
+		}
 	}
 
 	// If target resolution returns NoResponse, just return the CNAME record itself

--- a/resolver/custom_dns_resolver_test.go
+++ b/resolver/custom_dns_resolver_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/0xERR0R/blocky/helpertest"
 	"github.com/0xERR0R/blocky/log"
 	. "github.com/0xERR0R/blocky/model"
-	"github.com/0xERR0R/blocky/util"
 	"github.com/miekg/dns"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -598,21 +597,12 @@ var _ = Describe("CustomDNSResolver", func() {
 		When("the mapping has no answer of the requested type and fallbackUpstream is set", func() {
 			BeforeEach(func() {
 				cfg.FallbackUpstream = true
-				sut = NewCustomDNSResolver(cfg)
 			})
 
 			It("should ask the next resolver with the original name", func() {
-				var seen string
+				var seen *string
 
-				m = &mockResolver{}
-				m.On("Resolve", mock.Anything).Return(&Response{Res: new(dns.Msg)}, nil)
-				m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
-					seen = req.Req.Question[0].Name
-					resp, err := util.NewMsgWithAnswer(seen, uint(TTL), AAAA, "2001:db8::1")
-					Expect(err).Should(Succeed())
-
-					return &Response{Res: resp, RType: ResponseTypeRESOLVED, Reason: "RESOLVED"}, nil
-				}
+				m, seen = newRecordingResolver(AAAA, "2001:db8::1")
 				sut.Next(m)
 
 				// custom.domain has an A record only, so the AAAA query ends up
@@ -624,7 +614,75 @@ var _ = Describe("CustomDNSResolver", func() {
 							HaveReturnCode(dns.RcodeSuccess),
 						))
 
-				Expect(seen).Should(Equal("www.source.test."))
+				Expect(*seen).Should(Equal("www.source.test."))
+			})
+		})
+
+		When("the rewritten domain is not in the mapping", func() {
+			BeforeEach(func() {
+				cfg.Rewrite["nomatch.test"] = "nomatch.example"
+			})
+
+			It("should ask the next resolver with the original name", func() {
+				var seen *string
+
+				m, seen = newRecordingResolver(A, "192.192.192.192")
+				sut.Next(m)
+
+				Expect(sut.Resolve(ctx, newRequest("www.nomatch.test.", A))).
+					Should(
+						SatisfyAll(
+							BeDNSRecord("www.nomatch.test.", A, "192.192.192.192"),
+							HaveResponseType(ResponseTypeRESOLVED),
+							HaveReturnCode(dns.RcodeSuccess),
+						))
+
+				Expect(*seen).Should(Equal("www.nomatch.test."))
+				Expect(m.Calls).Should(HaveLen(1))
+			})
+		})
+
+		When("the mapping has no answer of the requested type and filterUnmappedTypes is false", func() {
+			BeforeEach(func() {
+				cfg.FilterUnmappedTypes = false
+			})
+
+			It("should ask the next resolver with the original name", func() {
+				var seen *string
+
+				m, seen = newRecordingResolver(AAAA, "2001:db8::1")
+				sut.Next(m)
+
+				// custom.domain has an A record only, so the AAAA query is unmapped
+				Expect(sut.Resolve(ctx, newRequest("www.source.test.", AAAA))).
+					Should(
+						SatisfyAll(
+							HaveResponseType(ResponseTypeRESOLVED),
+							HaveReturnCode(dns.RcodeSuccess),
+						))
+
+				Expect(*seen).Should(Equal("www.source.test."))
+				Expect(m.Calls).Should(HaveLen(1))
+			})
+		})
+
+		When("the mapping itself fails and fallbackUpstream is set", func() {
+			BeforeEach(func() {
+				cfg.FallbackUpstream = true
+				cfg.Rewrite["loop.test"] = "cname.recursive"
+			})
+
+			It("should ask the next resolver with the original name", func() {
+				var seen *string
+
+				m, seen = newRecordingResolver(A, "192.192.192.192")
+				sut.Next(m)
+
+				// the rewrite target is a self-referential CNAME: processRequest errors
+				Expect(sut.Resolve(ctx, newRequest("www.loop.test.", A))).
+					Should(HaveResponseType(ResponseTypeRESOLVED))
+
+				Expect(*seen).Should(Equal("www.loop.test."))
 			})
 		})
 

--- a/resolver/mocks_test.go
+++ b/resolver/mocks_test.go
@@ -245,3 +245,35 @@ func (c *mockConn) SetReadDeadline(time.Time) error {
 func (c *mockConn) SetWriteDeadline(time.Time) error {
 	panic("not implemented")
 }
+
+// newRecordingResolver returns a resolver that answers every query with the given
+// record, and a pointer to the question name it was last asked for. Use it to
+// assert which name a resolver hands down the chain.
+func newRecordingResolver(qType dns.Type, address string) (*mockResolver, *string) {
+	var seen string
+
+	m := &mockResolver{}
+	m.On("Resolve", mock.Anything).Return(&model.Response{Res: new(dns.Msg)}, nil)
+	m.ResolveFn = func(_ context.Context, req *model.Request) (*model.Response, error) {
+		seen = req.Req.Question[0].Name
+
+		resp, err := util.NewMsgWithAnswer(seen, 250, qType, address)
+		if err != nil {
+			return nil, err
+		}
+
+		return &model.Response{Res: resp, RType: model.ResponseTypeRESOLVED, Reason: "RESOLVED"}, nil
+	}
+
+	return m, &seen
+}
+
+// NewBrokenUDPUpstreamServer returns a started upstream that answers every query with
+// data the client cannot parse, so resolving via it always fails. Unlike starting a
+// server and closing it, the port stays bound, so the OS cannot hand it to someone else
+// and turn the "broken" upstream into a working one.
+func NewBrokenUDPUpstreamServer() config.Upstream {
+	return NewMockUDPUpstreamServer().
+		WithAnswerFn(func(*dns.Msg) *dns.Msg { return nil }).
+		Start()
+}

--- a/resolver/rebinding_resolver_test.go
+++ b/resolver/rebinding_resolver_test.go
@@ -547,4 +547,65 @@ var _ = Describe("RebindingProtectionResolver", func() {
 			})
 		})
 	})
+
+	When("chained below a rewriting customDNS resolver", func() {
+		// customDNS sits above this resolver and hands the *original* name down the
+		// chain: a `customDNS.rewrite` target is used only for its own mapping lookup
+		// and never leaves the resolver. The allowlist therefore matches the name the
+		// client asked for, not the rewrite target.
+		var chained ChainedResolver
+
+		JustBeforeEach(func() {
+			customDNS := NewCustomDNSResolver(config.CustomDNS{
+				RewriterConfig: config.RewriterConfig{
+					Rewrite: map[string]string{"source.test": "target.test"},
+				},
+				// the rewritten name is not in the mapping, so the query continues
+				// down the chain and reaches the rebinding protection
+				Mapping: config.CustomDNSMapping{"unrelated.lan": nil},
+			})
+
+			m = &mockResolver{}
+			m.On("Resolve", mock.Anything).Return(nil, nil)
+			m.ResolveFn = func(_ context.Context, req *Request) (*Response, error) {
+				res, err := util.NewMsgWithAnswer(req.Req.Question[0].Name, 300, A, "192.168.1.5")
+				Expect(err).Should(Succeed())
+
+				return &Response{Res: res, RType: ResponseTypeRESOLVED, Reason: "RESOLVED"}, nil
+			}
+
+			chained = Chain(customDNS, sut, m)
+		})
+
+		When("the name the client asked for is allowlisted", func() {
+			BeforeEach(func() {
+				sutConfig = config.RebindingProtection{
+					Enable:         true,
+					AllowedDomains: []string{"source.test"},
+				}
+			})
+
+			It("passes the private answer through", func() {
+				Expect(chained.Resolve(ctx, newRequest("www.source.test.", A))).
+					Should(SatisfyAll(
+						BeDNSRecord("www.source.test.", A, "192.168.1.5"),
+						HaveResponseType(ResponseTypeRESOLVED),
+					))
+			})
+		})
+
+		When("only the rewrite target is allowlisted", func() {
+			BeforeEach(func() {
+				sutConfig = config.RebindingProtection{
+					Enable:         true,
+					AllowedDomains: []string{"target.test"},
+				}
+			})
+
+			It("filters the answer", func() {
+				Expect(chained.Resolve(ctx, newRequest("www.source.test.", A))).
+					Should(HaveResponseType(ResponseTypeREBIND))
+			})
+		})
+	})
 })

--- a/resolver/rewrite_helper.go
+++ b/resolver/rewrite_helper.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"context"
+	"errors"
 	"strings"
 
 	"github.com/0xERR0R/blocky/config"
@@ -66,19 +68,20 @@ func rewriteDomain(domain string, rewriteMap map[string]string) (string, string)
 	return domain, ""
 }
 
-// shouldFallbackUpstream reports whether a rewritten query that ended without an
-// answer should be retried, with its original name, on the rest of the chain.
-// See `fallbackUpstream` in the documentation.
+// shouldFallbackUpstream reports whether a query the resolver answered itself,
+// with an error or without an answer, should be retried with its original name
+// on the rest of the chain. See `fallbackUpstream` in the documentation.
 //
-// answered tells whether the resolver produced the response itself: a response
-// it only passed through from the next resolver must not be retried there.
-func shouldFallbackUpstream(cfg *config.RewriterConfig, answered bool, response *model.Response, err error) bool {
-	if !cfg.FallbackUpstream || len(cfg.Rewrite) == 0 || !answered {
+// Callers must delegate queries they did not answer themselves before reaching
+// this: a response passed through from the next resolver must not go there again.
+func shouldFallbackUpstream(cfg *config.RewriterConfig, response *model.Response, err error) bool {
+	if !cfg.FallbackUpstream || len(cfg.Rewrite) == 0 {
 		return false
 	}
 
 	if err != nil {
-		return true
+		// a dead context fails on the next resolver too, and its error is the useful one
+		return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 	}
 
 	return response != nil && response != NoResponse && response.Res != nil && len(response.Res.Answer) == 0


### PR DESCRIPTION
Follow-up to #2223, which restored one half of what #1884 dropped. This restores the other half.

#1884 removed `RewriterResolver` and moved rewriting into `CustomDNSResolver` and `ConditionalUpstreamResolver`. The old rewriter wired its inner resolver to a `NoOpResolver` and continued the chain itself, **after** putting the original request back:

```go
// Revert the request: must be done before calling r.next
request.Req = original
```

Both new resolvers instead continue the chain from inside their own resolution, while `request.Req` still holds the rewritten message. So the rewrite target is what leaves the resolver:

```yaml
customDNS:
  rewrite:
    example.com: printer.lan
  mapping:
    printer.lan: 192.168.178.3
```

`blog.example.com` is rewritten to `blog.printer.lan`, misses the mapping, and `blog.printer.lan` is what goes upstream — an internal name handed to a public resolver, and an NXDOMAIN for a name the upstream could have answered. The documentation promises the opposite:

> If not found and if `fallbackUpstream` was set to `true`, the original query "blog.example.com" will be sent upstream.

## What changed

Both resolvers revert the request before **any** exit, and delegate to the next resolver themselves instead of from inside `processRequest`.

For `ConditionalUpstreamResolver` that is a move of `request.Req = original` above the delegation. For `CustomDNSResolver`, `processRequest` now reports whether the mapping handled the query at all — the same shape the conditional resolver's `processRequest` already had — rather than continuing the chain on its own. `processCNAME` keeps resolving out-of-mapping CNAME targets (#1867) by delegating explicitly.

Three things fall out of that:

- **`fallbackUpstream` now works with `filterUnmappedTypes: false`.** Previously the fallback could only fire for the empty `CUSTOM DNS` response that `filterUnmappedTypes: true` produces; with it off, the unmapped-type case `break`s to the next resolver and never reached the check at all.
- **`ConditionalUpstreamResolver` no longer leaks the rewritten request on error.** When the next resolver failed it returned before the revert, leaving the caller's `model.Request` pointing at the rewritten message — so query logging, metrics and `server.go`'s SERVFAIL reply all reported the internal name instead of what the client asked for.
- **`shouldFallbackUpstream` loses its `answered` parameter.** Callers now hand it only queries they answered themselves, so it no longer has to be told. That also means an error from `CustomDNSResolver` is always its own, so the error case is honoured for it too — a CNAME loop or an unsupported RR type in the mapping now falls back instead of returning SERVFAIL. A cancelled context is excluded: it would only fail again on the next resolver, and its own error is the useful one.

## Tests

Five specs, each failing on `main` before the change:

| spec | on `main` |
|---|---|
| conditional: rewritten name matches no mapping | next resolver saw `www.nomatch.example.` |
| conditional: next resolver fails | `request.Req` left at `www.nomatch.example.` |
| customDNS: rewritten domain not in mapping | next resolver saw `www.nomatch.example.` |
| customDNS: unmapped type, `filterUnmappedTypes: false` | next resolver saw `www.custom.domain.` |
| customDNS: mapping errors, `fallbackUpstream: true` | `CNAME loop detected` surfaced instead of falling back |

Two of them also assert the next resolver is called **exactly once**, pinning the invariant that a query which never hit the mapping is not resolved twice.

The existing `cname.example` → `example.com` specs cover the delegation `processCNAME` now does itself.

### Test cleanup

Also in here, since it is the same specs:

- The two `fallbackUpstream` error specs from #2223 built their dead upstream with `Start()` then `Close()`, which hands the ephemeral port back to the OS while the config still points at it. Under `ginkgo -p`, or if anything else claims that port, the "dead" upstream comes back to life and the spec asserts the wrong branch. Replaced with `NewBrokenUDPUpstreamServer()`, which keeps the port bound and answers with data the client cannot parse — `MockUDPUpstreamServer` already had that mode.
- The identical nine-line mock wiring repeated across four specs is now `newRecordingResolver`.
- Dropped a dead `sut = NewCustomDNSResolver(cfg)` in a `BeforeEach` — the outer `JustBeforeEach` rebuilds `sut` and re-wires `Next` afterwards, so it was discarded immediately.

## Verification

`go test ./...` green over 20 packages (e2e excluded locally), `-race` green, `gofmt` clean, `golangci-lint v2.12.2` — the version pinned in the Makefile — reports 0 issues.

## Not in scope

A CNAME whose target has no record of the queried type still yields a CNAME-only answer, so `len(Answer) == 0` is false and `fallbackUpstream` does not fire. That predates #1884 — the old rewriter tested `Answer == nil` and behaved identically — so it is a limitation of the feature rather than part of this regression.

https://claude.ai/code/session_01NueDwL4oyg972RkyQezMJL