### PR TITLE
fix(redis): recover optional connections after startup failure

### DIFF
--- a/cache/redis.go
+++ b/cache/redis.go
@@ -50,6 +50,8 @@ type RedisOptions[T any] struct {
 	FlushInterval time.Duration
 	// SendBufSize is the capacity of the internal send buffer channel.
 	SendBufSize int
+	// SkipInitialLoad avoids another blocking dial when Redis already failed its startup check.
+	SkipInitialLoad bool
 }
 
 // ReloadPublishable is implemented by inner caches that reload entries internally
@@ -113,7 +115,8 @@ func NewRedisExpiringByteCache(
 // NewRedisExpiringCache creates a new RedisExpiringCache decorator.
 //
 // It performs a blocking startup scan of existing Redis keys and loads them
-// into inner before launching the background writer and subscriber goroutines.
+// into inner before launching the background writer and subscriber goroutines,
+// unless SkipInitialLoad is set.
 // The goroutines run until ctx is cancelled.
 func NewRedisExpiringCache[T any](
 	ctx context.Context,
@@ -153,9 +156,10 @@ func NewRedisExpiringCache[T any](
 		rp.SetReloadPublisher(c.publishWriteThrough)
 	}
 
-	// Blocking startup load.
-	if err := c.loadFromRedis(ctx); err != nil {
-		c.logger.WithError(err).Warn("startup Redis scan failed – starting with empty local cache")
+	if !opts.SkipInitialLoad {
+		if err := c.loadFromRedis(ctx); err != nil {
+			c.logger.WithError(err).Warn("startup Redis scan failed – starting with empty local cache")
+		}
 	}
 
 	go c.runSubscriber(ctx)

--- a/redis/event_bridge.go
+++ b/redis/event_bridge.go
@@ -35,8 +35,9 @@ type EventBusBridge struct {
 }
 
 // NewEventBusBridge creates a new EventBusBridge that synchronizes blocking state
-// between local event bus and Redis pub/sub.
-func NewEventBusBridge(ctx context.Context, client *goredis.Client) (*EventBusBridge, error) {
+// between local event bus and Redis pub/sub. Without waitForConnection, the initial
+// subscription runs in the background so an optional Redis cannot delay startup.
+func NewEventBusBridge(ctx context.Context, client *goredis.Client, waitForConnection bool) (*EventBusBridge, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	b := &EventBusBridge{
@@ -54,14 +55,15 @@ func NewEventBusBridge(ctx context.Context, client *goredis.Client) (*EventBusBr
 		return nil, err
 	}
 
-	ps := client.Subscribe(ctx, b.channel)
+	var ps *goredis.PubSub
+	if waitForConnection {
+		ps = client.Subscribe(ctx, b.channel)
+		if _, err := ps.Receive(ctx); err != nil {
+			_ = b.Close()
+			_ = ps.Close()
 
-	if _, err := ps.Receive(ctx); err != nil {
-		_ = ps.Close()
-		_ = evt.Bus().Unsubscribe(evt.BlockingStateChanged, b.onLocalStateChanged)
-		cancel()
-
-		return nil, err
+			return nil, err
+		}
 	}
 
 	loop := &PubSubLoop{

--- a/redis/event_bridge_test.go
+++ b/redis/event_bridge_test.go
@@ -36,7 +36,7 @@ var _ = Describe("EventBusBridge", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 		DeferCleanup(cancel)
 
-		bridge, err = NewEventBusBridge(ctx, redisClient)
+		bridge, err = NewEventBusBridge(ctx, redisClient, true)
 		Expect(err).Should(Succeed())
 		DeferCleanup(func() { bridge.Close() })
 	})
@@ -53,7 +53,7 @@ var _ = Describe("EventBusBridge", func() {
 				newCtx, newCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 				DeferCleanup(newCancel)
 
-				_, err := NewEventBusBridge(newCtx, deadClient)
+				_, err := NewEventBusBridge(newCtx, deadClient, true)
 				Expect(err).Should(HaveOccurred())
 			})
 		})
@@ -63,7 +63,7 @@ var _ = Describe("EventBusBridge", func() {
 		When("BlockingStateChanged is published on the local bus", func() {
 			It("should publish a message to the Redis channel that a second subscriber receives", func(specCtx context.Context) {
 				// Create a second bridge to act as receiver
-				bridge2, err := NewEventBusBridge(ctx, redisClient)
+				bridge2, err := NewEventBusBridge(ctx, redisClient, true)
 				Expect(err).Should(Succeed())
 				DeferCleanup(func() { bridge2.Close() })
 
@@ -254,7 +254,7 @@ var _ = Describe("EventBusBridge", func() {
 				// Create a new bridge with its own context
 				bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
 
-				b, err := NewEventBusBridge(bridgeCtx, redisClient)
+				b, err := NewEventBusBridge(bridgeCtx, redisClient, true)
 				Expect(err).Should(Succeed())
 
 				// Close the Redis server to trigger reconnection
@@ -302,7 +302,7 @@ var _ = Describe("EventBusBridge", func() {
 				})
 
 				// Create a second bridge acting as the "remote" receiver
-				bridge2, err := NewEventBusBridge(ctx, redisClient)
+				bridge2, err := NewEventBusBridge(ctx, redisClient, true)
 				Expect(err).Should(Succeed())
 				DeferCleanup(func() { bridge2.Close() })
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -9,6 +9,7 @@ import (
 )
 
 // New creates a new Redis connection. Returns nil if Redis is not configured.
+// A failed initial connection returns the client with the error so optional users can reconnect.
 func New(ctx context.Context, cfg *config.Redis) (*goredis.Client, error) {
 	if cfg == nil || len(cfg.Address) == 0 {
 		return nil, nil //nolint:nilnil
@@ -41,7 +42,7 @@ func New(ctx context.Context, cfg *config.Redis) (*goredis.Client, error) {
 	rdb := client.WithContext(ctx)
 
 	if _, err := rdb.Ping(ctx).Result(); err != nil {
-		return nil, fmt.Errorf("failed to connect to Redis at '%s': %w", cfg.Address, err)
+		return rdb, fmt.Errorf("failed to connect to Redis at '%s': %w", cfg.Address, err)
 	}
 
 	return rdb, nil

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -33,7 +33,9 @@ var _ = Describe("Redis connection factory", func() {
 		})
 
 		It("should fail with error", func(ctx context.Context) {
-			_, err := New(ctx, redisConfig)
+			client, err := New(ctx, redisConfig)
+			Expect(client).ShouldNot(BeNil())
+			DeferCleanup(client.Close)
 			Expect(err).Should(HaveOccurred())
 		})
 	})
@@ -45,7 +47,9 @@ var _ = Describe("Redis connection factory", func() {
 		})
 
 		It("should fail with error", func(ctx context.Context) {
-			_, err := New(ctx, redisConfig)
+			client, err := New(ctx, redisConfig)
+			Expect(client).ShouldNot(BeNil())
+			DeferCleanup(client.Close)
 			Expect(err).Should(HaveOccurred())
 		})
 	})
@@ -62,6 +66,7 @@ var _ = Describe("Redis connection factory", func() {
 			client, err := New(ctx, redisConfig)
 			Expect(err).Should(Succeed())
 			Expect(client).ShouldNot(BeNil())
+			DeferCleanup(client.Close)
 		})
 	})
 
@@ -76,7 +81,9 @@ var _ = Describe("Redis connection factory", func() {
 		})
 
 		It("should fail with error", func(ctx context.Context) {
-			_, err := New(ctx, redisConfig)
+			client, err := New(ctx, redisConfig)
+			Expect(client).ShouldNot(BeNil())
+			DeferCleanup(client.Close)
 			Expect(err).Should(HaveOccurred())
 		})
 	})

--- a/server/redis_recovery_test.go
+++ b/server/redis_recovery_test.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"time"
+
+	"github.com/0xERR0R/blocky/config"
+	"github.com/0xERR0R/blocky/evt"
+	"github.com/0xERR0R/blocky/model"
+	"github.com/0xERR0R/blocky/redis"
+	"github.com/0xERR0R/blocky/resolver"
+	"github.com/0xERR0R/blocky/util"
+	"github.com/alicebob/miniredis/v2"
+	miniserver "github.com/alicebob/miniredis/v2/server"
+	"github.com/creasty/defaults"
+	"github.com/miekg/dns"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Optional Redis recovery", func() {
+	var cfg config.Config
+
+	BeforeEach(func() {
+		cfg = config.Config{}
+		Expect(defaults.Set(&cfg)).Should(Succeed())
+		cfg.Ports.DNS = config.ListenConfig{}
+		cfg.Upstreams.Groups = map[string][]config.Upstream{
+			"default": {{Net: config.NetProtocolTcpUdp, Host: "127.0.0.1", Port: 53}},
+		}
+		cfg.Redis.ConnectionAttempts = 1
+		cfg.Redis.ConnectionCooldown = config.Duration(10 * time.Millisecond)
+	})
+
+	It("resumes cache writes and blocking synchronization after Redis starts", func(ctx context.Context) {
+		redisServer, err := miniredis.Run()
+		Expect(err).Should(Succeed())
+		DeferCleanup(redisServer.Close)
+		address := redisServer.Addr()
+		redisServer.Close()
+
+		upstream := resolver.NewMockUDPUpstreamServer().WithAnswerFn(func(request *dns.Msg) *dns.Msg {
+			answer, err := util.NewMsgWithAnswer(util.ExtractDomain(request.Question[0]), 300, dns.Type(dns.TypeA), "203.0.113.77")
+			Expect(err).Should(Succeed())
+
+			return answer
+		})
+		upstreamConfig := upstream.Start()
+		DeferCleanup(upstream.Close)
+		cfg.Upstreams.Groups = map[string][]config.Upstream{"default": {upstreamConfig}}
+		cfg.Redis.Address = address
+
+		srv, err := NewServer(ctx, &cfg)
+		Expect(err).Should(Succeed())
+		DeferCleanup(func() { Expect(srv.Stop(ctx)).Should(Succeed()) })
+		query := func(domain string) {
+			response, err := srv.queryResolver.Resolve(ctx, &model.Request{
+				Req:      util.NewMsgWithQuestion(domain, dns.Type(dns.TypeA)),
+				Protocol: model.RequestProtocolUDP,
+			})
+			Expect(err).Should(Succeed())
+			Expect(response.Res.Answer).Should(HaveLen(1))
+			Expect(response.Res.Answer[0].(*dns.A).A.Equal(net.ParseIP("203.0.113.77"))).Should(BeTrue())
+		}
+		query("cache-unavailable.example.com.")
+		Expect(redisServer.StartAddr(address)).Should(Succeed())
+		query("cache-recovered.example.com.")
+		key := "blocky:cache:" + util.GenerateCacheKey(dns.Type(dns.TypeA), "cache-recovered.example.com")
+		Eventually(func(g Gomega) {
+			packed, err := redisServer.Get(key)
+			g.Expect(err).Should(Succeed())
+			response := new(dns.Msg)
+			g.Expect(response.Unpack([]byte(packed))).Should(Succeed())
+			g.Expect(response.Question[0].Name).Should(Equal("cache-recovered.example.com."))
+			g.Expect(response.Answer[0].(*dns.A).A.Equal(net.ParseIP("203.0.113.77"))).Should(BeTrue())
+		}).WithTimeout(5 * time.Second).Should(Succeed())
+
+		received := make(chan evt.BlockingState, 1)
+		handler := func(state evt.BlockingState) {
+			select {
+			case received <- state:
+			default:
+			}
+		}
+		Expect(evt.Bus().Subscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed())
+		DeferCleanup(func() { Expect(evt.Bus().Unsubscribe(evt.BlockingStateChangedRemote, handler)).Should(Succeed()) })
+		expected := evt.BlockingState{Enabled: true, Groups: []string{"recovery"}}
+		payload, err := json.Marshal(map[string]any{"s": expected, "c": "recovery-test"})
+		Expect(err).Should(Succeed())
+		Eventually(func() int { return redisServer.Publish(redis.EventBridgeChannel, string(payload)) }).
+			WithTimeout(5 * time.Second).Should(BeNumerically(">", 0))
+		Eventually(received).Should(Receive(Equal(expected)))
+	}, SpecTimeout(15*time.Second))
+
+	It("does not repeat blocking checks after the optional startup check fails", func(specCtx context.Context) {
+		redisServer, err := miniredis.Run()
+		Expect(err).Should(Succeed())
+		DeferCleanup(redisServer.Close)
+		ctx, cancel := context.WithCancel(specCtx)
+		DeferCleanup(cancel)
+		redisServer.Server().SetPreHook(func(peer *miniserver.Peer, command string, _ ...string) bool {
+			if command == "PING" {
+				peer.WriteError("ERR unavailable")
+			} else {
+				<-ctx.Done()
+			}
+
+			return true
+		})
+		cfg.Redis.Address = redisServer.Addr()
+		srv, err := NewServer(ctx, &cfg)
+		Expect(err).Should(Succeed())
+		DeferCleanup(func() { Expect(srv.Stop(ctx)).Should(Succeed()) })
+	}, SpecTimeout(2*time.Second))
+
+	It("closes the client when a required startup Ping fails", func(ctx context.Context) {
+		redisServer, err := miniredis.Run()
+		Expect(err).Should(Succeed())
+		DeferCleanup(redisServer.Close)
+		redisServer.Server().SetPreHook(func(peer *miniserver.Peer, command string, _ ...string) bool {
+			if command != "PING" {
+				return false
+			}
+			peer.WriteError("ERR unavailable")
+
+			return true
+		})
+		cfg.Redis.Address = redisServer.Addr()
+		cfg.Redis.Required = true
+
+		srv, err := NewServer(ctx, &cfg)
+		Expect(srv).Should(BeNil())
+		Expect(err).Should(MatchError(ContainSubstring("failed to create required Redis client")))
+		Eventually(redisServer.CurrentConnectionCount).Should(BeZero())
+	}, SpecTimeout(3*time.Second))
+
+	It("closes the client when a required subscription fails after Ping succeeds", func(ctx context.Context) {
+		redisServer, err := miniredis.Run()
+		Expect(err).Should(Succeed())
+		DeferCleanup(redisServer.Close)
+		redisServer.Server().SetPreHook(func(peer *miniserver.Peer, command string, _ ...string) bool {
+			if command != "SUBSCRIBE" {
+				return false
+			}
+			peer.WriteError("NOPERM subscription denied")
+
+			return true
+		})
+		cfg.Redis.Address = redisServer.Addr()
+		cfg.Redis.Required = true
+		srv, err := NewServer(ctx, &cfg)
+		Expect(srv).Should(BeNil())
+		Expect(err).Should(MatchError(ContainSubstring("failed to create required Redis event bridge")))
+		Eventually(redisServer.CurrentConnectionCount).Should(BeZero())
+	}, SpecTimeout(3*time.Second))
+})

--- a/server/server.go
+++ b/server/server.go
@@ -146,20 +146,21 @@ func NewServer(ctx context.Context, cfg *config.Config) (server *Server, err err
 		return nil, fmt.Errorf("failed to create bootstrap resolver: %w", err)
 	}
 
-	var redisConn *goredis.Client
-	if cfg.Redis.IsEnabled() {
-		redisConn, err = redis.New(ctx, &cfg.Redis)
-		if err != nil {
-			if cfg.Redis.Required {
-				return nil, fmt.Errorf("failed to create required Redis client: %w", err)
-			}
+	redisConn, err := redis.New(ctx, &cfg.Redis)
+	if err != nil {
+		if cfg.Redis.Required {
+			_ = redisConn.Close()
 
-			logger().WithError(err).Warn("Redis is enabled but optional and could not be initialized, continuing without Redis")
+			return nil, fmt.Errorf("failed to create required Redis client: %w", err)
 		}
+
+		logger().WithError(err).Warn("Redis is optional and unavailable; continuing with reconnection enabled")
 	}
 
-	redisResult, err := createRedisCacheDecorator(ctx, redisConn, cfg.Redis.Required)
+	redisResult, err := createRedisCacheDecorator(ctx, redisConn, cfg.Redis.Required, err == nil)
 	if err != nil {
+		_ = redisConn.Close()
+
 		return nil, err
 	}
 
@@ -460,13 +461,13 @@ type redisBridgeResult struct {
 }
 
 func createRedisCacheDecorator(
-	ctx context.Context, redisConn *goredis.Client, required bool,
+	ctx context.Context, redisConn *goredis.Client, required, connected bool,
 ) (*redisBridgeResult, error) {
 	if redisConn == nil {
 		return &redisBridgeResult{}, nil
 	}
 
-	bridge, err := redis.NewEventBusBridge(ctx, redisConn)
+	bridge, err := redis.NewEventBusBridge(ctx, redisConn, required)
 	if err != nil {
 		if required {
 			return nil, fmt.Errorf("failed to create required Redis event bridge: %w", err)
@@ -477,8 +478,9 @@ func createRedisCacheDecorator(
 
 	decorator := func(inner cache.ExpiringCache[[]byte]) (cache.ExpiringCache[[]byte], error) {
 		return cache.NewRedisExpiringByteCache(ctx, inner, redisConn, cache.RedisOptions[[]byte]{
-			Prefix:  "blocky:cache:",
-			Channel: "blocky_cache_sync",
+			Prefix:          "blocky:cache:",
+			Channel:         "blocky_cache_sync",
+			SkipInitialLoad: !connected,
 		})
 	}
 


### PR DESCRIPTION
When Redis is unavailable during startup with `required: false`, Blocky continues serving DNS but discards the Redis client. Starting Redis afterward does not restore cache sharing or blocking-state synchronization.

Retain the client and start the cache and event subscriptions so they can reconnect. Skip the initial cache load after a failed connection check, and preserve startup errors when Redis is required.

Add regression tests for cache writes and blocking-state events after Redis starts, optional startup without repeated blocking checks, and client cleanup when a required connection check or subscription fails.

Validation on Linux/amd64 with Go 1.26.2: build, regular tests, race tests, lint and generated-file checks passed. GoReleaser 2.18.1 configuration validation passed. The required-Ping cleanup regression also fails when the client close is removed.

Docker build and end-to-end targets could not run locally: unchanged upstream and the patch both stop at the missing Docker prerequisite. Those checks still need CI.
