### PR TITLE
feat(resolver): add refused block type

### DIFF
--- a/config/blocking.go
+++ b/config/blocking.go
@@ -23,7 +23,8 @@ type Blocking struct {
 	ListSchedules map[string][]string `yaml:"listSchedules"`
 	// Maps client identifiers (name, IP, CIDR) to the list groups that apply to them.
 	ClientGroupsBlock map[string][]string `yaml:"clientGroupsBlock"`
-	// Response for blocked A/AAAA queries: zeroIP (0.0.0.0/::), nxDomain, or custom IPs; other types get NXDOMAIN.
+	// Response for blocked queries: zeroIP (0.0.0.0/:: for A/AAAA, NXDOMAIN for other types),
+	// nxDomain, refused (REFUSED for every query type), or custom IPs.
 	BlockType string `default:"ZEROIP" yaml:"blockType"`
 	// TTL of blocked responses; how long clients cache the block before querying the domain again.
 	BlockTTL Duration `default:"6h" yaml:"blockTTL"`

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -293,7 +293,7 @@
         },
         "blockType": {
           "type": "string",
-          "description": "Response for blocked A/AAAA queries: zeroIP (0.0.0.0/::), nxDomain, or custom IPs; other types get NXDOMAIN.",
+          "description": "Response for blocked queries: zeroIP (0.0.0.0/:: for A/AAAA, NXDOMAIN for other types),\nnxDomain, refused (REFUSED for every query type), or custom IPs.",
           "default": "ZEROIP"
         },
         "blockTTL": {

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -137,6 +137,8 @@ blocking:
   # which response will be sent, if query is blocked:
   # zeroIp: 0.0.0.0 will be returned (default)
   # nxDomain: return NXDOMAIN as return code
+  # refused: return REFUSED as return code, for every query type. Note that stub resolvers commonly treat REFUSED
+  #   as a server failure and fall back to another configured DNS server, which bypasses blocking.
   # comma separated list of destination IP addresses (for example: 192.100.100.15, 2001:0db8:85a3:08d3:1319:8a2e:0370:7344). Should contain ipv4 and ipv6 to cover all query types. Useful with running web server on this address to display the "blocked" page.
   blockType: zeroIp
   # optional: TTL for answers to blocked domains

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -925,6 +925,7 @@ queries, NXDOMAIN for other types):
 | ---------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | zeroIP     | zeroIP                                                  | This is the default block type. Server returns 0.0.0.0 (or :: for IPv6) as result for A and AAAA queries                                                                               |
 | nxDomain   | nxDomain                                                | return NXDOMAIN as return code                                                                                                                                                         |
+| refused    | refused                                                 | return REFUSED as return code, without any records                                                                                                                                    |
 | custom IPs | 192.100.100.15, 2001:0db8:85a3:08d3:1319:8a2e:0370:7344 | comma separated list of destination IP addresses. Should contain ipv4 and ipv6 to cover all query types. Useful with running web server on this address to display the "blocked" page. |
 
 !!! example
@@ -946,6 +947,8 @@ time it could take for a client to be able to see the real IP address for a doma
 Blocky includes an SOA record in NXDOMAIN responses to enable proper negative caching by stub resolvers.
 The blockTTL value is used for both the SOA's TTL and its MINIMUM field, ensuring clients cache the
 NXDOMAIN response for the configured duration.
+
+**For `refused` mode:** The response carries no records, so blockTTL has no effect.
 
 !!! example
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -918,14 +918,15 @@ Time behavior:
 
 ### Block type
 
-You can configure, which response should be sent to the client, if a requested query is blocked (only for A and AAAA
-queries, NXDOMAIN for other types):
+You can configure, which response should be sent to the client, if a requested query is blocked. The `zeroIP` and
+custom IP modes answer only A and AAAA queries and return NXDOMAIN for other types, while `nxDomain` and `refused`
+apply to every query type:
 
 | blockType  | Example                                                 | Description                                                                                                                                                                            |
 | ---------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | zeroIP     | zeroIP                                                  | This is the default block type. Server returns 0.0.0.0 (or :: for IPv6) as result for A and AAAA queries                                                                               |
 | nxDomain   | nxDomain                                                | return NXDOMAIN as return code                                                                                                                                                         |
-| refused    | refused                                                 | return REFUSED as return code, without any records                                                                                                                                    |
+| refused    | refused                                                 | return REFUSED as return code for every query type, with no answer or authority records. **Caveat:** stub resolvers and forwarders commonly treat REFUSED as a server failure and fall back to another configured DNS server, which bypasses blocking. |
 | custom IPs | 192.100.100.15, 2001:0db8:85a3:08d3:1319:8a2e:0370:7344 | comma separated list of destination IP addresses. Should contain ipv4 and ipv6 to cover all query types. Useful with running web server on this address to display the "blocked" page. |
 
 !!! example
@@ -938,8 +939,9 @@ queries, NXDOMAIN for other types):
 ### Block TTL
 
 TTL for answers to blocked domains can be set to customize the time (in **duration format**) clients ask for those
-domains again. Default Block TTL is **6 hours**. This setting applies to all blocking modes and will affect how much
-time it could take for a client to be able to see the real IP address for a domain after receiving the blocked response.
+domains again. Default Block TTL is **6 hours**. It applies to every blocking mode that returns records (`zeroIP`,
+`nxDomain` and custom IPs) and will affect how much time it could take for a client to be able to see the real IP
+address for a domain after receiving the blocked response.
 
 **For `zeroIP` and custom IP modes:** The TTL is applied to the returned A/AAAA records in the answer section.
 
@@ -948,7 +950,8 @@ Blocky includes an SOA record in NXDOMAIN responses to enable proper negative ca
 The blockTTL value is used for both the SOA's TTL and its MINIMUM field, ensuring clients cache the
 NXDOMAIN response for the configured duration.
 
-**For `refused` mode:** The response carries no records, so blockTTL has no effect.
+**For `refused` mode:** The response carries no answer or authority records, so blockTTL has no effect. An OPT
+record may still be present in the additional section for EDNS0 queries.
 
 !!! example
 

--- a/e2e/blocking_test.go
+++ b/e2e/blocking_test.go
@@ -441,6 +441,57 @@ var _ = Describe("Domain blocking functionality", func() {
 			})
 		})
 
+		Context("with blockType: refused", func() {
+			BeforeEach(func(ctx context.Context) {
+				_, err = createHTTPServerContainer(ctx, "httpserver", e2eNet, "list.txt", "blocked.com")
+				Expect(err).Should(Succeed())
+
+				blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(`
+					log:
+					  level: warn
+					upstreams:
+					  groups:
+					    default:
+					      - moka
+					blocking:
+					  blockType: refused
+					  denylists:
+					    ads:
+					      - http://httpserver:8080/list.txt
+					  clientGroupsBlock:
+					    default:
+					      - ads
+					`))
+				Expect(err).Should(Succeed())
+			})
+
+			It("returns REFUSED without records for blocked domains", func(ctx context.Context) {
+				msg := util.NewMsgWithQuestion("blocked.com.", A)
+				resp, err := doDNSRequest(ctx, blocky, msg)
+				Expect(err).Should(Succeed())
+
+				By("returning REFUSED response code", func() {
+					Expect(resp.Rcode).Should(Equal(dns.RcodeRefused))
+				})
+
+				By("having no answer section", func() {
+					Expect(resp.Answer).Should(BeEmpty())
+				})
+
+				By("having no authority section", func() {
+					Expect(resp.Ns).Should(BeEmpty())
+				})
+			})
+
+			It("returns REFUSED for query types other than A/AAAA", func(ctx context.Context) {
+				msg := util.NewMsgWithQuestion("blocked.com.", TXT)
+				resp, err := doDNSRequest(ctx, blocky, msg)
+				Expect(err).Should(Succeed())
+				Expect(resp.Rcode).Should(Equal(dns.RcodeRefused))
+				Expect(resp.Answer).Should(BeEmpty())
+			})
+		})
+
 		Context("with blockType: custom IPs", func() {
 			BeforeEach(func(ctx context.Context) {
 				_, err = createHTTPServerContainer(ctx, "httpserver", e2eNet, "list.txt", "blocked.com")

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -45,6 +45,8 @@ func createBlockHandler(cfg config.Blocking) (blockHandler, error) {
 		return zeroIPBlockHandler{
 			BlockTimeSec: blockTime,
 		}, nil
+	case "refused":
+		return refusedBlockHandler{}, nil
 	default:
 		// Try parsing as IP address(es)
 		var ips []net.IP
@@ -65,9 +67,10 @@ func createBlockHandler(cfg config.Blocking) (blockHandler, error) {
 			}, nil
 		}
 
-		return nil,
-			fmt.Errorf("unknown blockType '%s', please use one of: ZeroIP, NxDomain or specify destination IP address(es)",
-				cfgBlockType)
+		return nil, fmt.Errorf(
+			"unknown blockType '%s', please use one of: ZeroIP, NxDomain, Refused "+
+				"or specify destination IP address(es)",
+			cfgBlockType)
 	}
 }
 
@@ -756,6 +759,8 @@ type nxDomainBlockHandler struct {
 	BlockTimeSec uint32
 }
 
+type refusedBlockHandler struct{}
+
 type ipBlockHandler struct {
 	destinations    []net.IP
 	fallbackHandler blockHandler
@@ -787,6 +792,10 @@ func (b nxDomainBlockHandler) handleBlock(question dns.Question, response *dns.M
 	// Add SOA to authority section per RFC 2308
 	soa := util.CreateSOAForNegativeResponse(question, b.BlockTimeSec)
 	response.Ns = []dns.RR{soa}
+}
+
+func (b refusedBlockHandler) handleBlock(_ dns.Question, response *dns.Msg) {
+	response.Rcode = dns.RcodeRefused
 }
 
 func (b ipBlockHandler) handleBlock(question dns.Question, response *dns.Msg) {

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -525,11 +525,32 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 					Should(
 						SatisfyAll(
 							HaveNoAnswer(),
+							WithTransform(ToAuthority, BeEmpty()),
 							HaveResponseType(ResponseTypeBLOCKED),
 							HaveReturnCode(dns.RcodeRefused),
 							HaveReason("BLOCKED (defaultGroup: blocked3.com)"),
 						))
 			})
+
+			// Unlike zeroIP and custom IPs, which fall back to NXDOMAIN for anything
+			// but A/AAAA, refused answers every query type the same way.
+			DescribeTable("should return REFUSED for every query type",
+				func(qType dns.Type) {
+					Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", qType, "1.2.1.2", "unknown"))).
+						Should(
+							SatisfyAll(
+								HaveNoAnswer(),
+								WithTransform(ToAuthority, BeEmpty()),
+								HaveResponseType(ResponseTypeBLOCKED),
+								HaveReturnCode(dns.RcodeRefused),
+								HaveReason("BLOCKED (defaultGroup: blocked3.com)"),
+							))
+				},
+				Entry("AAAA", AAAA),
+				Entry("TXT", TXT),
+				Entry("MX", MX),
+				Entry("HTTPS", HTTPS),
+			)
 		})
 
 		When("BlockType is NXDOMAIN with custom BlockTTL", func() {

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -506,6 +506,32 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			})
 		})
 
+		When("BlockType is Refused", func() {
+			BeforeEach(func() {
+				sutConfig = config.Blocking{
+					BlockTTL: config.Duration(time.Minute),
+					Denylists: map[string][]config.BytesSource{
+						"defaultGroup": config.NewBytesSources(defaultGroupFile.Path),
+					},
+					ClientGroupsBlock: map[string][]string{
+						"default": {"defaultGroup"},
+					},
+					BlockType: "Refused",
+				}
+			})
+
+			It("should return REFUSED without any records if query is blocked", func() {
+				Expect(sut.Resolve(ctx, newRequestWithClient("blocked3.com.", A, "1.2.1.2", "unknown"))).
+					Should(
+						SatisfyAll(
+							HaveNoAnswer(),
+							HaveResponseType(ResponseTypeBLOCKED),
+							HaveReturnCode(dns.RcodeRefused),
+							HaveReason("BLOCKED (defaultGroup: blocked3.com)"),
+						))
+			})
+		})
+
 		When("BlockType is NXDOMAIN with custom BlockTTL", func() {
 			BeforeEach(func() {
 				sutConfig = config.Blocking{
@@ -1497,7 +1523,7 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring(
-					"unknown blockType 'wrong', please use one of: ZeroIP, NxDomain or specify destination IP address(es)"))
+					"unknown blockType 'wrong', please use one of: ZeroIP, NxDomain, Refused or specify destination IP address(es)"))
 			})
 		})
 		When("strategy is failOnError", func() {


### PR DESCRIPTION
Closes #2187.

Adds `refused` as a blockType option, so blocked queries are answered with the DNS REFUSED rcode for parity with AdGuard DNS. It sits right next to `nxDomain`: the handler sets the rcode and returns no records, so blockTTL has no effect in this mode.

Added a test for it and a row in the config docs.