### PR TITLE
fix(server): always answer an EDNS0 query with an OPT record

### DIFF
--- a/server/client_query.go
+++ b/server/client_query.go
@@ -76,17 +76,17 @@ func (q clientQuery) normalizeResponse(res *dns.Msg) {
 		util.StripDNSSECRecords(res, q.qType)
 	}
 
-	if opt := res.IsEdns0(); opt != nil {
-		// RFC 3225 §3: the DO bit of the query is copied into the response. The OPT record here is
-		// the upstream's, which answered a query whose DO bit the chain may have set. Responses
-		// blocky assembles itself carry no OPT and none is added here, so there is nothing to
-		// mirror onto - notably cache hits, which are served from bytes packed without the OPT.
-		opt.SetDo(q.wantsDNSSEC)
-	}
-
 	if !q.hadEdns0 {
 		// don't return an OPT record to a client that didn't use EDNS0 (RFC 6891 section 7)
 		util.RemoveEdns0Record(res)
+	} else if opt := res.IsEdns0(); opt != nil {
+		// RFC 3225 §3: the DO bit of the query is copied into the response
+		opt.SetDo(q.wantsDNSSEC)
+	} else {
+		// RFC 6891 §6.1.1: a response to an EDNS0 query must carry an OPT record. Cache hits
+		// are served from bytes packed without one; resolvers such as systemd-resolved read
+		// its absence as a server without EDNS0 support and downgrade.
+		res.SetEdns0(dns.DefaultMsgSize, q.wantsDNSSEC)
 	}
 
 	// truncate if necessary; Truncate also disables compression when the message already fits

--- a/server/client_query.go
+++ b/server/client_query.go
@@ -82,6 +82,13 @@ func (q clientQuery) normalizeResponse(res *dns.Msg) {
 	} else if opt := res.IsEdns0(); opt != nil {
 		// RFC 3225 §3: the DO bit of the query is copied into the response
 		opt.SetDo(q.wantsDNSSEC)
+
+		// Not every OPT reaching this point is the upstream's: util.SetEdns0Option, which the EDE
+		// resolver uses to annotate cache hits and blocked answers, builds one without a class
+		// field. RFC 6891 §6.2.4 makes a peer read that zero as 512 and shrink its buffer to match.
+		if opt.UDPSize() == 0 {
+			opt.SetUDPSize(dns.DefaultMsgSize)
+		}
 	} else {
 		// RFC 6891 §6.1.1: a response to an EDNS0 query must carry an OPT record. Cache hits
 		// are served from bytes packed without one; resolvers such as systemd-resolved read

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1267,6 +1267,26 @@ var _ = Describe("Running DNS server", func() {
 			})
 		})
 
+		When("the client used EDNS0 and the response has no OPT record", func() {
+			// RFC 6891 section 6.1.1: cache hits are served without the OPT record, and a client
+			// reads its absence as a server without EDNS0 support.
+			It("adds an OPT record mirroring the DO bit", func() {
+				s := newServerWithChain(func(req *model.Request) *dns.Msg {
+					return chainResponse.SetReply(req.Req)
+				})
+
+				clientMsg := util.NewMsgWithQuestion("example.com.", A)
+				clientMsg.SetEdns0(1232, true)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP, clientMsg)
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.IsEdns0()).ShouldNot(BeNil())
+				Expect(resp.Res.IsEdns0().Do()).Should(BeTrue())
+			})
+		})
+
 		When("the client left the DO bit clear", func() {
 			// RFC 4035 section 3.2.1: the DNSSEC records the chain requested upstream on the
 			// client's behalf must not be added to the response of a client that didn't ask.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1284,6 +1284,48 @@ var _ = Describe("Running DNS server", func() {
 				Expect(err).Should(Succeed())
 				Expect(resp.Res.IsEdns0()).ShouldNot(BeNil())
 				Expect(resp.Res.IsEdns0().Do()).Should(BeTrue())
+				Expect(resp.Res.IsEdns0().UDPSize()).Should(BeNumerically(">", 0))
+			})
+
+			It("adds an OPT record with the DO bit clear when the client cleared it", func() {
+				s := newServerWithChain(func(req *model.Request) *dns.Msg {
+					return chainResponse.SetReply(req.Req)
+				})
+
+				clientMsg := util.NewMsgWithQuestion("example.com.", A)
+				clientMsg.SetEdns0(1232, false)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP, clientMsg)
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.IsEdns0()).ShouldNot(BeNil())
+				Expect(resp.Res.IsEdns0().Do()).Should(BeFalse())
+				Expect(resp.Res.IsEdns0().UDPSize()).Should(BeNumerically(">", 0))
+			})
+		})
+
+		When("the response carries an OPT record blocky added itself", func() {
+			// util.SetEdns0Option, which the EDE resolver uses on cache hits and blocked answers,
+			// leaves the class field zero. RFC 6891 section 6.2.4 makes a peer read that as 512.
+			It("advertises a usable buffer size instead of zero", func() {
+				s := newServerWithChain(func(req *model.Request) *dns.Msg {
+					res := chainResponse.SetReply(req.Req)
+					util.SetEdns0Option(res, &dns.EDNS0_EDE{InfoCode: dns.ExtendedErrorCodeCachedError})
+
+					return res
+				})
+
+				clientMsg := util.NewMsgWithQuestion("example.com.", A)
+				clientMsg.SetEdns0(1232, true)
+
+				_, req := newRequest(ctx, net.ParseIP("1.2.3.4"), "", model.RequestProtocolUDP, clientMsg)
+
+				resp, err := s.resolve(ctx, req)
+				Expect(err).Should(Succeed())
+				Expect(resp.Res.IsEdns0()).ShouldNot(BeNil())
+				Expect(resp.Res.IsEdns0().Do()).Should(BeTrue())
+				Expect(resp.Res.IsEdns0().UDPSize()).Should(BeNumerically(">", 0))
 			})
 		})
 


### PR DESCRIPTION
Responses served from the cache carry no OPT record, even when the query had one. `packForCache` strips the OPT before storing (#1150), and `normalizeResponse` only ever removes an OPT, never adds one. So the first answer for a name has an OPT and every later answer doesn't.

RFC 6891 §6.1.1 requires an OPT record in the response to any EDNS0 query. systemd-resolved treats its absence as a server without EDNS0 support, downgrades to plain UDP, and re-probes about every 45 minutes. Lookups that land inside a probe window return `SERVFAIL` to applications. The journal on such a client shows the loop:

```
Grace period over, resuming full feature set (UDP+EDNS0) for DNS server 192.168.1.161
Using degraded feature set UDP instead of UDP+EDNS0 for DNS server 192.168.1.161
```

In this commit when the client sends an OPT record and the response has none, `normalizeResponse` adds one with the client's DO bit. Responses to clients without EDNS0 unchanged.