### PR TITLE
fix(resolver): Return SOA record with custom DNS NOERROR response

### DIFF
--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -169,13 +169,13 @@ func (r *CustomDNSResolver) processRequest(
 				break
 			}
 
-			// return NOERROR/NODATA with an SOA record in the authority section (RFC 2308),  
-			// so caching resolvers know how long to cache the negative result  
-			response := model.NewResponseWithReason(request, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS")  
-			soa := util.CreateSOAForNegativeResponse(question, r.cfg.CustomTTL.SecondsU32())  
-			response.Res.Ns = []dns.RR{soa}  
-  
-			return response, nil  
+			// return NOERROR/NODATA with an SOA record in the authority section (RFC 2308),
+			// so caching resolvers know how long to cache the negative result
+			response := model.NewResponseWithReason(request, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS")
+			soa := util.CreateSOAForNegativeResponse(question, r.cfg.CustomTTL.SecondsU32())
+			response.Res.Ns = []dns.RR{soa}
+
+			return response, nil
 		}
 
 		if i := strings.IndexRune(domain, '.'); i >= 0 {

--- a/resolver/custom_dns_resolver.go
+++ b/resolver/custom_dns_resolver.go
@@ -169,8 +169,13 @@ func (r *CustomDNSResolver) processRequest(
 				break
 			}
 
-			// return NOERROR with empty result
-			return model.NewResponseWithReason(request, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS"), nil
+			// return NOERROR/NODATA with an SOA record in the authority section (RFC 2308),  
+			// so caching resolvers know how long to cache the negative result  
+			response := model.NewResponseWithReason(request, model.ResponseTypeCUSTOMDNS, "CUSTOM DNS")  
+			soa := util.CreateSOAForNegativeResponse(question, r.cfg.CustomTTL.SecondsU32())  
+			response.Res.Ns = []dns.RR{soa}  
+  
+			return response, nil  
 		}
 
 		if i := strings.IndexRune(domain, '.'); i >= 0 {

--- a/resolver/custom_dns_resolver_test.go
+++ b/resolver/custom_dns_resolver_test.go
@@ -173,11 +173,12 @@ var _ = Describe("CustomDNSResolver", func() {
 					// will not delegate to next resolver
 					m.AssertNotCalled(GinkgoT(), "Resolve", mock.Anything)
 				})
-				It("TXT query for defined mapping should return NOERROR and empty result", func() {
+				It("TXT query for defined mapping should return NOERROR with an SOA in the authority section", func() {
 					Expect(sut.Resolve(ctx, newRequest("custom.domain.", TXT))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
+								HaveSOARecord(TTL, TTL),
 								HaveResponseType(ResponseTypeCUSTOMDNS),
 								HaveReason("CUSTOM DNS"),
 								HaveReturnCode(dns.RcodeSuccess),
@@ -185,11 +186,12 @@ var _ = Describe("CustomDNSResolver", func() {
 					// will not delegate to next resolver
 					m.AssertNotCalled(GinkgoT(), "Resolve", mock.Anything)
 				})
-				It("ip6 query should return NOERROR and empty result", func() {
+				It("ip6 query should return NOERROR with an SOA in the authority section", func() {
 					Expect(sut.Resolve(ctx, newRequest("custom.domain.", AAAA))).
 						Should(
 							SatisfyAll(
 								HaveNoAnswer(),
+								HaveSOARecord(TTL, TTL),
 								HaveResponseType(ResponseTypeCUSTOMDNS),
 								HaveReason("CUSTOM DNS"),
 								HaveReturnCode(dns.RcodeSuccess),


### PR DESCRIPTION
#1895 added SOA records to NXDOMAIN responses to comply with RFC 2308, which is important for allowing clients to cache negative responses. See also #1874.

Currently, blocky does not generate SOA records when using the `customDNS` feature and a NOERROR response is returned. Without the SOA records, clients cannot cache the negative response, leading to repeated queries to blocky. This PR adds the SOA records so that the responses can be properly cached.