### PR TITLE
fix(querylog): exclude sqlite on Solaris and illumos

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1155,7 +1155,13 @@ You can select one of following query log types:
 The `sqlite` target stores the query log in a single local file (set via `queryLog.target`, e.g. `/var/lib/blocky/querylog.db`) — no external database is required. Blocky creates the file and its parent directory automatically.
 
 !!! note
-    The `sqlite` target is not available on every platform. It relies on a pure-Go SQLite driver that does not support all CPU architectures, so it is **not** compiled into the official builds for **`linux/mips`, `linux/mipsle`, `netbsd/arm`, `netbsd/arm64` and `openbsd/arm`**. On those builds, selecting `sqlite` fails at startup with a clear error message — use the `csv`, `mysql` or `postgresql` query log target instead. All other targets (including `linux/amd64`, `linux/arm`, `linux/arm64`, `windows/amd64` and `darwin`) support `sqlite`.
+    The `sqlite` target is not available on every platform. It relies on a pure-Go SQLite driver that ships no code for some GOOS/GOARCH combinations, so it is **not** compiled in on:
+
+    - all MIPS architectures (`mips`, `mipsle`, `mips64`, `mips64le`) and `loong64`
+    - NetBSD other than `netbsd/amd64`, and OpenBSD other than `openbsd/amd64` and `openbsd/arm64`
+    - Solaris and illumos
+
+    Among the official release builds this affects **`linux/mips`, `linux/mipsle`, `freebsd/mips`, `freebsd/mipsle`, `netbsd/arm`, `netbsd/arm64`, `netbsd/mips`, `netbsd/mipsle`, `openbsd/arm`, `openbsd/mips` and `openbsd/mipsle`**. On those builds, selecting `sqlite` fails at startup with a clear error message — use the `csv`, `mysql` or `postgresql` query log target instead. All other targets (including `linux/amd64`, `linux/arm`, `linux/arm64`, `windows/amd64` and `darwin`) support `sqlite`.
 
 Set `queryLog.target` to a **plain filesystem path**. Do **not** prefix it with `file:` — for query-log targets that prefix means "read the target value from this file" (see the [Redis tip](#redis)), so `file:/var/lib/blocky/querylog.db` would be treated as a file to read the path *from*, not as the database itself.
 

--- a/querylog/database_writer_sqlite.go
+++ b/querylog/database_writer_sqlite.go
@@ -1,4 +1,4 @@
-//go:build !mips && !mipsle && !mips64 && !mips64le && !loong64 && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64)
+//go:build !mips && !mipsle && !mips64 && !mips64le && !loong64 && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64) && !illumos
 
 // SQLite support is compiled in only on the GOOS/GOARCH targets supported by the
 // pure-Go driver chain (github.com/glebarez/sqlite -> modernc.org/sqlite ->

--- a/querylog/database_writer_sqlite.go
+++ b/querylog/database_writer_sqlite.go
@@ -1,11 +1,13 @@
-//go:build !mips && !mipsle && !mips64 && !mips64le && !loong64 && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64) && !illumos
+//go:build !mips && !mipsle && !mips64 && !mips64le && !loong64 && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64) && !solaris
 
 // SQLite support is compiled in only on the GOOS/GOARCH targets supported by the
 // pure-Go driver chain (github.com/glebarez/sqlite -> modernc.org/sqlite ->
-// modernc.org/libc). modernc ships no MIPS support at all and only a subset of the
-// BSD architectures (netbsd/amd64, openbsd/amd64+arm64), so the remaining release
-// targets compile the stub in database_writer_sqlite_unsupported.go instead. This
-// keeps the cross-compiled release build working (without SQLite query log there).
+// modernc.org/libc). modernc ships no MIPS, loong64 or Solaris support at all and
+// only a subset of the BSD architectures (netbsd/amd64, openbsd/amd64+arm64), so the
+// remaining release targets compile the stub in database_writer_sqlite_unsupported.go
+// instead. This keeps the cross-compiled release build working (without SQLite query
+// log there). Note that the solaris term also covers GOOS=illumos, which satisfies the
+// solaris build tag as well.
 // Revisit this list when the modernc.org/sqlite dependency is upgraded.
 
 package querylog

--- a/querylog/database_writer_sqlite_unsupported.go
+++ b/querylog/database_writer_sqlite_unsupported.go
@@ -1,9 +1,10 @@
-//go:build mips || mipsle || mips64 || mips64le || loong64 || (netbsd && !amd64) || (openbsd && !amd64 && !arm64) || illumos
+//go:build mips || mipsle || mips64 || mips64le || loong64 || (netbsd && !amd64) || (openbsd && !amd64 && !arm64) || solaris
 
 // This is the exact complement of the constraint in database_writer_sqlite.go: the
 // GOOS/GOARCH targets where the pure-Go SQLite driver chain (github.com/glebarez/
 // sqlite -> modernc.org/sqlite) ships no generated code, e.g. linux/mips,
-// linux/mipsle, netbsd/arm and openbsd/arm. Keep the two constraints in sync.
+// linux/mipsle, netbsd/arm, openbsd/arm, solaris and illumos. Keep this constraint in
+// sync with the two in database_writer_sqlite.go and database_writer_test.go.
 
 package querylog
 

--- a/querylog/database_writer_sqlite_unsupported.go
+++ b/querylog/database_writer_sqlite_unsupported.go
@@ -1,4 +1,4 @@
-//go:build mips || mipsle || mips64 || mips64le || loong64 || (netbsd && !amd64) || (openbsd && !amd64 && !arm64)
+//go:build mips || mipsle || mips64 || mips64le || loong64 || (netbsd && !amd64) || (openbsd && !amd64 && !arm64) || illumos
 
 // This is the exact complement of the constraint in database_writer_sqlite.go: the
 // GOOS/GOARCH targets where the pure-Go SQLite driver chain (github.com/glebarez/

--- a/querylog/database_writer_test.go
+++ b/querylog/database_writer_test.go
@@ -1,4 +1,4 @@
-//go:build !mips && !mipsle && !mips64 && !mips64le && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64)
+//go:build !mips && !mipsle && !mips64 && !mips64le && !loong64 && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64)
 
 package querylog
 

--- a/querylog/database_writer_test.go
+++ b/querylog/database_writer_test.go
@@ -1,4 +1,4 @@
-//go:build !mips && !mipsle && !mips64 && !mips64le && !loong64 && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64)
+//go:build !mips && !mipsle && !mips64 && !mips64le && !loong64 && !(netbsd && !amd64) && !(openbsd && !amd64 && !arm64) && !solaris
 
 package querylog
 


### PR DESCRIPTION
At the moment there is no pure-Go driver for SQLite available on illumos. For that reason disable it.