### PR TITLE
fix(resolver): reply to NOTFQDN queries with a well-formed NXDOMAIN

### DIFF
--- a/e2e/fqdn_only_test.go
+++ b/e2e/fqdn_only_test.go
@@ -41,14 +41,17 @@ var _ = Describe("FQDN only mode", func() {
 			Expect(err).Should(Succeed())
 		})
 
-		It("should reject non-FQDN queries", func(ctx context.Context) {
+		It("should reject non-FQDN queries with NXDOMAIN", func(ctx context.Context) {
 			msg := util.NewMsgWithQuestion("myserver.", A)
+
+			// the rejection must be a reply the client accepts: one that echoes the request id
+			// and question. A bare Rcode-only message is discarded as an id mismatch, leaving
+			// the client to time out instead of seeing the NXDOMAIN.
 			resp, err := doDNSRequest(ctx, blocky, msg)
-			if err != nil {
-				// Any DNS error (connection refused, id mismatch, etc.) is a valid rejection
-				return
-			}
+			Expect(err).Should(Succeed())
 			Expect(resp.Rcode).Should(Equal(dns.RcodeNameError))
+			Expect(resp.Question).Should(Equal(msg.Question))
+			Expect(resp.Answer).Should(BeEmpty())
 		})
 
 		It("should resolve FQDN queries normally", func(ctx context.Context) {

--- a/model/response_helpers.go
+++ b/model/response_helpers.go
@@ -42,16 +42,3 @@ func NewResponseWithRcode(request *Request, rcode int, rtype ResponseType, reaso
 		Reason: reason,
 	}
 }
-
-// NewEmptyResponse creates a response with just the Rcode field set (no SetReply or SetRcode).
-// This is used for minimal responses where only the return code matters.
-func NewEmptyResponse(request *Request, rcode int, rtype ResponseType, reason string) *Response {
-	response := new(dns.Msg)
-	response.Rcode = rcode
-
-	return &Response{
-		Res:    response,
-		RType:  rtype,
-		Reason: reason,
-	}
-}

--- a/resolver/fqdn_only_resolver.go
+++ b/resolver/fqdn_only_resolver.go
@@ -27,7 +27,7 @@ func (r *FQDNOnlyResolver) Resolve(ctx context.Context, request *model.Request) 
 	if r.IsEnabled() {
 		domainFromQuestion := util.ExtractDomain(request.Req.Question[0])
 		if !strings.Contains(domainFromQuestion, ".") {
-			return model.NewEmptyResponse(request, dns.RcodeNameError, model.ResponseTypeNOTFQDN, "NOTFQDN"), nil
+			return model.NewResponseWithRcode(request, dns.RcodeNameError, model.ResponseTypeNOTFQDN, "NOTFQDN"), nil
 		}
 	}
 

--- a/resolver/fqdn_only_resolver_test.go
+++ b/resolver/fqdn_only_resolver_test.go
@@ -88,6 +88,18 @@ var _ = Describe("FqdnOnlyResolver", func() {
 			// no call of next resolver
 			Expect(m.Calls).Should(BeZero())
 		})
+		It("Should reply to the request, echoing its id and question", func() {
+			request := newRequest("example", AAAA)
+
+			resp, err := sut.Resolve(ctx, request)
+			Expect(err).Should(Succeed())
+
+			// a reply that carries neither the request id nor the question is rejected by the
+			// client as an id mismatch, so it sees a timeout instead of the NXDOMAIN
+			Expect(resp.Res.Response).Should(BeTrue())
+			Expect(resp.Res.Id).Should(Equal(request.Req.Id))
+			Expect(resp.Res.Question).Should(Equal(request.Req.Question))
+		})
 
 		Describe("IsEnabled", func() {
 			It("is true", func() {


### PR DESCRIPTION
## Problem

With `fqdnOnly.enable: true`, a query for a dotless name never reached the client as NXDOMAIN. `FQDNOnlyResolver` built its answer through `model.NewEmptyResponse`, which set only the `Rcode`:

```go
func NewEmptyResponse(request *Request, rcode int, rtype ResponseType, reason string) *Response {
	response := new(dns.Msg)
	response.Rcode = rcode   // no SetReply, no SetRcode
	...
}
```

The resulting message echoes back neither the request id nor the question section. Conforming clients discard it as an id mismatch and keep waiting for a reply that never comes, so the user sees a **timeout** instead of the NXDOMAIN the documentation promises:

> If this option is enabled blocky will respond immediately with NXDOMAIN if the request is not a valid FQDN.

Reproduced end to end against a pre-fix image:

```
[FAILED] Expected success, but got an error:
    dns: id mismatch
```

## Fix

Use the existing `model.NewResponseWithRcode`, whose `SetRcode` calls `SetReply` internally and therefore echoes id and question, and drop `NewEmptyResponse` — `FQDNOnlyResolver` was its only caller.

I checked the other response-construction sites for the same class of defect; all of them (`resolver.newResponse`, both DNS64 paths) already call `SetReply`, so this was the only instance. No behaviour changes beyond the malformed message: the rcode, response type and reason are unchanged.

No documentation change: the docs already describe the correct behaviour, the code just didn't implement it.

## Why it went unnoticed

The e2e test explicitly accepted the broken case as valid:

```go
-  if err != nil {
-      // Any DNS error (connection refused, id mismatch, etc.) is a valid rejection
-      return
-  }
```

Any DNS error counted as a pass, including the id mismatch that *is* the bug. It now asserts what a client actually needs to observe:

```go
+  Expect(err).Should(Succeed())
   Expect(resp.Rcode).Should(Equal(dns.RcodeNameError))
+  Expect(resp.Question).Should(Equal(msg.Question))
+  Expect(resp.Answer).Should(BeEmpty())
```

A unit test in `resolver/fqdn_only_resolver_test.go` pins the same contract at the resolver level (`Response` flag, id and question echoed).

Both tests were confirmed to fail against the unfixed binary — the e2e one with the `dns: id mismatch` shown above — so they genuinely catch the regression rather than merely passing.

## Verification

- `./resolver` suite: pass
- full e2e suite: **160/160 pass**
- `golangci-lint` (v2.12.2): 0 issues
- `gofmt` clean

https://claude.ai/code/session_01QyEFFhrY3j9QtGzR2wUJr9
