### PR TITLE
fix(resolver): scope allowlist-only mode to the whole client

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -93,7 +93,8 @@ blocking:
       - https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews/hosts
   # definition of allowlist groups.
   # Note: if the same group has both allow/denylists, allowlists take precedence. Meaning if a domain is both blocked and allowed, it will be allowed.
-  # If a group has only allowlist entries, only domains from this list are allowed, and all others be blocked.
+  # If every group assigned to a client has only allowlist entries, that client is in exclusive
+  # allow mode: only domains from those lists are allowed, and all others are blocked.
   allowlists:
     ads:
       - allowlist.txt

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -799,8 +799,10 @@ The supported list formats are:
 
 !!! warning
 
-    If the same group has **both** allow/denylists, allowlists take precedence. Meaning if a domain is both blocked and allowed, it will be allowed.
-    If a group has **only allowlist** entries, only domains from this list are allowed, and all others be blocked.
+    Allowlists take precedence over denylists: if a domain is both blocked and allowed, it will be allowed.
+    This holds across **all** groups assigned to a client, so an allowlist in one group also excepts a domain that another of the client's groups denies. That is how you add client-specific exceptions to a shared denylist without duplicating it.
+
+    If **every** group assigned to a client has only allowlist entries, that client switches to exclusive allow mode: only the domains on those allowlists are resolved, everything else is blocked. Giving the client at least one group with denylist entries keeps the normal behavior, where allowlists are exceptions.
 
 !!! warning
     You must also define a client group mapping, otherwise the allow/denylist definitions will have no effect.
@@ -870,6 +872,7 @@ Rules:
 2. If a list group has multiple schedules, they are combined with OR logic (any active schedule enables the list).
 3. Schedules use local server time. During daylight-saving transitions, only the specific skipped minutes are unobservable (a window overlapping the gap fires for its non-skipped portion); windows in the repeated hour fire twice.
 4. Scheduling an allowlist-only group (a group that has allowlist entries but no denylist entries) time-gates that group's allowlist enforcement: outside the schedule, that allowlist is not consulted. Other active groups for the client (denylists or other allowlist-only groups) are still evaluated normally.
+5. Whether a client is in exclusive allow mode (see [Definition allow/denylists](#definition-allowdenylists)) follows from its configured groups, not from which of them are currently active. A schedule that deactivates the client's denylist group therefore never turns the client's remaining allowlists into a whitelist.
 
 Each schedule supports:
 

--- a/e2e/blocking_test.go
+++ b/e2e/blocking_test.go
@@ -147,9 +147,9 @@ var _ = Describe("Domain blocking functionality", func() {
 		})
 	})
 
-	// Note: Allowlist-only mode test (4.1) is not fully implemented here because
-	// allowlists in Blocky work as exceptions to denylists, not as standalone allow-only mode.
-	// The allowlist functionality is tested in conjunction with denylists in other tests.
+	// Note: standalone allow-only mode (a client whose groups are all allowlist-only)
+	// is covered by the resolver unit tests. Here we cover the mixed case, where an
+	// allowlist group supplements a denylist group for the same client.
 
 	Describe("Wildcard blocking", func() {
 		Context("with wildcard patterns in blocklist", func() {
@@ -865,6 +865,68 @@ var _ = Describe("Domain blocking functionality", func() {
 				Expect(doDNSRequest(ctx, blocky, msg)).
 					Should(BeDNSRecord("blockeddomain.com.", A, "5.6.7.8"))
 			})
+		})
+	})
+
+	// A client that is assigned a denylist group keeps resolving everything that is
+	// not denylisted, even when it is also assigned a group holding only allowlists:
+	// that allowlist supplies exceptions, it is not a whitelist (issue #2207).
+	Describe("Allowlist-only group combined with a denylist group", func() {
+		BeforeEach(func(ctx context.Context) {
+			// Upstream for the domains that must come back from the resolver rather
+			// than from the sinkhole.
+			_, err = createDNSMokkaContainer(ctx, "moka2", e2eNet,
+				`A unrelated.com/NOERROR("A 1.2.3.4 300")`,
+				`A social.example.com/NOERROR("A 5.6.7.8 300")`,
+			)
+			Expect(err).Should(Succeed())
+
+			_, err = createHTTPServerContainer(ctx, "httpserver1", e2eNet, "deny.txt",
+				"blockeddomain.com", "social.example.com")
+			Expect(err).Should(Succeed())
+
+			_, err = createHTTPServerContainer(ctx, "httpserver2", e2eNet, "allow.txt",
+				"social.example.com")
+			Expect(err).Should(Succeed())
+
+			blocky, err = createBlockyContainerFromString(ctx, e2eNet, dedent(`
+				log:
+				  level: warn
+				upstreams:
+				  groups:
+				    default:
+				      - moka2
+				blocking:
+				  denylists:
+				    ads:
+				      - http://httpserver1:8080/deny.txt
+				  allowlists:
+				    exceptions:
+				      - http://httpserver2:8080/allow.txt
+				  clientGroupsBlock:
+				    default:
+				      - ads
+				      - exceptions
+				`))
+			Expect(err).Should(Succeed())
+		})
+
+		It("resolves a domain that is on neither list", func(ctx context.Context) {
+			msg := util.NewMsgWithQuestion("unrelated.com.", A)
+			Expect(doDNSRequest(ctx, blocky, msg)).
+				Should(BeDNSRecord("unrelated.com.", A, "1.2.3.4"))
+		})
+
+		It("still blocks a denylisted domain", func(ctx context.Context) {
+			msg := util.NewMsgWithQuestion("blockeddomain.com.", A)
+			Expect(doDNSRequest(ctx, blocky, msg)).
+				Should(BeDNSRecord("blockeddomain.com.", A, "0.0.0.0"))
+		})
+
+		It("allows a denylisted domain that the allowlist group excepts", func(ctx context.Context) {
+			msg := util.NewMsgWithQuestion("social.example.com.", A)
+			Expect(doDNSRequest(ctx, blocky, msg)).
+				Should(BeDNSRecord("social.example.com.", A, "5.6.7.8"))
 		})
 	})
 })

--- a/resolver/blocking_resolver.go
+++ b/resolver/blocking_resolver.go
@@ -477,24 +477,12 @@ func (r *BlockingResolver) LogConfig(logger *logrus.Entry) {
 	log.WithIndent(logger, "  ", r.allowlistMatcher.LogConfig)
 }
 
-func (r *BlockingResolver) hasAllowlistOnlyAllowed(groupsToCheck []string) bool {
-	for _, group := range groupsToCheck {
-		if _, found := r.allowlistOnlyGroups[group]; found {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (r *BlockingResolver) handleDenylist(ctx context.Context, groupsToCheck []string,
+func (r *BlockingResolver) handleDenylist(ctx context.Context, groupsToCheck []string, allowlistOnly bool,
 	request *model.Request, logger *logrus.Entry,
 ) (bool, *model.Response, error) {
 	if isDebugEnabled(logger) {
 		logger.WithField("groupsToCheck", strings.Join(groupsToCheck, "; ")).Debug("checking groups for request")
 	}
-
-	allowlistOnlyAllowed := r.hasAllowlistOnlyAllowed(groupsToCheck)
 
 	for _, question := range request.Req.Question {
 		domain := util.ExtractDomain(question)
@@ -511,7 +499,7 @@ func (r *BlockingResolver) handleDenylist(ctx context.Context, groupsToCheck []s
 			return true, resp, err
 		}
 
-		if allowlistOnlyAllowed {
+		if allowlistOnly {
 			resp, err := r.handleBlocked(logger, request, question, "BLOCKED (ALLOWLIST ONLY)", "")
 			if err != nil {
 				err = fmt.Errorf("failed to handle allowlist-only block for %s: %w", domain, err)
@@ -541,10 +529,10 @@ func (r *BlockingResolver) Resolve(ctx context.Context, request *model.Request) 
 	}
 
 	ctx, logger := r.log(ctx)
-	groupsToCheck := r.groupsToCheckForClient(request)
+	groupsToCheck, allowlistOnly := r.groupsToCheckForClient(request)
 
 	if len(groupsToCheck) > 0 {
-		handled, resp, err := r.handleDenylist(ctx, groupsToCheck, request, logger)
+		handled, resp, err := r.handleDenylist(ctx, groupsToCheck, allowlistOnly, request, logger)
 		if handled {
 			return resp, err
 		}
@@ -588,8 +576,10 @@ func extractEntryToCheckFromResponse(rr dns.RR) (entryToCheck, tName string) {
 	return entryToCheck, tName
 }
 
-// returns groups which should be checked for client's request
-func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) []string {
+// groupsToCheckForClient returns the groups which should be checked for the client's
+// request, and whether those groups form an exclusive allowlist (block everything not
+// allowlisted).
+func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) ([]string, bool) {
 	// Snapshot disabledGroups under a brief read lock, then release it before the
 	// (lock-free) group collection and filtering below. The field's invariant
 	// (reassigned wholesale, never mutated in place) is what keeps the captured
@@ -605,6 +595,21 @@ func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) []stri
 	if len(groups) == 0 {
 		// return default
 		groups = r.clientGroups.byID["default"]
+	}
+
+	// Exclusive mode is derived from the client's configured groups, not from the
+	// active ones filtered below: a client that also has a denylist group uses its
+	// allowlists as exceptions to that denylist, so deactivating the denylist group
+	// -- via a schedule or the disable API -- must not promote those exceptions into
+	// a whitelist that blocks everything else.
+	allowlistOnly := len(groups) > 0
+
+	for _, sg := range groups {
+		if !r.allowlistOnlyGroups[sg.group] {
+			allowlistOnly = false
+
+			break
+		}
 	}
 
 	now := time.Now()
@@ -632,7 +637,7 @@ func (r *BlockingResolver) groupsToCheckForClient(request *model.Request) []stri
 		sort.Strings(result)
 	}
 
-	return result
+	return result, allowlistOnly
 }
 
 func isAnyScheduleActive(schedules []*config.Schedule, now time.Time) bool {

--- a/resolver/blocking_resolver_bench_test.go
+++ b/resolver/blocking_resolver_bench_test.go
@@ -60,7 +60,7 @@ func BenchmarkBlockingGroupsToCheckLiteralName(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		if got := r.groupsToCheckForClient(req); len(got) == 0 {
+		if got, _ := r.groupsToCheckForClient(req); len(got) == 0 {
 			b.Fatal("expected at least one group")
 		}
 	}
@@ -75,7 +75,7 @@ func BenchmarkBlockingGroupsToCheckGlobName(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		if got := r.groupsToCheckForClient(req); len(got) == 0 {
+		if got, _ := r.groupsToCheckForClient(req); len(got) == 0 {
 			b.Fatal("expected at least one group")
 		}
 	}

--- a/resolver/blocking_resolver_test.go
+++ b/resolver/blocking_resolver_test.go
@@ -1104,6 +1104,95 @@ var _ = Describe("BlockingResolver", Label("blockingResolver"), func() {
 			})
 		})
 
+		// A client that has a denylist group uses its allowlists as exceptions to that
+		// denylist, not as a whitelist: an allowlist-only group mixed into such a client
+		// must not put the whole client into "allow nothing else" mode (issue #2207).
+		When("An allowlist-only group is combined with a denylist group for the same client", func() {
+			var mixedDenyFile, mixedAllowFile *TmpFile
+
+			BeforeEach(func() {
+				mixedDenyFile = tmpDir.CreateStringFile("mixedDenyFile", "ads.example.com", "social.example.com")
+				mixedAllowFile = tmpDir.CreateStringFile("mixedAllowFile", "social.example.com")
+
+				sutConfig = config.Blocking{
+					BlockType: "ZEROIP",
+					BlockTTL:  config.Duration(60 * time.Second),
+					Denylists: map[string][]config.BytesSource{
+						"ads": config.NewBytesSources(mixedDenyFile.Path),
+					},
+					Allowlists: map[string][]config.BytesSource{
+						"exceptions": config.NewBytesSources(mixedAllowFile.Path),
+					},
+					ClientGroupsBlock: map[string][]string{
+						"default": {"ads"},
+						"laptop":  {"ads", "exceptions"},
+					},
+				}
+			})
+
+			It("resolves a domain that is on neither list", func() {
+				Expect(sut.Resolve(ctx, newRequestWithClient("wikipedia.org.", A, "1.2.1.2", "laptop"))).
+					Should(
+						SatisfyAll(
+							HaveNoAnswer(),
+							HaveResponseType(ResponseTypeRESOLVED),
+							HaveReturnCode(dns.RcodeSuccess),
+						))
+
+				m.AssertExpectations(GinkgoT())
+			})
+
+			It("still blocks a denylisted domain, naming the group that blocked it", func() {
+				Expect(sut.Resolve(ctx, newRequestWithClient("ads.example.com.", A, "1.2.1.2", "laptop"))).
+					Should(
+						SatisfyAll(
+							BeDNSRecord("ads.example.com.", A, "0.0.0.0"),
+							HaveResponseType(ResponseTypeBLOCKED),
+							HaveReturnCode(dns.RcodeSuccess),
+							HaveReason("BLOCKED (ads: ads.example.com)"),
+						))
+			})
+
+			It("allows a domain the allowlist-only group excepts from the other group's denylist", func() {
+				Expect(sut.Resolve(ctx, newRequestWithClient("social.example.com.", A, "1.2.1.2", "laptop"))).
+					Should(
+						SatisfyAll(
+							HaveNoAnswer(),
+							HaveResponseType(ResponseTypeRESOLVED),
+							HaveReturnCode(dns.RcodeSuccess),
+						))
+
+				m.AssertExpectations(GinkgoT())
+			})
+
+			It("leaves clients that do not have the allowlist-only group unaffected", func() {
+				Expect(sut.Resolve(ctx, newRequestWithClient("social.example.com.", A, "1.2.1.3", "phone"))).
+					Should(
+						SatisfyAll(
+							BeDNSRecord("social.example.com.", A, "0.0.0.0"),
+							HaveResponseType(ResponseTypeBLOCKED),
+							HaveReturnCode(dns.RcodeSuccess),
+							HaveReason("BLOCKED (ads: social.example.com)"),
+						))
+			})
+
+			// Deactivating the denylist group must not promote the remaining allowlist
+			// into a whitelist: disabling blocking can only ever block less, never more.
+			It("does not switch to allowlist-only mode when the denylist group is disabled", func() {
+				Expect(sut.DisableBlocking(ctx, 0, []string{"ads"})).Should(Succeed())
+
+				Expect(sut.Resolve(ctx, newRequestWithClient("wikipedia.org.", A, "1.2.1.2", "laptop"))).
+					Should(
+						SatisfyAll(
+							HaveNoAnswer(),
+							HaveResponseType(ResponseTypeRESOLVED),
+							HaveReturnCode(dns.RcodeSuccess),
+						))
+
+				m.AssertExpectations(GinkgoT())
+			})
+		})
+
 		When("IP address is on black and allowlist", func() {
 			BeforeEach(func() {
 				sutConfig = config.Blocking{


### PR DESCRIPTION
Fixes #2207

## Problem

A group holding only allowlist entries (no `denylists` key) put the **whole client** into exclusive "allow nothing else" mode, even when that client was also assigned ordinary denylist groups. The flag was ORed across the client's groups and the branch returned before the denylist was ever consulted:

```go
allowlistOnlyAllowed := r.hasAllowlistOnlyAllowed(groupsToCheck) // any group -> true
...
if allowlistOnlyAllowed {
    return true, r.handleBlocked(..., "BLOCKED (ALLOWLIST ONLY)", ""), nil
}
if matches := r.matches(groupsToCheck, r.denylistMatcher, domain); ... // never reached
```

So the config from the issue — a shared `ads` denylist plus a small client-specific allowlist group — blocked everything for that client:

```
macan   wikipedia.org        -> BLOCKED (ALLOWLIST ONLY)
macan   google.com           -> BLOCKED (ALLOWLIST ONLY)
macan   doubleclick.net      -> BLOCKED (ALLOWLIST ONLY)   <- attribution lost
default wikipedia.org        -> RESOLVED
default doubleclick.net      -> BLOCKED (ads: doubleclick.net)
```

Note the third line: denylist hits also lost their attribution, since the exclusive branch returned before the match was known. The query log and the `reason` metric label saw `BLOCKED (ALLOWLIST ONLY)` with an empty reason label rather than the group and rule that matched.

The reporter's workaround was a dummy `.invalid` domain in a denylist for that group. It works because `determineAllowlistOnlyGroups` tests **key presence** in `cfg.Denylists`, not whether the group denies anything — undiscoverable from the docs.

## Fix

Exclusive mode now requires that **every** group assigned to the client be allowlist-only. `hasAllowlistOnlyAllowed` is gone; `groupsToCheckForClient` returns the flag alongside the active groups.

Exclusivity is derived from the client's **configured** groups, before the schedule and disable-API filtering. Deriving it from the active groups would introduce a new bug: deactivating the denylist group would leave only the allowlist group active and promote its exceptions into a whitelist, so disabling blocking would block *more*. There is a test pinning that.

This keeps the pure allow-only use case (a client whose groups are all allowlist-only) working exactly as before — every pre-existing allowlist-only spec passes unchanged.

## Docs

The documented behaviour was wrong on two counts, both corrected in `docs/configuration.md` and `docs/config.yml`:

- **Scope** — it read as a per-group rule; exclusive mode is a property of the *client*.
- **"only domains from this list"** — the permitted set is the union of the allowlists across *all* of the client's groups. (Verified: a domain allowlisted only in the `ads` group resolves for a client whose exclusive mode came from a different group.)

The docs now also state that allowlist precedence holds across a client's groups, which is the supported way to add client-specific exceptions to a shared denylist without duplicating it. Added schedule rule 5 noting exclusivity follows configuration, not currently-active groups.

## Tests

Written test-first; the failing cases were observed before the fix.

**Unit** (`resolver/blocking_resolver_test.go`) — 5 new specs, 3 of which failed against the old code:
- resolves a domain on neither list
- still blocks a denylisted domain, **naming the group that blocked it**
- allowlist group excepts a domain the other group denies
- clients without the allowlist-only group unaffected
- denylist group disabled via API -> still not exclusive mode

The mixed case had no coverage at all before this: every existing allowlist-only spec used clients whose groups were *all* allowlist-only, which is why this shipped.

**E2E** (`e2e/blocking_test.go`) — 3 new specs over two list servers. Against a pre-fix image the first one reproduces the report end to end:

```
Expected ... unrelated.com. 21600 IN A 0.0.0.0
to contain domain 'unrelated.com.', type 'A', answer '1.2.3.4'
```

Also replaced the stale note claiming allow-only mode could not be tested here.

## Verification

- `./resolver` suite: 713/713 pass
- full e2e suite: **163/163 pass**
- `golangci-lint` (v2.12.2): 0 issues
- `gofmt` clean

https://claude.ai/code/session_01QyEFFhrY3j9QtGzR2wUJr9
