### PR TITLE
perf(resolver): avoid per-query label map allocations in metrics resolver

### DIFF
--- a/docs/prometheus_grafana.md
+++ b/docs/prometheus_grafana.md
@@ -17,7 +17,7 @@ Following metrics will be exported:
 | blocky_query_total                               | Counter of total queries, partitioned by client and DNS request type (A, AAAA, PTR, etc) |
 | blocky_request_duration_seconds                  | Histogram of request duration, partitioned by response type (Blocked, cached, etc)  |
 | blocky_response_total                            | Counter of responses, partitioned by response type (Blocked, cached, etc), DNS response code, and reason |
-| blocky_client_response_total                     | Counter of responses, partitioned by client and response type (Blocked, cached, etc) |
+| blocky_client_response_total                     | Counter of query outcomes, partitioned by client and response type (Blocked, cached, etc); failed requests are counted as `response_type="err"` |
 | blocky_blocking_enabled                          | Boolean 1 if blocking is enabled, 0 otherwise |
 | blocky_cache_entries                             | Gauge of entries in cache |
 | blocky_cache_hits_total                          | Counter of the number of cache hits |
@@ -40,7 +40,7 @@ Following metrics will be exported:
 
     To keep the `reason` label of `blocky_response_total` bounded, blocked responses use the matched
     group names only (e.g. `BLOCKED (ads)`), **not** the matched rule. The full reason including the
-    matched rule (e.g. `BLOCKED (ads: *.docler.com)`) is still available in the [query log](configuration.md#query-log).
+    matched rule (e.g. `BLOCKED (ads: *.docler.com)`) is still available in the [query log](configuration.md#query-logging).
     This avoids unbounded metric cardinality when large deny lists are used.
 
 !!! note "`client` label cardinality"
@@ -51,6 +51,38 @@ Following metrics will be exported:
     home LAN) this stays small, but on networks with high device turnover (e.g. public or guest Wi-Fi)
     the set of `client` label values can grow effectively unbounded over time. Consider this before
     scraping/retaining these metrics on such networks.
+
+    Blocky has no option to drop the label yet, so the mitigation is on the Prometheus side: drop the
+    affected metrics at scrape time when you do not need the per-client breakdown.
+
+    ```yaml
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: "blocky_(query|client_response)_total"
+        action: drop
+    ```
+
+    Dropping only the `client` label (`labeldrop`) does **not** work: the remaining series of the
+    different clients collapse into one, and Prometheus rejects the scrape with a duplicate-sample
+    error.
+
+!!! note "`response_type` values of `blocky_client_response_total`"
+
+    The counter is incremented once per query that reaches the metrics resolver, so it sums to
+    `blocky_query_total` rather than to `blocky_response_total` — the latter counts only successful
+    responses. Requests that produced no response at all are recorded as `response_type="err"`, which
+    is not one of the regular response types.
+
+    `FILTERED` and `NOTFQDN` never appear: the `filtering` and `fqdnOnly` resolvers answer those
+    queries above the metrics resolver in the chain, so they are missing from `blocky_query_total`,
+    `blocky_response_total` and `blocky_request_duration_seconds` as well. The query log sits below
+    them in the chain too, so those queries are only visible in the [statistics](configuration.md#statistics).
+
+    Example — per-client rate of queries that were actually resolved rather than blocked:
+
+    ```promql
+    sum by (client) (rate(blocky_client_response_total{response_type!~"BLOCKED|REBIND|err"}[5m]))
+    ```
 
 ### Grafana dashboard
 

--- a/e2e/metrics_test.go
+++ b/e2e/metrics_test.go
@@ -245,6 +245,9 @@ var _ = Describe("Metrics functional tests", func() {
 				g.Expect(metrics).Should(SatisfyAll(
 					ContainElement(MatchRegexp(`blocky_query_total\{[^}]*type="A"[^}]*\} \d+`)),
 					ContainElement(MatchRegexp(`blocky_response_total\{[^}]*\} \d+`)),
+					// blocked.com is on the ads denylist, so the per-client counter must show it
+					ContainElement(MatchRegexp(`blocky_client_response_total\{client="[^"]+",response_type="BLOCKED"\} \d+`)),
+					ContainElement(MatchRegexp(`blocky_client_response_total\{client="[^"]+",response_type="RESOLVED"\} \d+`)),
 					ContainElement(MatchRegexp(`blocky_request_duration_seconds_bucket\{[^}]*\}`)),
 					ContainElement(MatchRegexp(`blocky_request_duration_seconds_sum\{[^}]*\} [\d.]+`)),
 					ContainElement(MatchRegexp(`blocky_request_duration_seconds_count\{[^}]*\} \d+`)),

--- a/resolver/metrics_resolver.go
+++ b/resolver/metrics_resolver.go
@@ -23,6 +23,11 @@ const (
 	labelReason       = "reason"
 	labelResponseCode = "response_code"
 	labelResponseType = "response_type"
+
+	// responseTypeErr is the synthetic response_type used when the chain returned no
+	// response at all. It is not part of the model.ResponseType enum, so metrics using
+	// the response_type label can carry it in addition to the enum values.
+	responseTypeErr = "err"
 )
 
 // MetricsResolver resolver that records metrics about requests/response
@@ -48,13 +53,13 @@ func (r *MetricsResolver) Resolve(ctx context.Context, request *model.Request) (
 
 	clientLabel := strings.Join(request.ClientNames, ",")
 
-	r.totalQueries.With(prometheus.Labels{
-		labelClient: clientLabel,
-		labelType:   dns.TypeToString[request.Req.Question[0].Qtype],
-	}).Inc()
+	// WithLabelValues is used instead of With(prometheus.Labels{...}) throughout: the map
+	// literal costs an allocation per query on the hot path. The value order must match the
+	// label order of the corresponding metric constructor below.
+	r.totalQueries.WithLabelValues(clientLabel, dns.TypeToString[request.Req.Question[0].Qtype]).Inc()
 
 	reqDuration := time.Since(request.RequestTS)
-	responseType := "err"
+	responseType := responseTypeErr
 
 	if response != nil {
 		responseType = response.RType.String()
@@ -62,10 +67,7 @@ func (r *MetricsResolver) Resolve(ctx context.Context, request *model.Request) (
 
 	r.durationHistogram.WithLabelValues(responseType).Observe(reqDuration.Seconds())
 
-	r.totalClientResponse.With(prometheus.Labels{
-		labelClient:       clientLabel,
-		labelResponseType: responseType,
-	}).Inc()
+	r.totalClientResponse.WithLabelValues(clientLabel, responseType).Inc()
 
 	if err != nil {
 		r.totalErrors.Inc()
@@ -79,11 +81,11 @@ func (r *MetricsResolver) Resolve(ctx context.Context, request *model.Request) (
 			reasonLabel = response.Reason
 		}
 
-		r.totalResponse.With(prometheus.Labels{
-			labelReason:       reasonLabel,
-			labelResponseCode: dns.RcodeToString[response.Res.Rcode],
-			labelResponseType: response.RType.String(),
-		}).Inc()
+		r.totalResponse.WithLabelValues(
+			reasonLabel,
+			dns.RcodeToString[response.Res.Rcode],
+			response.RType.String(),
+		).Inc()
 	}
 
 	return response, err
@@ -158,7 +160,8 @@ func totalClientResponseMetric() *prometheus.CounterVec {
 	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "blocky_client_response_total",
-			Help: "Number of total responses per client and response type",
+			Help: "Number of total responses per client and response type, " +
+				"including failed requests as response_type=\"err\"",
 		}, []string{labelClient, labelResponseType},
 	)
 }

--- a/resolver/metrics_resolver_test.go
+++ b/resolver/metrics_resolver_test.go
@@ -108,6 +108,17 @@ var _ = Describe("MetricResolver", func() {
 					Expect(err).Should(Succeed())
 					Expect(testutil.ToFloat64(cnt)).Should(BeNumerically("==", 1))
 				})
+				It("records the blocked response per client, without the unbounded reason", func() {
+					_, err := sut.Resolve(ctx, newRequestWithClient("example.com.", A, "", "client"))
+					Expect(err).Should(Succeed())
+
+					clientCnt, err := sut.totalClientResponse.GetMetricWith(prometheus.Labels{
+						labelClient:       "client",
+						labelResponseType: ResponseTypeBLOCKED.String(),
+					})
+					Expect(err).Should(Succeed())
+					Expect(testutil.ToFloat64(clientCnt)).Should(BeNumerically("==", 1))
+				})
 			})
 			When("Response has no ReasonLabel", func() {
 				BeforeEach(func() {
@@ -132,6 +143,19 @@ var _ = Describe("MetricResolver", func() {
 					Expect(testutil.ToFloat64(cnt)).Should(BeNumerically("==", 1))
 				})
 			})
+			When("A client resolves to several names", func() {
+				It("joins them into a single client label, as blocky_query_total does", func() {
+					_, err := sut.Resolve(ctx, newRequestWithClient("example.com.", A, "", "name1", "name2"))
+					Expect(err).Should(Succeed())
+
+					clientCnt, err := sut.totalClientResponse.GetMetricWith(prometheus.Labels{
+						labelClient:       "name1,name2",
+						labelResponseType: ResponseTypeRESOLVED.String(),
+					})
+					Expect(err).Should(Succeed())
+					Expect(testutil.ToFloat64(clientCnt)).Should(BeNumerically("==", 1))
+				})
+			})
 			When("Error occurs while request processing", func() {
 				BeforeEach(func() {
 					m = &mockResolver{}
@@ -151,6 +175,20 @@ var _ = Describe("MetricResolver", func() {
 					})
 					Expect(err).Should(Succeed())
 					Expect(testutil.ToFloat64(clientCnt)).Should(BeNumerically("==", 1))
+				})
+			})
+			When("Metrics are disabled", func() {
+				BeforeEach(func() {
+					sut = NewMetricsResolver(config.Metrics{Enable: false})
+					sut.Next(m)
+				})
+				It("records nothing", func() {
+					_, err := sut.Resolve(ctx, newRequestWithClient("example.com.", A, "", "client"))
+					Expect(err).Should(Succeed())
+
+					Expect(testutil.CollectAndCount(sut.totalClientResponse)).Should(BeZero())
+					Expect(testutil.CollectAndCount(sut.totalQueries)).Should(BeZero())
+					Expect(testutil.CollectAndCount(sut.totalResponse)).Should(BeZero())
 				})
 			})
 		})


### PR DESCRIPTION
Follow-up to the review of #2222, implementing the points raised there.

> [!IMPORTANT]
> **Stacked on #2222**, which is not merged yet, so the diff against `main` currently
> also contains that PR's two commits. Only `05cd2a8` and `b229157` belong to this PR.
> Rebase onto `main` once #2222 lands.

## 1. `WithLabelValues` instead of `With(prometheus.Labels{…})`

Every counter in `MetricsResolver.Resolve` built a label map, on the path taken by every
DNS query. `#2222` added a third one. `WithLabelValues` passes the values positionally and
allocates nothing.

Benchmarked over `MetricsResolver.Resolve` (RESOLVED response, one client name):

| | before | after |
|---|---|---|
| GOGC default | 4593 ns/op, 1008 B/op, 6 allocs/op | **489 ns/op, 0 B/op, 0 allocs/op** |
| GOGC=off | 1245 ns/op, 1008 B/op, 6 allocs/op | **480 ns/op, 0 B/op, 0 allocs/op** |

The direct cost of the map literals is ~765 ns/query; the rest of the gap is GC pressure
from ~1 KB of garbage per query. Real-world gain sits between the two numbers, depending
on the overall allocation load. The benchmark was not committed — it needs a stub resolver
that does not belong in the package.

## 2. Document what `response_type` actually contains

`blocky_client_response_total` was justified by `response_type` being the bounded 12-value
enum. The exposed set differs from it in both directions:

- **`err` is a 13th value.** `responseType` starts as `"err"` and is only overwritten when
  the chain returned a response, so failures land in the counter. An alert written as
  `response_type!~"BLOCKED"` — the shape proposed in #2198 — silently counts failures as
  successfully resolved traffic. Now named as a constant, stated in the metric's `Help`
  text and in the docs.
- **`FILTERED` and `NOTFQDN` can never appear.** `FilteringResolver` and `FQDNOnlyResolver`
  answer those queries themselves and sit *above* `MetricsResolver` in the chain, so the
  `FILTERED` clause in the proposed alert is dead. They are missing from `blocky_query_total`,
  `blocky_response_total` and `blocky_request_duration_seconds` too — pre-existing, but worth
  writing down. See the note at the end.

Also documented: the counter increments once per query, so it sums to `blocky_query_total`,
**not** to the similarly named `blocky_response_total`, which skips the error path.

## 3. Give the cardinality note a lever

#2222 correctly warns that `client` is unbounded, but `config.Metrics` only has `enable`
and `path`, so the note left readers with nothing to do. It now shows the Prometheus-side
mitigation — and warns that the obvious one is wrong: dropping only the `client` label
collapses the per-client series into one and makes Prometheus reject the scrape with a
duplicate-sample error. Dropping the two metrics is the working option.

## 4. Tests

- `blocky_client_response_total` for a **BLOCKED** response — the metric's whole purpose,
  previously untested.
- multi-name clients joining into `name1,name2`, covering the `clientLabel` value now
  shared between two counters.
- metrics disabled: nothing is recorded.
- e2e: asserts the counter reaches `/metrics` with a real client label and both
  `response_type="BLOCKED"` and `response_type="RESOLVED"`. This is what pins the positional
  `WithLabelValues` order end-to-end.

Each new spec was mutation-checked (break the expectation → spec fails), so none pass vacuously.

## Not included

- **Grafana dashboard.** `blocky-grafana.json` has a `topk(10, sum by (client) (…blocky_query_total…))`
  panel; a "top blocked clients" companion would fit, but that is a dashboard change with its
  own review surface.
- **A config toggle for the `client` label.** You mentioned planning this in #2198 — it is the
  real fix for the cardinality note and deserves its own PR.
- **Moving `MetricsResolver` above `filtering`/`fqdnOnly`** so `FILTERED`/`NOTFQDN` become
  visible. Documented here rather than changed, since it shifts existing metric semantics.
  Happy to open an issue for it.

## Verification

- `go build ./...`
- `go test -race ./resolver/... ./metrics/...` — pass
- `go test ./resolver/... ./metrics/... ./server/... ./stats/...` — pass
- `make lint` (golangci-lint v2.12.2) — 0 issues
- e2e metrics spec against a locally built `blocky-e2e` image — pass